### PR TITLE
Add exec option to execute shell commands in server scope

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,6 @@ To do so, it starts an HTTP server that handles the request's lifecycle like API
 - [Installation](https://github.com/dherault/serverless-offline#installation)
 - [Usage and command line options](https://github.com/dherault/serverless-offline#usage-and-command-line-options)
 - [Usage with Babel](https://github.com/dherault/serverless-offline#usage-with-babel)
-- [Usage with CoffeeScript](https://github.com/dherault/serverless-offline#usage-with-coffeescript)
 - [Token Authorizers](https://github.com/dherault/serverless-offline#token-authorizers)
 - [Custom authorizers](https://github.com/dherault/serverless-offline#custom-authorizers)
 - [AWS API Gateway Features](https://github.com/dherault/serverless-offline#aws-api-gateway-features)
@@ -78,6 +77,7 @@ All CLI options are optional:
 --corsAllowOrigin           Used as default Access-Control-Allow-Origin header value for responses. Delimit multiple values with commas. Default: '*'
 --corsAllowHeaders          Used as default Access-Control-Allow-Headers header value for responses. Delimit multiple values with commas. Default: 'accept,content-type,x-api-key'
 --corsDisallowCredentials   When provided, the default Access-Control-Allow-Credentials header value will be passed as 'false'. Default: true
+--exec "<script>"           When provided, a shell script is executed when the server starts up, and the server will shut domn after handling this command.
 ```
 
 By default you can send your requests to `http://localhost:3000/`. Please note that:
@@ -106,10 +106,6 @@ custom:
 
 Here is the full list of [babel-register options](https://babeljs.io/docs/usage/require/)
 
-
-## Usage with CoffeeScript
-
-You can have `handler.coffee` instead of `handler.js`. No additional configuration is needed.
 
 ## Token Authorizers
 
@@ -254,6 +250,12 @@ The system will start in wait status. This will also automatically start the chr
 
 Depending on the breakpoint, you may need to call the URL path for your function in seperate browser window for your serverless function to be run and made available for debugging.
 
+## Scoped execution
+
+Serverless offline plugin can invoke shell scripts when a simulated server has been started up for the purposes of integration testing. Downstream plugins may tie into the
+"before:offline:start:end" hook to release resources when the server is shutting down.
+
+`> sls offline start --exec "./startIntegrationTests.sh"`
 
 ## Simulation quality
 

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ To do so, it starts an HTTP server that handles the request's lifecycle like API
 - [AWS API Gateway Features](https://github.com/dherault/serverless-offline#aws-api-gateway-features)
 - [Velocity nuances](https://github.com/dherault/serverless-offline#velocity-nuances)
 - [Debug process](https://github.com/dherault/serverless-offline#debug-process)
+- [Scoped execution](https://github.com/dherault/serverless-offline#scoped-execution)
 - [Simulation quality](https://github.com/dherault/serverless-offline#simulation-quality)
 - [Credits and inspiration](https://github.com/dherault/serverless-offline#credits-and-inspiration)
 - [Contributing](https://github.com/dherault/serverless-offline#contributing)

--- a/src/index.js
+++ b/src/index.js
@@ -181,7 +181,6 @@ class Offline {
             // Use the failed command's exit code, proceed as normal so that shutdown can occur gracefully
             this.serverlessLog(`Offline error executing script [${error}]`);
             this.exitCode = error.code || 1;
-            resolve();
           }
           resolve();
         });

--- a/src/index.js
+++ b/src/index.js
@@ -107,7 +107,7 @@ class Offline {
             usage: 'Defines the api key value to be used for endpoints marked as private. Defaults to a random hash.',
           },
           exec: {
-            usage: 'A shell script to execute when the server starts up. If specified, the server will shut domn after handling this command.',
+            usage: 'When provided, a shell script is executed when the server starts up, and the server will shut domn after handling this command.',
           },
         },
       },

--- a/src/index.js
+++ b/src/index.js
@@ -155,7 +155,15 @@ class Offline {
   _start() {
     // Start hapijs
     this._prestart();
-    return this._listen();
+    return this._listen().then(() => {
+      return new Promise((resolve, reject) => {
+        const terminate = () => {
+          this.serverlessLog('Serverless Halting...');
+          resolve();
+        };
+        process.on('SIGINT', terminate);
+      });
+    });
   }
 
   _exec() {


### PR DESCRIPTION
This PR will allow use cases like this, that allow for automated testing within the scope of an active simulated server.
`sls offline --stage=integration --exec="npm run tests:integration"`

Ideally, this would have been a separate command (e.g. `sls offline exec`), but there's an ecosystem of serverless plugins that depend on the lifecycle hooks that are fired when sls-offline starts (e.g. Dynamo, Webpack), so this has been implemented as an option instead.

~~What I'm seeing is that if another plugin (e.g. serverless-dynamodb-local) is using the offline lifecycle, the database process is never told to shut down, so this process is stuck waiting for children to exit.  We'll need to think about emitting a lifecycle hook to those plugins so that they can exit cleanly.~~

A new lifecycle hook has been added that signals to downstream libraries that `serverless-offline` is shutting down. This has been verified using the PR linked below. In `serverless-dynamodb-local`, the hook binding looks like this: 
```
this.hooks = {
  "before:offline:start:init": this.startHandler.bind(this), // start dynamo
  "before:offline:start:end": this.endHandler.bind(this), // shut down dynamo
};
```

Fixes #196 