### PR TITLE
Add catch-all path variable support

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -308,6 +308,7 @@ class Offline {
         // Prefix must start and end with '/' BUT path must not end with '/'
         let fullPath = this.options.prefix + (epath.startsWith('/') ? epath.slice(1) : epath);
         if (fullPath !== '/' && fullPath.endsWith('/')) fullPath = path.slice(0, -1);
+        fullPath = fullPath.replace(/\+}/g, '*}');
 
         this.serverlessLog(`${method} ${fullPath}`);
 

--- a/test/integration/offline.js
+++ b/test/integration/offline.js
@@ -241,4 +241,21 @@ describe('Offline', () => {
       });
     });
   });
+
+  context('with catch-all route', () => {
+    it('should match arbitary route', (done) => {
+      const offLine = new OffLineBuilder().addFunctionHTTP('test', {
+        path: 'test/{stuff+}',
+        method: 'GET',
+      }, (event, context, cb) => cb(null, {
+        statusCode: 200, body: 'Hello'
+      })).toObject();
+
+      offLine.inject('/test/some/matching/route', (res) => {
+        expect(res.statusCode).to.eq(200);
+        expect(res.payload).to.eq('Hello');
+        done();
+      });
+    })
+  });
 });


### PR DESCRIPTION
Adds support for catch-all paths which were added to API gateway a few month ago:

https://aws.amazon.com/blogs/aws/api-gateway-update-new-features-simplify-api-development/