### PR TITLE
Added the 30 seconds timeout function to mock API Gateway timeout.

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -434,6 +434,16 @@ class Offline {
           },
           handler: (request, reply) => { // Here we go
 
+            // Time out the request after 30 seconds, because Amazon API GAteway forces a hard timeout of 30 seconds.
+            setTimeout(function() {
+              // Gateway timeout HTTP error status code.
+              response.statusCode = 504;
+              response.headers = {'x-amzn-ErrorType' : 'GatewayTimeoutException'};
+              response.source = { Message: 'Request endpoint timed out.'};
+              debugLog('Request endpoint timed out. API Gateway 30 second time out reached.');
+              response.send()
+            }, 30000);
+
             this.printBlankLine();
             this.serverlessLog(`${method} ${request.path} (λ: ${funName})`);
             if (firstCall) {


### PR DESCRIPTION
Added a setTimout for 30 seconds at the start where the handler is being called so that if the handler takes more than 30 seconds, the request will time out which is how Amazon API Gateway currently works.