### PR TITLE
Pass json if provided when given empty velocity template

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -382,6 +382,10 @@ module.exports = S => {
                 } catch (err) {
                   return this._reply500(response, `Error while parsing template "${contentType}" for ${funName}`, err, requestId);
                 }
+              } else {
+                if (typeof request.payload === 'object') {
+                  event = request.payload || {};
+                }
               }
 
               event.isOffline = true;


### PR DESCRIPTION
Variable requestTemplate as empty string for `application/json` as shown [here](http://docs.serverless.com/docs/project-structure#section-functions) should pass the payload json variables through event if json variables are present as occurs in AWS. Referenced in #58 and #54. 