### PR TITLE
Remove stage prefix from auth event methodArn

### DIFF
--- a/src/createAuthScheme.js
+++ b/src/createAuthScheme.js
@@ -37,7 +37,7 @@ module.exports = function createAuthScheme(authFun, authorizerOptions, funName, 
       const event = {
         type: 'TOKEN',
         authorizationToken: authorization,
-        methodArn: `arn:aws:execute-api:${options.region}:random-account-id:random-api-id/${options.stage}/${request.method.toUpperCase()}${request.path}`,
+        methodArn: `arn:aws:execute-api:${options.region}:random-account-id:random-api-id/${options.stage}/${request.method.toUpperCase()}${request.path.replace(new RegExp(`^/${options.stage}`), '')}`,
       };
 
       // Create the Authorization function handler


### PR DESCRIPTION
This is to more closely match the behavior of API Gateway.