### PR TITLE
Fix set environment process

### DIFF
--- a/src/createLambdaProxyContext.js
+++ b/src/createLambdaProxyContext.js
@@ -55,7 +55,7 @@ module.exports = function createLambdaProxyContext(request, options, stageVariab
     resource: request.route.path,
     httpMethod: request.method.toUpperCase(),
     queryStringParameters: utils.nullIfEmpty(request.query),
-    body,
+    body: stringBody,
     stageVariables: utils.nullIfEmpty(stageVariables),
   };
 };

--- a/src/index.js
+++ b/src/index.js
@@ -197,8 +197,13 @@ class Offline {
   _setEnvironment() {
     if (this.options.noEnvironment) return;
 
-    Object.keys(this.service.provider.environment || {})
-    .forEach(key => process.env[key] = this.service.provider.environment[key]);
+    Object.assign(process.env, this.service.provider.environment || {});
+
+    var _this = this;
+
+    Object.keys(this.service.functions).forEach(function(function_name) {
+        Object.assign(process.env, _this.service.functions[function_name].environment || {});
+    });
   }
 
   _setOptions() {


### PR DESCRIPTION
Changes on environment set

* Small fix on set environment from `serverless.yml` in `provider.environment` into `process.env`.

* Add support to set environment into `process.env` from `functions.$func-name.environment` in `serverless.yml` file like example below:

```yaml
provider:
  name: aws
  environment:
    provider_var1: "provider_var1_value"
    provider_var2: "provider_var2_value"

functions:
  myfunction:
    environment:
      function_var1: "function_var1_value"
```

I think that this fixes #176 