### PR TITLE
Integrate serverless-webpack with serverless-offline

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
   "homepage": "https://github.com/dherault/serverless-offline",
   "dependencies": {
     "babel-register": "^6.11.6",
+    "bluebird": "^3.4.6",
     "boom": "^3.2.2",
     "coffee-script": "^1.10.0",
     "hapi": "14.1.0",

--- a/src/index.js
+++ b/src/index.js
@@ -8,6 +8,7 @@ const fs = require('fs');
 const path = require('path');
 
 // External dependencies
+const BbPromise = require('bluebird');
 const Hapi = require('hapi');
 const isPlainObject = require('lodash').isPlainObject;
 
@@ -98,8 +99,13 @@ class Offline {
     };
 
     this.hooks = {
-      'offline:start:init': this.start.bind(this),
-      'offline:start': this.start.bind(this)
+      'before:offline:start:init': () => BbPromise.bind(this),
+      'offline:start:init': () => BbPromise.bind(this)
+        .then(this.start),
+      
+      'before:offline:start': () => BbPromise.bind(this),
+      'offline:start': BbPromise.bind(this)
+        .then(this.start),
     };
   }
 


### PR DESCRIPTION
This will allow us to use `serverless-webpack` to transpile our services rather than using babel-register.

To allow this dont set babelConfig and include the `serverless-webpack` plugin before the `serverless-offline` plugin.

This pull request is depended on [PR 47](https://github.com/elastic-coders/serverless-webpack/pull/47)

And will resolve the feature request for [#29](https://github.com/elastic-coders/serverless-webpack/issue/29)