### PR TITLE
#162 Add context object values to event.requestContext.authorizer

### DIFF
--- a/src/createAuthScheme.js
+++ b/src/createAuthScheme.js
@@ -70,7 +70,7 @@ module.exports = function createAuthScheme(authFun, authorizerOptions, funName, 
           serverlessLog(`Authorization function returned a successful response: (λ: ${authFunName})`, policy);
 
           // Set the credentials for the rest of the pipeline
-          return reply.continue({ credentials: { user: policy.principalId } });
+          return reply.continue({ credentials: { user: policy.principalId, context: policy.context } });
         };
 
         if (result && typeof result.then === 'function' && typeof result.catch === 'function') {

--- a/src/createLambdaProxyContext.js
+++ b/src/createLambdaProxyContext.js
@@ -8,6 +8,7 @@ const utils = require('./utils');
  */
 module.exports = function createLambdaProxyContext(request, options, stageVariables) {
   const authPrincipalId = request.auth && request.auth.credentials && request.auth.credentials.user;
+  const authContext = (request.auth && request.auth.credentials && request.auth.credentials.context) || {};
 
   var body = request.payload && JSON.stringify(request.payload);
   var headers = utils.capitalizeKeys(request.headers);
@@ -39,9 +40,9 @@ module.exports = function createLambdaProxyContext(request, options, stageVariab
         userAgent: request.headers['user-agent'] || '',
         user: 'offlineContext_user',
       },
-      authorizer: {
+      authorizer: Object.assign(authContext, { // 'principalId' should have higher priority
         principalId: authPrincipalId || process.env.PRINCIPAL_ID || 'offlineContext_authorizer_principalId', // See #24
-      },
+      }),
     },
     resource: request.route.path,
     httpMethod: request.method.toUpperCase(),


### PR DESCRIPTION
```
// authorizer response
{
  "principalId": "yyyyyyyy", // The principal user identification associated with the token sent by the client.
  "policyDocument": {
    "Version": "2012-10-17",
    "Statement": [
      {
        "Action": "execute-api:Invoke",
        "Effect": "Allow|Deny",
        "Resource": "arn:aws:execute-api:<regionId>:<accountId>:<appId>/<stage>/<httpVerb>/[<resource>/<httpVerb>/[...]]"
      }
    ]
  },
  "context": {
    "key": "value",
    "numKey": 1,
    "boolKey": true
  }
}

// in handler
console.log(event.requestContext.authorizer.key);
console.log(event.requestContext.authorizer.numKey);
console.log(event.requestContext.authorizer.boolKey);
``` 


reference: [AWS docs: API Gateway custom authorizer output](http://docs.aws.amazon.com/apigateway/latest/developerguide/use-custom-authorizer.html#api-gateway-custom-authorizer-output)