### PR TITLE
Properly respond to preflight OPTIONS requests for CORS

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "Luke Chavers (https://github.com/vmadman)",
     "Marc Campbell (https://github.com/marccampbell)",
     "Martin Micunda (https://github.com/martinmicunda)",
+    "Matt Hodgson (https://github.com/mhodgson)",
     "Norimitsu Yamashita (https://github.com/nori3tsu)",
     "Oliv (https://github.com/obearn)",
     "Piotr Gasiorowski (https://github.com/WooDzu)",

--- a/package.json
+++ b/package.json
@@ -67,6 +67,7 @@
     "coffee-script": "^1.11.1",
     "crypto": "0.0.3",
     "hapi": "15.2.0",
+    "hapi-cors-headers": "^1.0.0",
     "js-string-escape": "^1.0.1",
     "jsonpath-plus": "^0.15.0",
     "lodash": "^4.16.4",

--- a/src/index.js
+++ b/src/index.js
@@ -217,9 +217,6 @@ class Offline {
       },
     });
 
-    // Enable CORS preflight response
-    this.server.ext('onPreResponse', corsHeaders);
-
     const connectionOptions = {
       host: this.options.host,
       port: this.options.port,
@@ -236,6 +233,9 @@ class Offline {
 
     // Passes the configuration object to the server
     this.server.connection(connectionOptions);
+
+    // Enable CORS preflight response
+    this.server.ext('onPreResponse', corsHeaders);
   }
 
   _createRoutes() {

--- a/src/index.js
+++ b/src/index.js
@@ -262,8 +262,6 @@ class Offline {
       process.env.tokens = tokens;
     }
 
-    // const corsRoutes = [];
-    this.serverlessLog(`---------- CORS OPTIONS enabled! ------------`);
     Object.keys(this.service.functions).forEach(key => {
 
       const fun = this.service.getFunction(key);
@@ -304,10 +302,6 @@ class Offline {
         // Prefix must start and end with '/' BUT path must not end with '/'
         let fullPath = this.options.prefix + (epath.startsWith('/') ? epath.slice(1) : epath);
         if (fullPath !== '/' && fullPath.endsWith('/')) fullPath = path.slice(0, -1);
-
-        // if (_.eq(event.http.cors, true) && corsRoutes.indexOf(fullPath) === -1) {
-        //   corsRoutes.push(fullPath);
-        // }
 
         this.serverlessLog(`${method} ${fullPath}`);
 
@@ -681,18 +675,6 @@ class Offline {
         });
       });
     });
-    //
-    // corsRoutes.forEach((path) => {
-    //   this.serverlessLog(`Mounting OPTIONS endpoint for CORS at ${path}`);
-    //   this.server.route({
-    //     method: 'OPTIONS',
-    //     path,
-    //     config: {
-    //       cors: this.options.corsConfig
-    //     },
-    //     handler: (request, reply) => reply('ok')
-    //   });
-    // });
   }
 
   // All done, we can listen to incomming requests

--- a/src/index.js
+++ b/src/index.js
@@ -681,14 +681,14 @@ class Offline {
     corsRoutes.forEach((path) => {
       this.serverlessLog(`Mounting OPTIONS endpoint for CORS at ${path}`);
       this.server.route({
-        'OPTIONS',
-        path: path,
+        method: 'OPTIONS',
+        path,
         config: {
           cors: this.options.corsConfig
         },
         handler: (request, reply) => reply('ok')
       });
-    })
+    });
   }
 
   // All done, we can listen to incomming requests

--- a/src/index.js
+++ b/src/index.js
@@ -9,6 +9,7 @@ const path = require('path');
 
 // External dependencies
 const Hapi = require('hapi');
+const corsHeaders = require('hapi-cors-headers');
 const _ = require('lodash');
 const crypto = require('crypto');
 // Internal lib
@@ -216,6 +217,9 @@ class Offline {
       },
     });
 
+    // Enable CORS preflight response
+    this.server.ext('onPreResponse', corsHeaders);
+
     const connectionOptions = {
       host: this.options.host,
       port: this.options.port,
@@ -258,7 +262,7 @@ class Offline {
       process.env.tokens = tokens;
     }
 
-    const corsRoutes = [];
+    // const corsRoutes = [];
     this.serverlessLog(`---------- CORS OPTIONS enabled! ------------`);
     Object.keys(this.service.functions).forEach(key => {
 
@@ -301,9 +305,9 @@ class Offline {
         let fullPath = this.options.prefix + (epath.startsWith('/') ? epath.slice(1) : epath);
         if (fullPath !== '/' && fullPath.endsWith('/')) fullPath = path.slice(0, -1);
 
-        if (_.eq(event.http.cors, true) && corsRoutes.indexOf(fullPath) === -1) {
-          corsRoutes.push(fullPath);
-        }
+        // if (_.eq(event.http.cors, true) && corsRoutes.indexOf(fullPath) === -1) {
+        //   corsRoutes.push(fullPath);
+        // }
 
         this.serverlessLog(`${method} ${fullPath}`);
 
@@ -677,18 +681,18 @@ class Offline {
         });
       });
     });
-
-    corsRoutes.forEach((path) => {
-      this.serverlessLog(`Mounting OPTIONS endpoint for CORS at ${path}`);
-      this.server.route({
-        method: 'OPTIONS',
-        path,
-        config: {
-          cors: this.options.corsConfig
-        },
-        handler: (request, reply) => reply('ok')
-      });
-    });
+    //
+    // corsRoutes.forEach((path) => {
+    //   this.serverlessLog(`Mounting OPTIONS endpoint for CORS at ${path}`);
+    //   this.server.route({
+    //     method: 'OPTIONS',
+    //     path,
+    //     config: {
+    //       cors: this.options.corsConfig
+    //     },
+    //     handler: (request, reply) => reply('ok')
+    //   });
+    // });
   }
 
   // All done, we can listen to incomming requests


### PR DESCRIPTION
This is a pretty simple solution that blanket allows any CORS preflight OPTIONS request. It could probably be improved upon to allow for customization, but for now it at least allows CORS development.

Fixes #94 