### PR TITLE
Added an option to disable the loading of environment variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ All CLI options are optional:
 --stage                 -s  The stage used to populate your templates. Default: the first stage found in your project.
 --region                -r  The region used to populate your templates. Default: the first region for the first stage found.
 --noTimeout             -t  Disables the timeout feature.
+--noEnvironment             Turns of loading of your environment variables from serverless.yml. Allows the usage of tools such as PM2 or docker-compose.
 --dontPrintOutput           Turns of logging of your lambda outputs in the terminal.
 --httpsProtocol         -H  To enable HTTPS, specify directory (relative to your cwd, typically your project dir) for both cert.pem and key.pem files.
 --skipCacheInvalidation -c  Tells the plugin to skip require cache invalidation. A script reloading tool like Nodemon might then be needed.

--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "Shine Li (https://github.com/shineli)",
     "Stefan Siegl (https://github.com/stesie)",
     "Tuan Minh Huynh (https://github.com/tuanmh)",
+    "Utku Turunc (https://github.com/utkuturunc)",
     "Vasiliy Solovey (https://github.com/miltador)"
   ],
   "license": "MIT",

--- a/src/index.js
+++ b/src/index.js
@@ -87,6 +87,9 @@ class Offline {
             usage: 'Disable the timeout feature.',
             shortcut: 't',
           },
+          noEnvironment: {
+            usage: 'Turns of loading of your environment variables from serverless.yml. Allows the usage of tools such as PM2 or docker-compose.',
+          },
           dontPrintOutput: {
             usage: 'Turns of logging of your lambda outputs in the terminal.',
           },
@@ -139,8 +142,8 @@ class Offline {
     this.requests = {};
 
     // Methods
-    this._setEnvironment(); // will set environment variables from serverless.yml file
     this._setOptions();     // Will create meaningful options from cli options
+    this._setEnvironment(); // will set environment variables from serverless.yml file
     this._registerBabel();  // Support for ES6
     this._createServer();   // Hapijs boot
     this._createRoutes();   // API  Gateway emulation
@@ -149,6 +152,7 @@ class Offline {
   }
 
   _setEnvironment() {
+    if (this.options.noEnvironment) return;
     Object.keys(this.service.provider.environment || {}).forEach(key => {
       process.env[key] = this.service.provider.environment[key];
     });
@@ -164,6 +168,7 @@ class Offline {
       stage: this.service.provider.stage,
       region: this.service.provider.region,
       noTimeout: this.options.noTimeout || false,
+      noEnvironment: this.options.noEnvironment || false,
       dontPrintOutput: this.options.dontPrintOutput || false,
       httpsProtocol: this.options.httpsProtocol || '',
       skipCacheInvalidation: this.options.skipCacheInvalidation || false,


### PR DESCRIPTION
This pull request adds an option to disable loading of environment variables. This enables usage of tools like PM2 and docker-compose to set the environment variables that would otherwise get overridden, while preserving the ability to deploy to aws with environment variables from serverless.yml. 