### PR TITLE
Added ignore the authorizer for the non custom authorizers.

### DIFF
--- a/manual_test/handler.js
+++ b/manual_test/handler.js
@@ -12,6 +12,23 @@ module.exports.hello = (event, context, callback) => {
   callback(null, response);
 };
 
+module.exports.authFunction = (event, context, callback) => {
+  context.succeed({
+    principalId: 'xxxxxxx', // the principal user identification associated with the token send by the client
+    policyDocument: {
+      // example policy shown below, but this value is any valid policy
+      Version: '2012-10-17',
+      Statement: [
+        {
+          Effect: 'Allow',
+          Action: ['execute-api:Invoke'],
+          Resource: [event.methodArn],
+        },
+      ],
+    },
+  });
+};
+
 module.exports.hello500 = (event, context, callback) => {
   const response = {
     statusCode: 500,

--- a/manual_test/serverless.yml
+++ b/manual_test/serverless.yml
@@ -59,6 +59,29 @@ functions:
           path: hello
           method: post
 
+  helloAuthorizerWithArn:
+    handler: handler.hello
+    events:
+      - http:
+          path: helloAuthorizerWithArn
+          method: get
+          authorizer:
+            arn: sometest
+
+  helloAuthorizerWithFunctionName:
+    handler: handler.hello
+    events:
+      - http:
+          path: helloAuthorizerWithCustomFunction
+          method: get
+          authorizer:
+            name: authFunction
+            identitySource: method.request.header.Authorization #Required for serverless-offline, although it's a default
+            resultTtlInSeconds: 0 #prevents caching the authorizer
+
+  authFunction:
+    handler: handler.authFunction
+
   hello500:
     handler: handler.hello500
     events:

--- a/src/index.js
+++ b/src/index.js
@@ -370,61 +370,7 @@ class Offline {
         this.serverlessLog(`${method} ${fullPath}`);
 
         // If the endpoint has an authorization function, create an authStrategy for the route
-        let authStrategyName = null;
-
-        if (endpoint.authorizer) {
-          let authFunctionName = endpoint.authorizer;
-          if (typeof endpoint.authorizer === 'object') {
-            if (endpoint.authorizer.arn) {
-              this.serverlessLog(`WARNING: Serverless Offline does not support non local authorizers: ${endpoint.authorizer.arn}`);
-
-              return;
-            }
-            authFunctionName = endpoint.authorizer.name;
-          }
-
-          this.serverlessLog(`Configuring Authorization: ${endpoint.path} ${authFunctionName}`);
-
-          const authFunction = this.service.getFunction(authFunctionName);
-
-          if (!authFunction) return this.serverlessLog(`WARNING: Authorization function ${authFunctionName} does not exist`);
-
-          let authorizerOptions = {};
-          if (typeof endpoint.authorizer === 'string') {
-            // serverless 1.x will create default values, so we will to
-            authorizerOptions.name = authFunctionName;
-            authorizerOptions.resultTtlInSeconds = '300';
-            authorizerOptions.identitySource = 'method.request.header.Authorization';
-          }
-          else {
-            authorizerOptions.identitySource = endpoint.authorizer.identitySource ||
-              'method.request.header.Authorization'; // See #207
-            authorizerOptions = endpoint.authorizer;
-          }
-
-          // Create a unique scheme per endpoint
-          // This allows the methodArn on the event property to be set appropriately
-          const authKey = `${funName}-${authFunctionName}-${method}-${epath}`;
-          const authSchemeName = `scheme-${authKey}`;
-          authStrategyName = `strategy-${authKey}`; // set strategy name for the route config
-
-          debugLog(`Creating Authorization scheme for ${authKey}`);
-
-          // Create the Auth Scheme for the endpoint
-          const scheme = createAuthScheme(
-            authFunction,
-            authorizerOptions,
-            funName,
-            epath,
-            this.options,
-            this.serverlessLog,
-            servicePath
-          );
-
-          // Set the auth scheme and strategy on the server
-          this.server.auth.scheme(authSchemeName, scheme);
-          this.server.auth.strategy(authStrategyName, authSchemeName);
-        }
+        let authStrategyName = this._configureAuthorization(endpoint, funName, method, epath, servicePath);
 
         let cors = null;
         if (endpoint.cors) {
@@ -779,6 +725,64 @@ class Offline {
         });
       });
     });
+  }
+
+  _configureAuthorization(endpoint, funName, method, epath, servicePath) {
+    let authStrategyName = null;
+    if (endpoint.authorizer) {
+      let authFunctionName = endpoint.authorizer;
+      if (typeof endpoint.authorizer === 'object') {
+        if (endpoint.authorizer.arn) {
+          this.serverlessLog(`WARNING: Serverless Offline does not support non local authorizers: ${endpoint.authorizer.arn}`);
+
+          return authStrategyName;
+        }
+        authFunctionName = endpoint.authorizer.name;
+      }
+
+      this.serverlessLog(`Configuring Authorization: ${endpoint.path} ${authFunctionName}`);
+
+      const authFunction = this.service.getFunction(authFunctionName);
+
+      if (!authFunction) return this.serverlessLog(`WARNING: Authorization function ${authFunctionName} does not exist`);
+
+      let authorizerOptions = {};
+      if (typeof endpoint.authorizer === 'string') {
+        // serverless 1.x will create default values, so we will to
+        authorizerOptions.name = authFunctionName;
+        authorizerOptions.resultTtlInSeconds = '300';
+        authorizerOptions.identitySource = 'method.request.header.Authorization';
+      }
+      else {
+        authorizerOptions.identitySource = endpoint.authorizer.identitySource ||
+          'method.request.header.Authorization'; // See #207
+        authorizerOptions = endpoint.authorizer;
+      }
+
+      // Create a unique scheme per endpoint
+      // This allows the methodArn on the event property to be set appropriately
+      const authKey = `${funName}-${authFunctionName}-${method}-${epath}`;
+      const authSchemeName = `scheme-${authKey}`;
+      authStrategyName = `strategy-${authKey}`; // set strategy name for the route config
+
+      debugLog(`Creating Authorization scheme for ${authKey}`);
+
+      // Create the Auth Scheme for the endpoint
+      const scheme = createAuthScheme(
+        authFunction,
+        authorizerOptions,
+        funName,
+        epath,
+        this.options,
+        this.serverlessLog,
+        servicePath
+      );
+
+      // Set the auth scheme and strategy on the server
+      this.server.auth.scheme(authSchemeName, scheme);
+      this.server.auth.strategy(authStrategyName, authSchemeName);
+    }
+    return authStrategyName;
   }
 
   // All done, we can listen to incomming requests


### PR DESCRIPTION
#118 The endpoints still work as is even tho the authorizer is not supported.
Added manual tests for the ARN authorizer and custom function
authorizer. 