### PR TITLE
Service wide environment variables passed on in authorizer

### DIFF
--- a/src/createAuthScheme.js
+++ b/src/createAuthScheme.js
@@ -19,8 +19,8 @@ module.exports = function createAuthScheme(authFun, authorizerOptions, funName, 
 
   // Create Auth Scheme
   return () => ({
-
     authenticate(request, reply) {
+      process.env = _.extend({},serverless.service.provider.environment, process.env);
       console.log(''); // Just to make things a little pretty
       serverlessLog(`Running Authorization function for ${request.method} ${request.path} (λ: ${authFunName})`);
 

--- a/src/createAuthScheme.js
+++ b/src/createAuthScheme.js
@@ -5,8 +5,9 @@ const Boom = require('boom');
 const createLambdaContext = require('./createLambdaContext');
 const functionHelper = require('./functionHelper');
 const debugLog = require('./debugLog');
+const _ = require('lodash')
 
-module.exports = function createAuthScheme(authFun, authorizerOptions, funName, endpointPath, options, serverlessLog, servicePath) {
+module.exports = function createAuthScheme(authFun, authorizerOptions, funName, endpointPath, options, serverlessLog, servicePath, serverless) {
   const authFunName = authorizerOptions.name;
 
   const identitySourceMatch = /^method.request.header.((?:\w+-?)+\w+)$/.exec(authorizerOptions.identitySource);
@@ -20,7 +21,7 @@ module.exports = function createAuthScheme(authFun, authorizerOptions, funName, 
   // Create Auth Scheme
   return () => ({
     authenticate(request, reply) {
-      process.env = _.extend({},serverless.service.provider.environment, process.env);
+      process.env = _.extend({}, serverless.service.provider.environment, process.env);
       console.log(''); // Just to make things a little pretty
       serverlessLog(`Running Authorization function for ${request.method} ${request.path} (λ: ${authFunName})`);
 

--- a/src/index.js
+++ b/src/index.js
@@ -778,7 +778,8 @@ class Offline {
         epath,
         this.options,
         this.serverlessLog,
-        servicePath
+        servicePath,
+        this.serverless
       );
 
       // Set the auth scheme and strategy on the server


### PR DESCRIPTION
Currently, the environment variables set in the `serverless.yml` are not available in the custom authorizers implemented. This PR aims to resolve that issue.