### PR TITLE
doc: improve installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,14 +27,7 @@ All changes occur to your project.
 `npm install serverless-offline` 
 
 or better still as development depency
-`npm install serverless-offline --save-dev`
-
-##### Attention Manual Step Needed until release:
->This above will currently install serverless **0.5** compatible version of plug-in. You will need to **download** the 1.0 code from this v1 branch, e.g. into empty directory with a command like: 
-
->`git clone -b serverless_v1 https://github.com/dherault/serverless-offline.git` 
-
->Then, copy the code over the serverless-offline node module code in your project and, then, run `npm install` inside the serverless-offline root one more time
+`npm install git+https://github.com/dherault/serverless-offline/tree/serverless_v1\#serverless_v1 --save-dev`
 
 
 


### PR DESCRIPTION
Hi!

I'd like to propose a simple doc improvement. Open to feedbacks :)

> show how to install npm package for serverless v1 directly from github branch which makes it simpler than proceeding manually;