### PR TITLE
Feature/verbose handler loader

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ All CLI options are optional:
 --corsAllowHeaders          Used as default Access-Control-Allow-Headers header value for responses. Delimit multiple values with commas. Default: 'accept,content-type,x-api-key'
 --corsDisallowCredentials   When provided, the default Access-Control-Allow-Credentials header value will be passed as 'false'. Default: true
 --exec "<script>"           When provided, a shell script is executed when the server starts up, and the server will shut domn after handling this command.
+--verboseHandlerLoader      When provided, the lambda handler loader will provide better stack traces on modules that fail to load into memory. Default: false
 ```
 
 By default you can send your requests to `http://localhost:3000/`. Please note that:

--- a/package.json
+++ b/package.json
@@ -92,6 +92,7 @@
     "eslint-config-nelson": "^0.2.0",
     "eslint-plugin-import": "^2.2.0",
     "mocha": "^3.2.0",
-    "sinon": "^1.17.7"
+    "sinon": "^1.17.7",
+    "sinon-chai": "^2.8.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -88,6 +88,7 @@
     "chai": "^3.5.0",
     "dirty-chai": "^1.2.2",
     "eslint": "^3.16.1",
+    "eslint-config-airbnb-base": "^11.1.1",
     "eslint-config-nelson": "^0.2.0",
     "eslint-plugin-import": "^2.2.0",
     "mocha": "^3.2.0",

--- a/src/functionHelper.js
+++ b/src/functionHelper.js
@@ -1,6 +1,8 @@
 'use strict';
 
 const debugLog = require('./debugLog');
+const path = require('path');
+const execSync = require('child_process').execSync;
 
 module.exports = {
   getFunctionOptions(fun, funName, servicePath) {
@@ -31,8 +33,7 @@ module.exports = {
       }
     }
 
-    debugLog(`Loading handler... (${funOptions.handlerPath})`);
-    const handler = require(funOptions.handlerPath)[funOptions.handlerName];
+    const handler = options.verboseHandlerLoader ? this.verboseHandlerLoader(funOptions) : this.handlerLoader(funOptions);
 
     if (typeof handler !== 'function') {
       throw new Error(`Serverless-offline: handler for '${funOptions.funName}' is not a function`);
@@ -40,4 +41,54 @@ module.exports = {
 
     return handler;
   },
+
+  // require module/handler from handlerPath
+  handlerLoader(funOptions) {
+    debugLog(`Loading handler... (${funOptions.handlerPath})`);
+
+    return require(funOptions.handlerPath)[funOptions.handlerName];
+  },
+
+  // Verbose Load lambda handler and better loading errors
+  // Attempts to load handlerPath
+  // On failure, it execs the handleFile and throw interpreter errors
+  // This is workaround for node 4.x, should be fixed in 6+
+  // https://github.com/nodejs/node/issues/2762
+  verboseHandlerLoader(funOptions) {
+    debugLog(`Loading handler (verbose)... (${funOptions.handlerPath})`);
+
+    let moduleLoadError,
+      handler;
+
+    // Basic to attempt to load handler
+    try {
+      handler = require(funOptions.handlerPath)[funOptions.handlerName];
+    }
+    catch (error) {
+      moduleLoadError = error;
+    }
+
+    // Let's try to get a better, more in depth error stack
+    if (moduleLoadError) {
+      try {
+        const ext = path.extname(funOptions.handlerPath);
+        execSync(`node ${funOptions.handlerPath}${ext ? '' : '.js'}`, { stdio: [null, null] });
+      }
+      catch (execError) {
+        // remove internal exec failed message (useless trace to Offline users)
+        const stack = execError.stack.split('\n');
+        stack.shift();
+        execError.stack = stack.join('\n');
+
+        throw execError;
+      }
+
+      // Unable to find deeper error from manually loading
+      // throwing require error
+      throw moduleLoadError;
+    }
+
+    return handler;
+  },
+
 };

--- a/src/index.js
+++ b/src/index.js
@@ -109,6 +109,9 @@ class Offline {
           exec: {
             usage: 'When provided, a shell script is executed when the server starts up, and the server will shut domn after handling this command.',
           },
+          verboseHandlerLoader: {
+            usage: 'When provided, the lambda handler loader will provide better stack traces on modules that fail to load into memory',
+          },
         },
       },
     };
@@ -220,6 +223,7 @@ class Offline {
       corsAllowCredentials: true,
       apiKey: this.options.apiKey || crypto.createHash('md5').digest('hex'),
       exec: this.options.exec, // undefined ok
+      verboseHandlerLoader: this.options.verboseHandlerLoader || false,
     };
 
     // Prefix must start and end with '/'
@@ -583,7 +587,7 @@ class Offline {
 
                 this.serverlessLog(`Failure: ${errorMessage}`);
                 if (result.stackTrace) {
-                  debugLog(result.stackTrace.join('\n  '));
+                  debugLog(result.stackTrace);
                 }
 
                 for (const key in endpoint.responses) {
@@ -792,6 +796,7 @@ class Offline {
     const stackTrace = this._getArrayStackTrace(err.stack);
 
     this.serverlessLog(message);
+
     console.log(stackTrace || err);
 
     /* eslint-disable no-param-reassign */
@@ -854,7 +859,7 @@ class Offline {
 
     const splittedStack = stack.split('\n');
 
-    return splittedStack.slice(0, splittedStack.findIndex(item => item.match(/server.route.handler.createLambdaContext/))).map(line => line.trim());
+    return splittedStack.slice(0, splittedStack.findIndex(item => item.match(/server.route.handler.createLambdaContext/))).map(line => line.trim()).join('\n');
   }
 
   _logAndExit() {

--- a/test/support/OffLineBuilder.js
+++ b/test/support/OffLineBuilder.js
@@ -13,13 +13,6 @@ module.exports = class OffLineBuilder {
   constructor(serviceBuilder, options) {
     this.serviceBuilder = serviceBuilder || new ServiceBuilder();
     this.handlers = {};
-
-    // Avoid already wrapped exception when offline is instanciated many times
-    // Problem if test are instanciated serveral times
-    // FIXME, we could refactor index to have an handlerFactory and just instanciate offline with a factory test stub
-    if (functionHelper.createHandler.restore) {
-      functionHelper.createHandler.restore();
-    }
     this.options = options || {};
   }
 
@@ -65,6 +58,7 @@ module.exports = class OffLineBuilder {
     sinon.stub(functionHelper, 'createHandler', createHandler(this.handlers));
     sinon.stub(offline, 'printBlankLine');
     this.server = offline._buildServer();
+
     Object.assign(this.server, {
       restore: this.restore,
     });
@@ -72,7 +66,7 @@ module.exports = class OffLineBuilder {
     return this.server;
   }
 
-  static restore() {
+  restore() {
     functionHelper.createHandler.restore();
   }
 };

--- a/test/unit/functionHelperTest.js
+++ b/test/unit/functionHelperTest.js
@@ -4,10 +4,13 @@
 
 const chai = require('chai');
 const dirtyChai = require('dirty-chai');
+const sinon = require('sinon');
+const sinonChai = require('sinon-chai');
 const functionHelper = require('../../src/functionHelper');
 
 const expect = chai.expect;
 chai.use(dirtyChai);
+chai.use(sinonChai);
 
 describe('functionHelper', () => {
   describe('#getFunctionOptions', () => {
@@ -56,5 +59,49 @@ describe('functionHelper', () => {
         expect(result.funTimeout).to.eql(7000);
       });
     });
+  });
+
+  describe('#createHandler', () => {
+
+    function stubHandler() { }
+
+    const funOptions = {
+      handlerName: 'hello',
+      handlerPath: '/handler',
+    };
+
+    before(() => {
+      // Somebody isn't being a very good citizen
+      if (functionHelper.createHandler.restore) {
+        functionHelper.createHandler.restore();
+      }
+    });
+
+    it('should load a module handler with handlerLoader', () => {
+      const options = { verboseHandlerLoader: false };
+      const handlerLoader = functionHelper.handlerLoader;
+
+      // set handlerLoader to a dummy spy
+      functionHelper.handlerLoader = sinon.spy(() => stubHandler);
+      const handler = functionHelper.createHandler(funOptions, options);
+
+      expect(functionHelper.handlerLoader).to.be.have.calledWith(funOptions);
+      expect(handler).to.eq(stubHandler);
+      functionHelper.handlerLoader = handlerLoader;
+    });
+
+    it('it should load a module handler with verboseHandlerLoader', () => {
+      const options = { verboseHandlerLoader: true };
+      const verboseHandlerLoader = functionHelper.verboseHandlerLoader;
+
+      // set verboseHandlerLoader to a dummy spy
+      functionHelper.verboseHandlerLoader = sinon.spy(() => stubHandler);
+      const handler = functionHelper.createHandler(funOptions, options);
+
+      expect(functionHelper.verboseHandlerLoader).to.be.have.calledWith(funOptions);
+      expect(handler).to.eq(stubHandler);
+      functionHelper.verboseHandlerLoader = verboseHandlerLoader;
+    });
+
   });
 });

--- a/test/unit/functionHelperTest.js
+++ b/test/unit/functionHelperTest.js
@@ -70,13 +70,6 @@ describe('functionHelper', () => {
       handlerPath: '/handler',
     };
 
-    before(() => {
-      // Somebody isn't being a very good citizen
-      if (functionHelper.createHandler.restore) {
-        functionHelper.createHandler.restore();
-      }
-    });
-
     it('should load a module handler with handlerLoader', () => {
       const options = { verboseHandlerLoader: false };
       const handlerLoader = functionHelper.handlerLoader;


### PR DESCRIPTION
## Verbose Handler Loader
#### Backstory 
Node v4.0 has some trouble with displaying lineNumbers, fileNames from code that was dynamically required, like this project does. More information on the issues (https://github.com/nodejs/node/issues/2762).

#### Goal 
Provide devs an option to receive better stack traces from SyntaxErrors.

#### implementation
A new parameter,  `--verboseHandlerLoader` (Default: false). 
When provided, it will run a different loader function. If the code fails to load, it will spawn a childProcess `node ${handlerPath}.js` attempting to retrieve more in depth debug/stack information.

By default the previous handlerLoader is ran which only requires the handlerModule.

#### Additional bugfixes (tests)
Added before and after hooks to integration tests to handle restoring functionHelper.createHandler

Commits are broken up so this can be easily separated out. 

### Notes
* I used a server option, because I was attempting to keep the default api unchanged and staying with with the theme. Emulation of the lambda environment is the key.

**Why child process execSync node?**
* I attempted use a couple different modules, one such as [syntax-error](https://www.npmjs.com/package/syntax-error), but they required building a dependency tree. Running node filename.js seemed to be the better direction since it still gives decent stack traces if modules are eager loaded.

### Screenshots
#### Example Manual Test Setup (Replication)
For example replace [line 46 of `manual_test/handler.js`](https://github.com/dherault/serverless-offline/blob/3252062f95970384d39a9dbddafc4ba804595b6e/manual_test/handler.js#L46) with an intentional SyntaxError like
```js
module.exports.catchAll = (event, context, cb) => {
  const response = {
    statusCode: 200,
    body: JSON.stringify({
      message: 'Catch all route'
      stuff: 'hello'
    }),
  };

  cb(null, response);
};
```

##### Before
![screen shot 2017-03-08 at 8 09 30 pm](https://cloud.githubusercontent.com/assets/5419727/23732238/ecd0b150-043f-11e7-85f0-0a4e810f09a7.png)

##### After (default: without --verboseHandlerLoader)
![screen shot 2017-03-08 at 8 17 18 pm](https://cloud.githubusercontent.com/assets/5419727/23732267/146ebd4c-0440-11e7-91ce-bf281b8f1c96.png)

##### After (with --verboseHandlerLoader)
![screen shot 2017-03-08 at 8 16 52 pm](https://cloud.githubusercontent.com/assets/5419727/23732251/fa17d744-043f-11e7-8448-70a6228eb6fe.png)


Any suggestions would be greatly appreciated.
