### PR TITLE
Added Java-like String functions for better VTL compatibility

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -14,6 +14,7 @@ const isPlainObject = require('lodash.isplainobject');
 // Internal lib
 const debugLog = require('./debugLog');
 const jsonPath = require('./jsonPath');
+const javaHelper = require('./javaHelper');
 const createLambdaContext = require('./createLambdaContext');
 const createVelocityContext = require('./createVelocityContext');
 const renderVelocityTemplateObject = require('./renderVelocityTemplateObject');

--- a/src/javaHelper.js
+++ b/src/javaHelper.js
@@ -1,0 +1,63 @@
+"use strict";
+
+
+/////////////////////////////////////////////////////////////////
+// String functions
+/////////////////////////////////////////////////////////////////
+
+String.prototype.contains = function(value) {
+	return this.indexOf(value) >= 0;
+};
+
+String.prototype.replaceAll = function(oldValue, newValue) {
+	return this.replace(new RegExp(oldValue, "gm"), newValue);
+};
+
+String.prototype.replaceFirst = function(oldValue, newValue) {
+	return this.replace(new RegExp(oldValue, "m"), newValue);
+};
+
+String.prototype.matches = function(value) {
+	return this.match(new RegExp(value, "m"));
+};
+
+String.prototype.regionMatches = function (ignoreCase, toffset, other, ooffset, len) {
+	/*
+	 * Support different method signatures
+	 */
+	if (typeof ignoreCase == "number"
+			|| (ignoreCase != true && ignoreCase != false)) {
+		len = ooffset;
+		ooffset = other;
+		other = toffset;
+		toffset = ignoreCase;
+		ignoreCase = false;
+	}
+	var to = toffset;
+	var po = ooffset;
+	// Note: toffset, ooffset, or len might be near -1>>>1.
+	if ((ooffset < 0) || (toffset < 0) || (toffset > this.length - len) ||
+			(ooffset > other.length - len)) {
+		return false;
+	}
+	var s1 = this.substring (toffset, toffset + len);
+	var s2 = other.substring (ooffset, ooffset + len);
+	if (ignoreCase) {
+		s1 = s1.toLowerCase ();
+		s2 = s2.toLowerCase ();
+	}
+	return s1 == s2;
+};
+
+String.prototype.equals = function (anObject) {
+	return this.toString() === anObject.toString();
+};
+
+String.prototype.equalsIgnoreCase = function (anotherString) {
+	return (anotherString === null) ? false :
+		(this === anotherString || this.toLowerCase() === anotherString.toLowerCase());
+};
+
+
+// No particular exports
+module.exports = null;


### PR DESCRIPTION
VTL is based on Java and exposes all standard Java APIs. So you can actually write things like this using regular Java String operations:
```
#if ( $foo.equalsIgnoreCase("bar") )
  ...
#end
```

This pull request adds some basic String operations by updating the JavaScript `String.prototype` - though prototype manipulation is evil, this is the only reasonable way of simulating a Java-like API. The following operations are added:
* String.prototype.contains
* ~~String.prototype.startsWith~~ (already part of Node 4.x)
* ~~String.prototype.endsWith~~ (already part of Node 4.x)
* String.prototype.replaceAll
* String.prototype.replaceFirst
* String.prototype.matches
* String.prototype.regionMatches
* String.prototype.equals
* String.prototype.equalsIgnoreCase

It is noteworthy that not all operations return the exact same result as Java, also because JavaScript isn't strongly typed and some functionality is ambivalent. However, in my tests the results have been satisfying enough to ask for feedback and opinions now.

