### PR TITLE
Add apiId to requestContext

### DIFF
--- a/package.json
+++ b/package.json
@@ -80,7 +80,8 @@
     "Stewart Gleadow (https://github.com/sgleadow)",
     "Tuan Minh Huynh (https://github.com/tuanmh)",
     "Utku Turunc (https://github.com/utkuturunc)",
-    "Vasiliy Solovey (https://github.com/miltador)"
+    "Vasiliy Solovey (https://github.com/miltador)",
+    "Rob Brazier (https://github.com/robbrazier)"
   ],
   "license": "MIT",
   "bugs": {

--- a/src/createLambdaProxyContext.js
+++ b/src/createLambdaProxyContext.js
@@ -33,6 +33,7 @@ module.exports = function createLambdaProxyContext(request, options, stageVariab
     requestContext: {
       accountId: 'offlineContext_accountId',
       resourceId: 'offlineContext_resourceId',
+      apiId: 'offlineContext_apiId',
       stage: options.stage,
       requestId: `offlineContext_requestId_${utils.random().toString(10).slice(2)}`,
       identity: {


### PR DESCRIPTION
This was sparked from [vandium-io/lambda-event-identifier](https://github.com/vandium-io/lambda-event-identifier) not properly supporting serverless-offline due to a missing apiId in the requestContext.

Looking at some lambda proxy examples though, this could be useful to include for future compatibility reasons, if other libraries are checking the requestContext data as well.