### PR TITLE
Fix headers for lambda-proxy context

### DIFF
--- a/src/createLambdaProxyContext.js
+++ b/src/createLambdaProxyContext.js
@@ -14,7 +14,7 @@ module.exports = function createLambdaProxyContext(request, options, stageVariab
       principalId: authPrincipalId || process.env.PRINCIPAL_ID || 'offlineContext_authorizer_principalId', // See #24
     },
     path: request.route.path,
-    headers: request.headers,
+    headers: utils.capitalizeKeys(request.headers),
     pathParameters: utils.nullIfEmpty(request.params),
     requestContext: {
       accountId: 'offlineContext_accountId',

--- a/src/createVelocityContext.js
+++ b/src/createVelocityContext.js
@@ -1,5 +1,6 @@
 'use strict';
 
+const utils = require('./utils');
 const jsonPath = require('./jsonPath');
 const jsEscapeString = require('js-string-escape');
 const isPlainObject = require('lodash').isPlainObject;
@@ -29,10 +30,7 @@ module.exports = function createVelocityContext(request, options, payload) {
 
   // Capitalize request.headers as NodeJS use lowercase headers
   // however API Gateway always pass capitalize headers
-  const headers = {};
-  for (let key in request.headers) { // eslint-disable-line prefer-const
-    headers[key.replace(/((?:^|-)[a-z])/g, x => x.toUpperCase())] = request.headers[key];
-  }
+  const headers = utils.capitalizeKeys(request.headers);
 
   return {
     context: {

--- a/src/utils.js
+++ b/src/utils.js
@@ -6,4 +6,11 @@ module.exports = {
   toPlainOrEmptyObject: obj => _.isPlainObject(obj) ? obj : {},
   random: (lower, upper, floating) => _.random(lower, upper, floating),
   nullIfEmpty: o => o && (Object.keys(o).length > 0 ? o : null),
+  capitalizeKeys: o => {
+    const capitalized = {};
+    for (let key in o) { // eslint-disable-line prefer-const
+      capitalized[key.replace(/((?:^|-)[a-z])/g, x => x.toUpperCase())] = o[key];
+    }
+    return capitalized;
+  },
 };


### PR DESCRIPTION
API Gateway always passes capitalize headers for lambda-proxy context so fix them as we do in velocity context. Also I extracted a function for capitalization and placed it in `utils`.