### PR TITLE
Fix default custom authorizer identitySource to match serverless framework

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -285,7 +285,7 @@ class Offline {
             authorizerOptions.name = authFunctionName;
             authorizerOptions.type = 'TOKEN';
             authorizerOptions.resultTtlInSeconds = '300';
-            authorizerOptions.identitySource = 'method.request.header.Auth';
+            authorizerOptions.identitySource = 'method.request.header.Authorization';
           }
           else {
             authorizerOptions = endpoint.authorizer;


### PR DESCRIPTION
When using custom authorizers and only specifying the function name, the default identitySource is `method.request.header.Auth` and doesn't function as expected because the default identitySource in serverless framework is `method.request.header.Authorization`. 

This PR just changes the default to match Serverless Framework to ensure correct functionality for those just using defaults in their configurations.