### PR TITLE
Increase payload size limit from 1MB default to match AWS 10MB limit.

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -391,8 +391,9 @@ class Offline {
         };
 
         if (routeMethod !== 'HEAD' && routeMethod !== 'GET') {
-          // maxBytes: Increase request stize from 1MB default limit to 15MB
-          routeConfig.payload = { parse: false, maxBytes: 1024 * 1024 * 15 };
+          // maxBytes: Increase request size from 1MB default limit to 10MB.
+          // Cf AWS API GW payload limits.
+          routeConfig.payload = { parse: false, maxBytes: 1024 * 1024 * 10 };
         }
 
         this.server.route({

--- a/src/index.js
+++ b/src/index.js
@@ -391,7 +391,8 @@ class Offline {
         };
 
         if (routeMethod !== 'HEAD' && routeMethod !== 'GET') {
-          routeConfig.payload = { parse: false };
+          // maxBytes: Increase request stize from 1MB default limit to 15MB
+          routeConfig.payload = { parse: false, maxBytes: 1024 * 1024 * 15 };
         }
 
         this.server.route({


### PR DESCRIPTION
Requests with binary data may need more than 1MB, and there is no such 1MB limit in AWS API Gateway.

Closes #282 