### PR TITLE
Use endpoint CORS options to override default ones

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,9 +72,9 @@ All CLI options are optional:
 --dontPrintOutput           Turns of logging of your lambda outputs in the terminal.
 --httpsProtocol         -H  To enable HTTPS, specify directory (relative to your cwd, typically your project dir) for both cert.pem and key.pem files.
 --skipCacheInvalidation -c  Tells the plugin to skip require cache invalidation. A script reloading tool like Nodemon might then be needed.
---corsAllowOrigin           Used to build the Access-Control-Allow-Origin header for all responses.  Delimit multiple values with commas. Default: '*'
---corsAllowHeaders          Used to build the Access-Control-Allow-Headers header for all responses.  Delimit multiple values with commas. Default: 'accept,content-type,x-api-key'
---corsDisallowCredentials   When provided, the Access-Control-Allow-Credentials header will be passed as 'false'. Default: true
+--corsAllowOrigin           Used as default Access-Control-Allow-Origin header value for responses. Delimit multiple values with commas. Default: '*'
+--corsAllowHeaders          Used as default Access-Control-Allow-Headers header value for responses. Delimit multiple values with commas. Default: 'accept,content-type,x-api-key'
+--corsDisallowCredentials   When provided, the default Access-Control-Allow-Credentials header value will be passed as 'false'. Default: true
 ```
 
 By default you can send your requests to `http://localhost:3000/`. Please note that:
@@ -152,7 +152,8 @@ your response template should be in file: `helloworld.res.vm` and your request t
 ### CORS
 
 [Serverless doc](https://serverless.com/framework/docs/providers/aws/events/apigateway#enabling-cors)
-By default plugin uses global cors options. CORS options defined for endpoint will override global ones.
+Plugin uses endpoint CORS options. If CORS is set plugin will use CLI CORS options as fallback for default values.
+If CORS options are not set for endpoint, no CORS headers will be added.
 
 ### Catch-all Path Variables
 

--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ your response template should be in file: `helloworld.res.vm` and your request t
 ### CORS
 
 [Serverless doc](https://serverless.com/framework/docs/providers/aws/events/apigateway#enabling-cors)
-May not be working properly. Please PR (Difficulty: moderate).
+By default plugin uses global cors options. CORS options defined for endpoint will override global ones.
 
 ### Catch-all Path Variables
 

--- a/src/index.js
+++ b/src/index.js
@@ -366,12 +366,21 @@ class Offline {
           this.server.auth.scheme(authSchemeName, scheme);
           this.server.auth.strategy(authStrategyName, authSchemeName);
         }
+
+        // If the endpoint has cors options, override them, else use default ones
+        const endpointCors = endpoint.cors || {};
+        const cors = {
+          origin: endpointCors.origins || this.options.corsConfig.origin,
+          headers: endpointCors.headers || this.options.corsConfig.headers,
+          credentials: endpointCors.credentials || this.options.corsConfig.credentials,
+        };
+
         // Route creation
         this.server.route({
           method: method === 'ANY' ? '*' : method,
           path: fullPath,
           config: {
-            cors: this.options.corsConfig,
+            cors,
             auth: authStrategyName,
           },
           handler: (request, reply) => { // Here we go

--- a/src/index.js
+++ b/src/index.js
@@ -367,13 +367,14 @@ class Offline {
           this.server.auth.strategy(authStrategyName, authSchemeName);
         }
 
-        // If the endpoint has cors options, override them, else use default ones
-        const endpointCors = endpoint.cors || {};
-        const cors = {
-          origin: endpointCors.origins || this.options.corsConfig.origin,
-          headers: endpointCors.headers || this.options.corsConfig.headers,
-          credentials: endpointCors.credentials || this.options.corsConfig.credentials,
-        };
+        let cors = null;
+        if (endpoint.cors) {
+          cors = {
+            origin: endpoint.cors.origins || this.options.corsConfig.origin,
+            headers: endpoint.cors.headers || this.options.corsConfig.headers,
+            credentials: endpoint.cors.credentials || this.options.corsConfig.credentials,
+          };
+        }
 
         // Route creation
         this.server.route({


### PR DESCRIPTION
With this PR `serverless-offline` will honor the endpoint CORS options and will use CLI CORS options as default values. If the CORS settings aren't set for a specific endpoint, no CORS headers will be added to response.