### PR TITLE
add support for nodejs6.10 into serverless_0.5

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -267,7 +267,7 @@ module.exports = S => {
         // Runtime checks
         // No python or Java :'(
         const funRuntime = fun.runtime;
-        if (['nodejs', 'nodejs4.3', 'babel'].indexOf(funRuntime) === -1) {
+        if (['nodejs', 'nodejs4.3', 'nodejs6.10', 'babel'].indexOf(funRuntime) === -1) {
           printBlankLine();
 
           return serverlessLog(`Warning: found unsupported runtime '${funRuntime}' for function '${fun.name}'`);


### PR DESCRIPTION
Hi guys, I use the old version of serverless (0.5.6) but I want to use new node runtime (6.10).

The branch "serverless_0.5" still doesn't support **nodejs6.10**, can you please approve these changes  for "serverless_0.5" as well?