### PR TITLE
replaces fat arrows with functions so 'this' refers to global String object

### DIFF
--- a/src/javaHelper.js
+++ b/src/javaHelper.js
@@ -1,25 +1,34 @@
 'use strict';
 
-/* eslint-disable no-extend-native */
+/* eslint no-extend-native:0 func-names:0 */
 
 /* ---------------------------------------------------------------
   String functions
   For velocity templates to access java functions, to mimick AWS
 --------------------------------------------------------------- */
 
-String.prototype.contains = value => this.indexOf(value) >= 0;
+String.prototype.contains = function (value) {
+  return this.indexOf(value) >= 0;
+};
 
-String.prototype.replaceAll = (oldValue, newValue) => this.replace(new RegExp(oldValue, 'gm'), newValue);
+String.prototype.replaceAll = function (oldValue, newValue) {
+  return this.replace(new RegExp(oldValue, 'gm'), newValue);
+};
 
-String.prototype.replaceFirst = (oldValue, newValue) => this.replace(new RegExp(oldValue, 'm'), newValue);
+String.prototype.replaceFirst = function (oldValue, newValue) {
+  return this.replace(new RegExp(oldValue, 'm'), newValue);
+};
 
-String.prototype.matches = value => this.match(new RegExp(value, 'm'));
+String.prototype.matches = function (value) {
+  return this.match(new RegExp(value, 'm'));
+};
 
-String.prototype.regionMatches = (ignoreCase, toffset, other, ooffset, len) => {
+String.prototype.regionMatches = function (ignoreCase, toffset, other, ooffset, len) {
   /*
    * Support different method signatures
    */
-  if (typeof ignoreCase === 'number' || (ignoreCase !== true && ignoreCase !== false)) {
+  if (typeof ignoreCase === 'number'
+    || (ignoreCase !== true && ignoreCase !== false)) {
     len = ooffset;
     ooffset = other;
     other = toffset;
@@ -28,7 +37,8 @@ String.prototype.regionMatches = (ignoreCase, toffset, other, ooffset, len) => {
   }
 
   // Note: toffset, ooffset, or len might be near -1>>>1.
-  if ((ooffset < 0) || (toffset < 0) || (toffset > this.length - len) || (ooffset > other.length - len)) {
+  if ((ooffset < 0) || (toffset < 0) || (toffset > this.length - len) ||
+      (ooffset > other.length - len)) {
     return false;
   }
 
@@ -43,11 +53,15 @@ String.prototype.regionMatches = (ignoreCase, toffset, other, ooffset, len) => {
   return s1 == s2; // eslint-disable-line eqeqeq
 };
 
-String.prototype.equals = anObject => this.toString() === anObject.toString();
+String.prototype.equals = function (anObject) {
+  return this.toString() === anObject.toString();
+};
 
-String.prototype.equalsIgnoreCase = anotherString => anotherString === null ?
-  false :
-  this === anotherString || this.toLowerCase() === anotherString.toLowerCase();
+String.prototype.equalsIgnoreCase = function (anotherString) {
+  return (anotherString === null) ? false :
+    (this === anotherString || this.toLowerCase() === anotherString.toLowerCase());
+};
+
 
 // No particular exports
 module.exports = null;


### PR DESCRIPTION
Fat arrows have lexical this from parent scope. This undoes the breaking code introduced in https://github.com/dherault/serverless-offline/commit/3e8dd460231716339575106164aa454e8ec7e01a#diff-21b064378b3b7277f0da2780d78604ff.
