### PR TITLE
Ensure path parameters are url encoded to match aws behavior

### DIFF
--- a/manual_test/handler.js
+++ b/manual_test/handler.js
@@ -70,3 +70,14 @@ module.exports.catchAll = (event, context, cb) => {
 
   cb(null, response);
 };
+
+module.exports.pathParams = (event, context, cb) => {
+  const response = {
+    statusCode: 200,
+    body: JSON.stringify({
+      message: `id is ${event.pathParameters.id}`,
+    }),
+  };
+
+  cb(null, response);
+};

--- a/manual_test/serverless.yml
+++ b/manual_test/serverless.yml
@@ -148,6 +148,12 @@ functions:
       - http:
           path: /{proxy+}
           method: ANY
+  pathParams:
+    handler: handler.pathParams
+    events:
+      - http:
+          path: /pathParams/{id}
+          method: GET
 
 # you can add CloudFormation resource templates here
 #resources:

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "Gert Jansen van Rensburg (https://github.com/gertjvr)",
     "Guillaume Carbonneau (https://github.com/guillaume)",
     "Jarda Snajdr (https://github.com/jsnajdr)",
+    "Jeff Hall (https://github.com/electrikdevelopment)",
     "jgilbert01 (https://github.com/jgilbert01)",
     "John McKim (https://github.com/johncmckim)",
     "Jonas De Kegel (https://github.com/jlsjonas)",

--- a/src/createLambdaProxyContext.js
+++ b/src/createLambdaProxyContext.js
@@ -13,6 +13,11 @@ module.exports = function createLambdaProxyContext(request, options, stageVariab
   let body = request.payload;
   // Used for Content-Length calculation
   const headers = utils.capitalizeKeys(request.headers);
+  const pathParams = {};
+  Object.keys(request.params).forEach(key => {
+    // aws doesn't auto decode path params - hapi does
+    pathParams[key] = encodeURIComponent(request.params[key]);
+  });
 
   if (body) {
     if(typeof body !== 'string') {
@@ -29,7 +34,7 @@ module.exports = function createLambdaProxyContext(request, options, stageVariab
   return {
     headers,
     path: request.path,
-    pathParameters: utils.nullIfEmpty(request.params),
+    pathParameters: utils.nullIfEmpty(pathParams),
     requestContext: {
       accountId: 'offlineContext_accountId',
       resourceId: 'offlineContext_resourceId',

--- a/test/support/RequestBuilder.js
+++ b/test/support/RequestBuilder.js
@@ -25,6 +25,10 @@ module.exports = class RequestBuilder {
     this.request.payload = body;
   }
 
+  addParam(key, value) {
+    this.request.params[key] = value;
+  }
+
   toObject() {
     return this.request;
   }

--- a/test/unit/createLambdaProxyContextTest.js
+++ b/test/unit/createLambdaProxyContextTest.js
@@ -106,4 +106,38 @@ describe('createLambdaProxyContext', () => {
       expect(lambdaProxyContext.body).to.eq("{\"key\":\"value\"}");
     });
   });
+
+  context('with a GET /fn1/{id} request with path parameters', () => {
+    const requestBuilder = new RequestBuilder('GET', '/fn1/1234');
+    requestBuilder.addParam('id', '1234');
+    const request = requestBuilder.toObject();
+
+    let lambdaProxyContext;
+
+    before(() => {
+      lambdaProxyContext = createLambdaProxyContext(request, options, stageVariables);
+    });
+
+    it('should have a path parameter', () => {
+      expect(Object.keys(lambdaProxyContext.pathParameters).length).to.eq(1);
+      expect(lambdaProxyContext.pathParameters.id).to.eq('1234');
+    });
+  });
+
+  context('with a GET /fn1/{id} request with encoded path parameters', () => {
+    const requestBuilder = new RequestBuilder('GET', '/fn1/test|1234');
+    requestBuilder.addParam('id', 'test|1234');
+    const request = requestBuilder.toObject();
+
+    let lambdaProxyContext;
+
+    before(() => {
+      lambdaProxyContext = createLambdaProxyContext(request, options, stageVariables);
+    });
+
+    it('should have a path parameter', () => {
+      expect(Object.keys(lambdaProxyContext.pathParameters).length).to.eq(1);
+      expect(lambdaProxyContext.pathParameters.id).to.eq('test%7C1234');
+    });
+  });
 });


### PR DESCRIPTION
Re-encoding path params that hapi auto decoded to match AWS behavior. Fixes #265 