### PR TITLE
Update authorizer options

### DIFF
--- a/src/createAuthScheme.js
+++ b/src/createAuthScheme.js
@@ -9,10 +9,6 @@ const debugLog = require('./debugLog');
 module.exports = function createAuthScheme(authFun, authorizerOptions, funName, endpointPath, options, serverlessLog, servicePath) {
   const authFunName = authorizerOptions.name;
 
-  if (authorizerOptions.type !== 'TOKEN') {
-    throw new Error(`Authorizer Type must be TOKEN (λ: ${authFunName})`);
-  }
-
   const identitySourceMatch = /^method.request.header.(\w+)$/.exec(authorizerOptions.identitySource);
   if (!identitySourceMatch || identitySourceMatch.length !== 2) {
     throw new Error(`Serverless Offline only supports retrieving tokens from the headers (λ: ${authFunName})`);

--- a/src/index.js
+++ b/src/index.js
@@ -324,7 +324,6 @@ class Offline {
           if (typeof endpoint.authorizer === 'string') {
             // serverless 1.x will create default values, so we will to
             authorizerOptions.name = authFunctionName;
-            authorizerOptions.type = 'TOKEN';
             authorizerOptions.resultTtlInSeconds = '300';
             authorizerOptions.identitySource = 'method.request.header.Authorization';
           }


### PR DESCRIPTION
As of serverless@1.1.0 the `authorizer.type` option has been removed, it is now explicitly set to `TOKEN` in template.
This PR removes `authorizer.type` option setting and checking from plugin so that it can be used with latest version of serverless.