### PR TITLE
Handle undefined this.httpData.request

### DIFF
--- a/src/Endpoint.js
+++ b/src/Endpoint.js
@@ -43,7 +43,7 @@ class Endpoint {
       // determine request template override
       const reqFilename = `${this.options.handlerPath}.req.vm`;
       // check if serverless framework populates the object itself
-      if (typeof this.httpData.request.template === 'object') {
+      if (typeof this.httpData.request === 'object' && typeof this.httpData.request.template === 'object') {
         const templatesConfig = this.httpData.request.template;
         Object.keys(templatesConfig).forEach(function(key,index) {
           fep.requestTemplates[key] = templatesConfig[key];


### PR DESCRIPTION
Currently if you don't set a custom request template, like

```
functions:
  putSessions:
    handler: handler.putSessions
    events:
      - http:
          path: sessions/{uuid}
          method: put
```

serverless-offline spits (v1) spits out an error like;

```
[offline] putSessions runtime nodejs4.3 
Serverless: Routes for putSessions:
[offline] Error: TypeError: Cannot read property 'template' of undefined
Serverless: PUT /sessions/{uuid}

Serverless: Offline listening on http://localhost:3000
```

... which is caused by `this.httpData.request` being undefined, hence the access to `this.httpData.request.template` fails even so it should be just a typecheck.

... and hence the catch is called, skipping application of default request & response template... which obviously is bad
