### PR TITLE
Include resourcePath and httpMethod fields in event.requestContext

### DIFF
--- a/src/createLambdaProxyContext.js
+++ b/src/createLambdaProxyContext.js
@@ -47,6 +47,8 @@ module.exports = function createLambdaProxyContext(request, options, stageVariab
       authorizer: Object.assign(authContext, { // 'principalId' should have higher priority
         principalId: authPrincipalId || process.env.PRINCIPAL_ID || 'offlineContext_authorizer_principalId', // See #24
       }),
+      resourcePath: request.route.path,
+      httpMethod: request.method.toUpperCase(),
     },
     resource: request.route.path,
     httpMethod: request.method.toUpperCase(),


### PR DESCRIPTION
Events sent by the real AWS API Gateway have `resourcePath` and `httpMethod` as properties
of `requestContext`. They duplicate the values of `resource` and `httpMethod` already present
one level above. See the docs [here](http://docs.aws.amazon.com/apigateway/latest/developerguide/api-gateway-set-up-simple-proxy.html#api-gateway-simple-proxy-for-lambda-input-format).

Some libraries for implementing Lambda functions (in our case, we use [claudia-api-builder](https://github.com/claudiajs/claudia-api-builder))
rely on these fields being present. This patch adds these fields to the events generated
by serverless-offline.