### PR TITLE
Fix event authorizer property path in lambda-proxy context

### DIFF
--- a/src/createLambdaProxyContext.js
+++ b/src/createLambdaProxyContext.js
@@ -10,9 +10,6 @@ module.exports = function createLambdaProxyContext(request, options, stageVariab
   const authPrincipalId = request.auth && request.auth.credentials && request.auth.credentials.user;
 
   return {
-    authorizer: {
-      principalId: authPrincipalId || process.env.PRINCIPAL_ID || 'offlineContext_authorizer_principalId', // See #24
-    },
     path: request.route.path,
     headers: request.headers,
     pathParameters: utils.nullIfEmpty(request.params),
@@ -33,6 +30,9 @@ module.exports = function createLambdaProxyContext(request, options, stageVariab
         userArn: 'offlineContext_userArn',
         userAgent: request.headers['user-agent'] || '',
         user: 'offlineContext_user',
+      },
+      authorizer: {
+        principalId: authPrincipalId || process.env.PRINCIPAL_ID || 'offlineContext_authorizer_principalId', // See #24
       },
     },
     resource: 'offlineContext_resource',

--- a/test/unit/createLambdaProxyContextTest.js
+++ b/test/unit/createLambdaProxyContextTest.js
@@ -23,6 +23,7 @@ describe('createLambdaProxyContext', () => {
     expect(requestContext.identity.cognitoAuthenticationProvider).to.eq('offlineContext_cognitoAuthenticationProvider');
     expect(requestContext.identity.userArn).to.eq('offlineContext_userArn');
     expect(requestContext.identity.user).to.eq('offlineContext_user');
+    expect(requestContext.authorizer.principalId).to.eq('offlineContext_authorizer_principalId');
   };
 
   const stageVariables = {};


### PR DESCRIPTION
As of aws-sdk@2.7.0 (and probably a few releases earlier) the `authorizer` is located inside `requestContext` when using lambda-proxy integration.