### PR TITLE
Add option to pass principalId as env variable

### DIFF
--- a/src/createVelocityContext.js
+++ b/src/createVelocityContext.js
@@ -22,7 +22,7 @@ module.exports = function createVelocityContext(request, options, payload) {
     context: {
       apiId: 'offlineContext_apiId',
       authorizer: {
-        principalId: 'offlineContext_authorizer_principalId',
+        principalId: process.env.PRINCIPAL_ID || 'offlineContext_authorizer_principalId'
       },
       httpMethod:request.method.toUpperCase(),
       identity: {


### PR DESCRIPTION
I am using principalId in my lambda function and for testing purpose I need to be able to use different principalIds so this pull request let me pass the principalId through env variable.