### PR TITLE
Don't swallow error message when creating auth function handler

### DIFF
--- a/src/createAuthScheme.js
+++ b/src/createAuthScheme.js
@@ -47,7 +47,8 @@ module.exports = function createAuthScheme(authFun, authorizerOptions, funName, 
         handler = functionHelper.createHandler(funOptions, options);
       }
       catch (err) {
-        return reply(Boom.badImplementation(null, `Error while loading ${authFunName}`));
+        debugLog(`create authorization function handler error: ${err}`);
+        return reply(Boom.badImplementation(null, `Error while loading ${authFunName}: ${err.message}`));
       }
 
       // Creat the Lambda Context for the Auth function


### PR DESCRIPTION
Pretty frequently have issues with the authfunc having some error and it gets swallowed with a pretty unhelpful message. I'm constantly having to add a debug print of the error to find out what the issue is. 

I think this change will improve developer's lives (at least mine!)

The change adds the following to the debug output (example):

`[offline] create authorization function handler Error: Cannot find module '../authorize'`

