### PR TITLE
Disabling node socket timeout

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: node_js
 node_js:
   - node
+  - '7'
   - '6'
   - '5'
   - '4.3.2'

--- a/src/index.js
+++ b/src/index.js
@@ -330,6 +330,7 @@ class Offline {
       const funName = key;
       const servicePath = path.join(this.serverless.config.servicePath, this.options.location);
       const funOptions = functionHelper.getFunctionOptions(fun, key, servicePath);
+      debugLog(`funOptions ${JSON.stringify(funOptions, null, 2)} `);
 
       this.printBlankLine();
       debugLog(funName, 'runtime', serviceRuntime, funOptions.babelOptions || '');
@@ -386,6 +387,7 @@ class Offline {
         const routeConfig = {
           cors,
           auth: authStrategyName,
+          timeout: { socket: false },
         };
 
         if (routeMethod !== 'HEAD' && routeMethod !== 'GET') {

--- a/test/integration/offline.js
+++ b/test/integration/offline.js
@@ -116,7 +116,7 @@ describe('Offline', () => {
 
       offLine.inject('/index', res => {
         expect(res.headers['content-type']).to.contains('text/html');
-        expect(res.statusCode).to.eq('200');
+        expect(res.statusCode).to.satisfy(status => status === 200 || status === '200');
         done();
       });
     });
@@ -142,7 +142,7 @@ describe('Offline', () => {
 
         offLine.inject('/index', res => {
           expect(res.headers['content-type']).to.contains('text/html');
-          expect(res.statusCode).to.eq('500');
+          expect(res.statusCode).to.satisfy(status => status === 500 || status === '500');
           done();
         });
       });
@@ -167,7 +167,7 @@ describe('Offline', () => {
 
         offLine.inject('/index', res => {
           expect(res.headers['content-type']).to.contains('text/html');
-          expect(res.statusCode).to.eq('401');
+          expect(res.statusCode).to.satisfy(status => status === 401 || status === '401');
           done();
         });
       });


### PR DESCRIPTION
Even setting my function handler timeout to 300 seconds my connections was closing after 120 seconds.
That's because of node socket default timeout (https://hapijs.com/api#route-options, navigate to timeout -> socket or search for `2 minutes` on this page).
This PR sets route config `timeout.socket` to `false` so we can delegate the timeout just to the  `_replyTimeout` function.
Also I am adding a debug log for `funOptions` because I think it's an important value to see when debugging.