### PR TITLE
Allow use of the `ANY` method.

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -368,7 +368,7 @@ class Offline {
         }
         // Route creation
         this.server.route({
-          method,
+          method: method === 'ANY' ? '*' : method,
           path: fullPath,
           config: {
             cors: this.options.corsConfig,


### PR DESCRIPTION
Serverless allows the `ANY` method to be used for describing endpoints that can be invoked using any HTTP method,

This wasn't working in serverless-offline, the following fix modifies the `ANY` string to the `*` string expected by hapijs