### PR TITLE
Added support for authorizer type `AWS_IAM`

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -731,7 +731,17 @@ class Offline {
     let authStrategyName = null;
     if (endpoint.authorizer) {
       let authFunctionName = endpoint.authorizer;
+      if (typeof authFunctionName === 'string' && authFunctionName.toUpperCase() === 'AWS_IAM') {
+        this.serverlessLog('WARNING: Serverless Offline does not support the AWS_IAM authorization type');
+
+        return null;
+      }
       if (typeof endpoint.authorizer === 'object') {
+        if (endpoint.authorizer.type && endpoint.authorizer.type.toUpperCase() === 'AWS_IAM') {
+          this.serverlessLog('WARNING: Serverless Offline does not support the AWS_IAM authorization type');
+
+          return null;
+        }
         if (endpoint.authorizer.arn) {
           this.serverlessLog(`WARNING: Serverless Offline does not support non local authorizers: ${endpoint.authorizer.arn}`);
 


### PR DESCRIPTION
Added support for the upcoming `AWS_IAM` authorization type in Serverless: https://github.com/serverless/serverless/pull/3534

Supporting other endpoint types such as `HTTP`, `HTTP_PROXY` and `MOCK` are *not* part of this pull request.