### PR TITLE
Add support to forbidden access if you deny on custom rule

### DIFF
--- a/src/createAuthScheme.js
+++ b/src/createAuthScheme.js
@@ -72,6 +72,12 @@ module.exports = function createAuthScheme(authFun, authorizerOptions, funName, 
 
           serverlessLog(`Authorization function returned a successful response: (λ: ${authFunName})`, policy);
 
+          if (policy.policyDocument.Statement[0].Effect === 'Deny') {
+            serverlessLog(`Authorization response didn't authorize user to access resource: (λ: ${authFunName})`, err);
+
+            return reply(Boom.forbidden('User is not authorized to access this resource'));
+          }
+
           // Set the credentials for the rest of the pipeline
           return reply.continue({ credentials: { user: policy.principalId, context: policy.context } });
         };

--- a/src/createAuthScheme.js
+++ b/src/createAuthScheme.js
@@ -36,7 +36,7 @@ module.exports = function createAuthScheme(authFun, authorizerOptions, funName, 
       const event = {
         type: 'TOKEN',
         authorizationToken: authorization,
-        methodArn: `arn:aws:execute-api:${options.region}:<Account id>:<API id>/${options.stage}/${request.method.toUpperCase()}/${endpointPath}`,
+        methodArn: `arn:aws:execute-api:${options.region}:random-account-id:random-api-id/${options.stage}/${request.method.toUpperCase()}/${endpointPath}`,
       };
 
       // Create the Authorization function handler


### PR DESCRIPTION
Add support to forbidden access if you deny on custom rule

On custom authorizer you can deny access, as example below:

```json
{
  "principalId": "user",
  "policyDocument": {
    "Version": "2012-10-17",
    "Statement": [
      {
        "Action": "execute-api:Invoke",
        "Effect": "Deny",
        "Resource": "arn:aws:execute-api:us-west-2:123456789012:ymy8tbxw7b/*/GET/"
      }
    ]
  }
}
```

Then, now serverless-offline can forbidden access if you deny access on custom rule like on AWS Lambda and API Gatweway, as below:

AWS Lambda response
```json
{
  "Message": "User is not authorized to access this resource"
}
```
serverless-offline response
```json
{
  "statusCode": 403,
  "error": "Forbidden",
  "message": "User is not authorized to access this resource"
}
```

Reference: https://docs.aws.amazon.com/apigateway/latest/developerguide/use-custom-authorizer.html#api-gateway-custom-authorizer-output