### PR TITLE
Update Content-Length and Content-Type headers based on the request body

### DIFF
--- a/src/createLambdaProxyContext.js
+++ b/src/createLambdaProxyContext.js
@@ -9,9 +9,17 @@ const utils = require('./utils');
 module.exports = function createLambdaProxyContext(request, options, stageVariables) {
   const authPrincipalId = request.auth && request.auth.credentials && request.auth.credentials.user;
 
+  var body = request.payload && JSON.stringify(request.payload);
+  var headers = utils.capitalizeKeys(request.headers);
+
+  if (body) {
+    headers['Content-Length'] = Buffer.byteLength(body);
+    headers['Content-Type'] = 'application/json';
+  }
+
   return {
     path: request.path,
-    headers: utils.capitalizeKeys(request.headers),
+    headers: headers,
     pathParameters: utils.nullIfEmpty(request.params),
     requestContext: {
       accountId: 'offlineContext_accountId',
@@ -38,7 +46,7 @@ module.exports = function createLambdaProxyContext(request, options, stageVariab
     resource: request.route.path,
     httpMethod: request.method.toUpperCase(),
     queryStringParameters: utils.nullIfEmpty(request.query),
-    body: request.payload && JSON.stringify(request.payload),
+    body: body,
     stageVariables: utils.nullIfEmpty(stageVariables),
   };
 };


### PR DESCRIPTION
For requests that contain application/x-www-form-urlencoded data, the Content-Type and Content-Length headers need to be updated to reflect the JSON stringified data that is being sent in the body. This sets the Content-Type to "application/json" and sets Content-Length to the length of the JSON stringified data, if the request contains a payload.