### PR TITLE
add support for nodejs6.10

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -311,7 +311,7 @@ class Offline {
     const apiKeys = this.service.provider.apiKeys;
     const protectedRoutes = [];
 
-    if (['nodejs', 'nodejs4.3', 'babel'].indexOf(serviceRuntime) === -1) {
+    if (['nodejs', 'nodejs4.3', 'nodejs6.10', 'babel'].indexOf(serviceRuntime) === -1) {
       this.printBlankLine();
       this.serverlessLog(`Warning: found unsupported runtime '${serviceRuntime}'`);
 


### PR DESCRIPTION
Add support for nodejs6.10

[AWS nodejs6.10 Release announcement](https://aws.amazon.com/about-aws/whats-new/2017/03/aws-lambda-supports-node-js-6-10/?sc_channel=sm&sc_campaign=launch_Serverless_73c6f9ab&sc_publisher=tw_go&sc_content=Node_6_10_support&sc_geo=global&sc_outcome=launches&adbsc=social_launches_20170322_70997816&adbid=844682201593659393&adbpl=tw&adbpr=66780587)
AWS lambda released support for nodejs6.10. Serverless already allows you to deploy to it. 