### PR TITLE
Added CORS options as CLI parameters

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,17 @@
+root = true
+
+# All Files (Defaults)
+
+[*]
+
+indent_style = space
+indent_size = 2
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+# Markdown Files
+
+[*.md]
+trim_trailing_whitespace = false

--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ All CLI options are optionnal:
 --debugOffline              Prints debug messages. Can be useful to see how your templates are processed.
 --corsAllowOrigin           Used to build the Access-Control-Allow-Origin header for all responses.  Delimit multiple values with commas. Default: '*'
 --corsAllowHeaders          Used to build the Access-Control-Allow-Headers header for all responses.  Delimit multiple values with commas. Default: 'accept,content-type,x-api-key'
+--corsDisallowCredentials   When provided, the Access-Control-Allow-Credentials header will be passed as 'false'. Default: true
 ```
 
 Just send your requests to `http://localhost:3000/` as it would be API Gateway. Please note that:

--- a/README.md
+++ b/README.md
@@ -39,6 +39,8 @@ All CLI options are optionnal:
 --httpsProtocol         -H  To enable HTTPS, specify directory (relative to your cwd, typically your project dir) for both cert.pem and key.pem files.
 --skipCacheInvalidation -c  Tells the plugin to skip require cache invalidation. A script reloading tool like Nodemon might then be needed.
 --debugOffline              Prints debug messages. Can be useful to see how your templates are processed.
+--corsAllowOrigin           Used to build the Access-Control-Allow-Origin header for all responses.  Delimit multiple values with commas. Default: '*'
+--corsAllowHeaders          Used to build the Access-Control-Allow-Headers header for all responses.  Delimit multiple values with commas. Default: 'accept,content-type,x-api-key'
 ```
 
 Just send your requests to `http://localhost:3000/` as it would be API Gateway. Please note that:

--- a/src/index.js
+++ b/src/index.js
@@ -85,6 +85,10 @@ module.exports = S => {
             option:      'corsAllowHeaders',
             description: 'Used to build the Access-Control-Allow-Headers header for CORS support.',
           },
+          {
+            option:      'corsDisallowCredentials',
+            description: 'Used to override the Access-Control-Allow-Credentials default (which is true) to false.',
+          },
         ],
       });
       return Promise.resolve();
@@ -141,7 +145,8 @@ module.exports = S => {
         httpsProtocol:         userOptions.httpsProtocol || '',
         skipCacheInvalidation: userOptions.skipCacheInvalidation || false,
         corsAllowOrigin:       userOptions.corsAllowOrigin || '*',
-        corsAllowHeaders:      userOptions.corsAllowHeaders || 'accept,content-type,x-api-key'
+        corsAllowHeaders:      userOptions.corsAllowHeaders || 'accept,content-type,x-api-key',
+        corsAllowCredentials:  true
       };
 
       const stageVariables = stages[this.options.stage];
@@ -161,10 +166,17 @@ module.exports = S => {
       // Parse CORS options
       this.options.corsAllowOrigin = this.options.corsAllowOrigin.replace(/\s/g,'').split(',');
       this.options.corsAllowHeaders = this.options.corsAllowHeaders.replace(/\s/g,'').split(',');
+
+      if( userOptions.corsDisallowCredentials ) {
+        this.options.corsAllowCredentials = false;
+      }
+      
       this.options.corsConfig = {
         origin: this.options.corsAllowOrigin,
-        headers: this.options.corsAllowHeaders
+        headers: this.options.corsAllowHeaders,
+        credentials: this.options.corsAllowCredentials
       };
+
 
       serverlessLog(`Starting Offline: ${this.options.stage}/${this.options.region}.`);
       debugLog('options:', this.options);


### PR DESCRIPTION
I added two new CLI options, `--corsAllowOrigin` and `--corsAllowHeaders` in order to extend the CORS support of the plugin by way of HapiJs's `cors` configuration options.

**Important Note:** My changes will affect the output headers of `OPTIONS` requests, even if the user does not use the new CLI arguments.  The CLI arguments simply allow additional changes to be made by the user in case the defaults, that I provided, are insufficient.

See also: #39

--

I also added an `.editorconfig` in order to override my IDE's whitespace settings to those preferred by the project Owner so that I would not break the styles and conventions of the existing code.