### PR TITLE
Parsing [XXX] in error messages, to match serverless 1.0

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -450,9 +450,16 @@ class Offline {
               /* RESPONSE SELECTION (among endpoint's possible responses) */
 
               // Failure handling
+              let errorStatusCode = 0;
               if (err) {
 
                 const errorMessage = (err.message || err).toString();
+
+                const re = /\[(\d{3})\]/;
+                const found = errorMessage.match(re);
+                if (found && found.length > 1) {
+                  errorStatusCode = found[1];
+                }
 
                 // Mocks Lambda errors
                 result = {
@@ -568,8 +575,7 @@ class Offline {
                 }
 
                 /* HAPIJS RESPONSE CONFIGURATION */
-
-                statusCode = chosenResponse.statusCode || 200;
+                const statusCode = errorStatusCode !== 0 ? errorStatusCode : chosenResponse.statusCode || 200;
                 if (!chosenResponse.statusCode) {
                   this.printBlankLine();
                   this.serverlessLog(`Warning: No statusCode found for response "${responseName}".`);

--- a/src/index.js
+++ b/src/index.js
@@ -459,6 +459,8 @@ class Offline {
                 const found = errorMessage.match(re);
                 if (found && found.length > 1) {
                   errorStatusCode = found[1];
+                } else {
+                  errorStatusCode = '500';
                 }
 
                 // Mocks Lambda errors
@@ -544,7 +546,6 @@ class Offline {
               let statusCode;
               if (integration === 'lambda') {
                 /* RESPONSE TEMPLATE PROCCESSING */
-
                 // If there is a responseTemplate, we apply it to the result
                 const responseTemplates = chosenResponse.responseTemplates;
 

--- a/test/integration/offline.js
+++ b/test/integration/offline.js
@@ -99,6 +99,58 @@ describe('Offline', () => {
     });
   });
 
+  context('lambda integration, parse [xxx] as status codes in errors', () => {
+    it('should set the status code to 500 when no [xxx] is present', (done) => {
+      const offLine = new OffLineBuilder().addFunctionConfig('index', {
+        handler: 'users.index',
+        events: [{
+          http: {
+            path: 'index',
+            method: 'GET',
+            integration: 'lambda',
+            response: {
+              headers: {
+                'Content-Type': "'text/html'",
+              },
+              template: "$input.path('$')",
+            },
+          },
+        }],
+      }, (event, context, cb) => cb(new Error('Internal Server Error'))).toObject();
+
+      offLine.inject('/index', (res) => {
+        expect(res.headers['content-type']).to.contains('text/html');
+        expect(res.statusCode).to.eq('500');
+        done();
+      });
+    });
+
+    it('should set the status code to 401 when [401] is the prefix of the error message', (done) => {
+      const offLine = new OffLineBuilder().addFunctionConfig('index', {
+        handler: 'users.index',
+        events: [{
+          http: {
+            path: 'index',
+            method: 'GET',
+            integration: 'lambda',
+            response: {
+              headers: {
+                'Content-Type': "'text/html'",
+              },
+              template: "$input.path('$')",
+            },
+          },
+        }],
+      }, (event, context, cb) => cb(new Error('[401] Unauthorized'))).toObject();
+
+      offLine.inject('/index', (res) => {
+        expect(res.headers['content-type']).to.contains('text/html');
+        expect(res.statusCode).to.eq('401');
+        done();
+      });
+    });
+  });
+
   context('[lamda-proxy] Support stageVariables from the stageVariables plugin', () => {
     it('should handle custom stage variables declaration', (done) => {
       const offLine = new OffLineBuilder().addCustom("stageVariables", {hello: 'Hello World'}).addFunctionHTTP('hello', {


### PR DESCRIPTION
This fixes #108 

There are a few ways this could be accomplished. Is this an acceptable solution?

This isn't a significant change, but when an error message is being returned from a serverless handler, if there's a "[XXX] Message" in the response, the status code on the response object will be set from this error object.

It makes no attempt to response the different patterns that serverless supports with API Gateway. I feel that this is out of scope of this PR and could be an interesting option by itself.
