### PR TITLE
tweaked identitySource regex to support hyphens

### DIFF
--- a/src/createAuthScheme.js
+++ b/src/createAuthScheme.js
@@ -9,7 +9,7 @@ const debugLog = require('./debugLog');
 module.exports = function createAuthScheme(authFun, authorizerOptions, funName, endpointPath, options, serverlessLog, servicePath) {
   const authFunName = authorizerOptions.name;
 
-  const identitySourceMatch = /^method.request.header.(\w+)$/.exec(authorizerOptions.identitySource);
+  const identitySourceMatch = /^method.request.header.((?:\w+-?)+\w+)$/.exec(authorizerOptions.identitySource);
   if (!identitySourceMatch || identitySourceMatch.length !== 2) {
     throw new Error(`Serverless Offline only supports retrieving tokens from the headers (λ: ${authFunName})`);
   }


### PR DESCRIPTION
this is the fix for issue #200 
this original validation regex did not allow header names with hyphens such as X-Gitlab-Token