### PR TITLE
Fix relative directory for importing TLS certs

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ All CLI options are optionnal.
 
 `--region` `-r`: The region used to populate your velocity templates. Default: the first region for the first stage found in your project.
 
-`--httpsProtocol` `-h`: To enable HTTPS, specify directory for both `cert.pem` and `key.pem` files. E.g. `-h ../`. Default: none.
+`--httpsProtocol` `-h`: To enable HTTPS, specify directory (relative to Serverless project root) for both `cert.pem` and `key.pem` files. E.g. `-h ./certs`. Default: none.
 
 `--skipRequireCacheInvalidation` `-c`: Tells the plugin to skip require cache invalidation. A script reloading tool like Nodemon might then be needed. Default: false.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "serverless-offline",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "description": "A Serverless plugin to emulate AWS APIG and Lambda offline.",
   "main": "src/index.js",
   "scripts": {},

--- a/src/index.js
+++ b/src/index.js
@@ -148,8 +148,8 @@ module.exports = function(ServerlessPlugin, serverlessPath) {
       const httpsDir = this.options.httpsProtocol;
       
       if (typeof httpsDir === 'string' && httpsDir.length > 0) connectionOptions.tls = {
-        key: fs.readFileSync(path.join(__dirname, '../../../', httpsDir, 'key.pem'), 'ascii'),
-        cert: fs.readFileSync(path.join(__dirname, '../../../', httpsDir, 'cert.pem'), 'ascii')
+        key: fs.readFileSync(path.join(httpsDir, 'key.pem'), 'ascii'),
+        cert: fs.readFileSync(path.join(httpsDir, 'cert.pem'), 'ascii')
       };
       
       this.server.connection(connectionOptions);

--- a/src/index.js
+++ b/src/index.js
@@ -148,8 +148,8 @@ module.exports = function(ServerlessPlugin, serverlessPath) {
       const httpsDir = this.options.httpsProtocol;
       
       if (typeof httpsDir === 'string' && httpsDir.length > 0) connectionOptions.tls = {
-        key: fs.readFileSync(path.join(__dirname, httpsDir, 'key.pem'), 'ascii'),
-        cert: fs.readFileSync(path.join(__dirname, httpsDir, 'cert.pem'), 'ascii')
+        key: fs.readFileSync(path.join(__dirname, '../../../', httpsDir, 'key.pem'), 'ascii'),
+        cert: fs.readFileSync(path.join(__dirname, '../../../', httpsDir, 'cert.pem'), 'ascii')
       };
       
       this.server.connection(connectionOptions);
@@ -385,7 +385,8 @@ module.exports = function(ServerlessPlugin, serverlessPath) {
       this.server.start(err => {
         if (err) throw err;
         console.log();
-        serverlessLog(`Offline listening on http://localhost:${this.options.port}`);
+        var protocol = this.options.httpsProtocol ? 'https' : 'http';
+        serverlessLog(`Offline listening on ${protocol}://localhost:${this.options.port}`);
       });
     }
     


### PR DESCRIPTION
With Serverless v0.4, running `sls offline start` sets the working directory to `node_modules/serverless-offline/src`, and when using the `-h` option, it tries to import certs relative to this working dir.

This PR is a basic fix, hope it will help others.