### PR TITLE
Add --host flag to set IP address other than localhost to hapi

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -54,6 +54,10 @@ module.exports = S => {
             description: 'Adds a prefix to every path, to send your requests to http://localhost:3000/prefix/[your_path] instead.',
           },
           {
+            option:      'host',
+            description: 'The host name to listen on. Default: localhost',
+          },
+          {
             option:      'port',
             shortcut:    'P',
             description: 'Port to listen on. Default: 3000',
@@ -159,6 +163,7 @@ module.exports = S => {
 
       // Applies defaults
       this.options = {
+        host:                  userOptions.host || 'localhost',
         port:                  userOptions.port || 3000,
         prefix:                userOptions.prefix || '/',
         stage:                 userOptions.stage || stagesKeys[0],
@@ -234,7 +239,7 @@ module.exports = S => {
         },
       });
 
-      const connectionOptions = { port: this.options.port };
+      const connectionOptions = { host: this.options.host, port: this.options.port };
       const httpsDir = this.options.httpsProtocol;
 
       // HTTPS support
@@ -626,7 +631,7 @@ module.exports = S => {
       this.server.start(err => {
         if (err) throw err;
         printBlankLine();
-        serverlessLog(`Offline listening on http${this.options.httpsProtocol ? 's' : ''}://localhost:${this.options.port}`);
+        serverlessLog(`Offline listening on http${this.options.httpsProtocol ? 's' : ''}://${this.options.host}:${this.options.port}`);
       });
     }
 


### PR DESCRIPTION
I've added --host flag.

The added options is 

```
$ sls offline start --help

Simulates API Gateway to call your lambda functions offline

  -p, --prefix
        Adds a prefix to every path, to send your requests to http://localhost:3000/prefix/[your_path] instead.

  -undefined, --host
        The host name to listen on. Default: localhost

  -P, --port
        Port to listen on. Default: 3000
...
```

and usage is 

```
$ sls offline start --host 0.0.0.0
Serverless: Starting Offline: {stage}/{region}

...

Serverless: Offline listening on http://0.0.0.0:3000
```

and default option is 

```
$ sls offline start
Serverless: Starting Offline: {stage}/{region}

...

Serverless: Offline listening on http://localhost:3000
```

Note: I did not add -h of the short option because -h option already defined as --help option.