### PR TITLE
Add test for default content-type and content-size

### DIFF
--- a/test/support/RequestBuilder.js
+++ b/test/support/RequestBuilder.js
@@ -21,6 +21,10 @@ module.exports = class RequestBuilder {
     this.request.headers[key] = value;
   }
 
+  addBody(body) {
+    this.request.payload = body;
+  }
+
   toObject() {
     return this.request;
   }

--- a/test/unit/createLambdaProxyContextTest.js
+++ b/test/unit/createLambdaProxyContextTest.js
@@ -82,4 +82,28 @@ describe('createLambdaProxyContext', () => {
       expect(lambdaProxyContext.headers.Authorization).to.eq('Token token="1234567890"');
     });
   });
+
+  context('with a POST /fn1 request with no headers', () => {
+    const requestBuilder = new RequestBuilder('POST', '/fn1');
+    requestBuilder.addBody({ key: 'value' });
+    const request = requestBuilder.toObject();
+
+    let lambdaProxyContext;
+
+    before(() => {
+      lambdaProxyContext = createLambdaProxyContext(request, options, stageVariables);
+    });
+
+    it('should calculate the Content-Length header', () => {
+      expect(lambdaProxyContext.headers['Content-Length']).to.eq(15);
+    });
+
+    it('should inject a default Content-Type header', () => {
+      expect(lambdaProxyContext.headers['Content-Type']).to.eq('application/json');
+    });
+
+    it('should stringify the payload for the body', () => {
+      expect(lambdaProxyContext.body).to.eq("{\"key\":\"value\"}");
+    });
+  });
 });


### PR DESCRIPTION
I was fiddling around with a different issues, and incidentally added a couple of tests around the default headers added in the Lambda Proxy request context:

If the body is present:

* calculate and add a `Content-Length` header
* set a default `Content-Type` of `application/json` if none is provided

No underlying library behaviour is changed.