### PR TITLE
Also parse a derivative of application/json

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -368,7 +368,7 @@ module.exports = S => {
               const contentType = request.mime || defaultContentType;
               const requestTemplate = requestTemplates[contentType];
 
-              if (contentType === 'application/json') {
+              if (contentType === 'application/json' || contentType === 'application/vnd.api+json') {
                 request.payload = JSON.parse(request.payload); // eslint-disable-line
               }
 


### PR DESCRIPTION
Follow up on the PR in #73.

`application/json` is not the only MIME that is currently supported by APIG. I'm working with `application/vnd.api+json` and APIG seems to be parsing it well.

`application/vnd.api+json` is a registeded IANA format:
https://www.iana.org/assignments/media-types/application/vnd.api+json

Unfortunatelly, I haven't had a chance to check other derivatives like `text/json` but will do so. If you are aware of others let me know so I can test them too.