### PR TITLE
153 serve from subfolder

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ All CLI options are optional:
 
 ```
 --prefix                -p  Adds a prefix to every path, to send your requests to http://localhost:3000/[prefix]/[your_path] instead. E.g. -p dev
+--location              -l  The root location of the handlers' files. Defaults to the current directory
 --host                  -o  Host name to listen on. Default: localhost
 --port                  -P  Port to listen on. Default: 3000
 --stage                 -s  The stage used to populate your templates. Default: the first stage found in your project.

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "Cameron Cooper (https://github.com/cameroncooper)",
     "Daniel Parker (https://github.com/rlgod)",
     "David Bunker (https://github.com/dbunker)",
+    "Dave Sole (https://github.com/dsole)",
     "demetriusnunes (https://github.com/demetriusnunes)",
     "DJCrabhat (https://github.com/djcrabhat)",
     "Egor Kislitsyn (https://github.com/minibikini)",

--- a/src/index.js
+++ b/src/index.js
@@ -79,6 +79,10 @@ class Offline {
             usage: 'To enable HTTPS, specify directory (relative to your cwd, typically your project dir) for both cert.pem and key.pem files.',
             shortcut: 'H',
           },
+          location: {
+            usage: 'The root location of the handlers\' files.',
+            shortcut: 'l',
+          },
           noTimeout: {
             usage: 'Disable the timeout feature.',
             shortcut: 't',
@@ -148,6 +152,7 @@ class Offline {
     // Applies defaults
     this.options = {
       host: this.options.host || 'localhost',
+      location: this.options.location || '.',
       port: this.options.port || 3000,
       prefix: this.options.prefix || '/',
       stage: this.service.provider.stage,
@@ -266,7 +271,7 @@ class Offline {
 
       const fun = this.service.getFunction(key);
       const funName = key;
-      const funOptions = functionHelper.getFunctionOptions(fun, key, this.serverless.config.servicePath);
+      const funOptions = functionHelper.getFunctionOptions(fun, key, path.join(this.serverless.config.servicePath, this.options.location));
 
       this.printBlankLine();
       debugLog(funName, 'runtime', serviceRuntime, funOptions.babelOptions || '');


### PR DESCRIPTION
Add a --location command line option to specify the directory from which the functions' files will be loaded.

Fixes #153 