### PR TITLE
FIXED: Random requestId generation.

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "Garun Vagidov (https://github.com/garunski)",
     "Gert Jansen van Rensburg (https://github.com/gertjvr)",
     "Guillaume Carbonneau (https://github.com/guillaume)",
+    "György Balássy (https://github.com/balassy)",
     "Jarda Snajdr (https://github.com/jsnajdr)",
     "Jeff Hall (https://github.com/electrikdevelopment)",
     "jgilbert01 (https://github.com/jgilbert01)",

--- a/src/createLambdaContext.js
+++ b/src/createLambdaContext.js
@@ -1,5 +1,7 @@
 'use strict';
 
+const utils = require('./utils');
+
 /*
   Mimicks the lambda context object
   http://docs.aws.amazon.com/lambda/latest/dg/nodejs-prog-model-context.html
@@ -22,7 +24,7 @@ module.exports = function createLambdaContext(fun, cb) {
     memoryLimitInMB:    fun.memorySize,
     functionVersion:    `offline_functionVersion_for_${functionName}`,
     invokedFunctionArn: `offline_invokedFunctionArn_for_${functionName}`,
-    awsRequestId:       `offline_awsRequestId_${Math.random().toString(10).slice(2)}`,
+    awsRequestId:       `offline_awsRequestId_${utils.randomId()}`,
     logGroupName:       `offline_logGroupName_for_${functionName}`,
     logStreamName:      `offline_logStreamName_for_${functionName}`,
     identity:           {},

--- a/src/createLambdaProxyContext.js
+++ b/src/createLambdaProxyContext.js
@@ -53,7 +53,7 @@ module.exports = function createLambdaProxyContext(request, options, stageVariab
       resourceId: 'offlineContext_resourceId',
       apiId: 'offlineContext_apiId',
       stage: options.stage,
-      requestId: `offlineContext_requestId_${utils.random().toString(10).slice(2)}`,
+      requestId: `offlineContext_requestId_${utils.randomId()}`,
       identity: {
         cognitoIdentityPoolId: 'offlineContext_cognitoIdentityPoolId',
         accountId: 'offlineContext_accountId',

--- a/src/createVelocityContext.js
+++ b/src/createVelocityContext.js
@@ -1,6 +1,6 @@
 'use strict';
 
-// const utils = require('./utils');
+const utils = require('./utils');
 const jsonPath = require('./jsonPath');
 const jsEscapeString = require('js-string-escape');
 const isPlainObject = require('lodash').isPlainObject;
@@ -48,7 +48,7 @@ module.exports = function createVelocityContext(request, options, payload) {
         userAgent:                     request.headers['user-agent'] || '',
         userArn:                       'offlineContext_userArn',
       },
-      requestId:    `offlineContext_requestId_${Math.random().toString(10).slice(2)}`,
+      requestId:    `offlineContext_requestId_${utils.randomId()}`,
       resourceId:   'offlineContext_resourceId',
       resourcePath: request.route.path,
       stage:        options.stage,

--- a/src/index.js
+++ b/src/index.js
@@ -23,6 +23,7 @@ const createAuthScheme = require('./createAuthScheme');
 const functionHelper = require('./functionHelper');
 const Endpoint = require('./Endpoint');
 const parseResources = require('./parseResources');
+const utils = require('./utils');
 
 /*
  I'm against monolithic code like this file, but splitting it induces unneeded complexity.
@@ -462,7 +463,7 @@ class Offline {
               }
             }
             // Shared mutable state is the root of all evil they say
-            const requestId = Math.random().toString().slice(2);
+            const requestId = utils.randomId();
             this.requests[requestId] = { done: false };
             this.currentRequestId = requestId;
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -4,7 +4,7 @@ const _ = require('lodash');
 
 module.exports = {
   toPlainOrEmptyObject: obj => _.isPlainObject(obj) ? obj : {},
-  random: (lower, upper, floating) => _.random(lower, upper, floating),
+  randomId: () => Math.random().toString(10).slice(2),
   nullIfEmpty: o => o && (Object.keys(o).length > 0 ? o : null),
   capitalizeKeys: o => {
     const capitalized = {};

--- a/test/unit/createLambdaProxyContextTest.js
+++ b/test/unit/createLambdaProxyContextTest.js
@@ -59,6 +59,14 @@ describe('createLambdaProxyContext', () => {
       expect(lambdaProxyContext.body).to.be.null();
     });
 
+    it('should have a unique requestId', () => {
+      const prefix = 'offlineContext_requestId_';
+      expect(lambdaProxyContext.requestContext.requestId.length).to.be.greaterThan(prefix.length);
+      
+      const randomNumber = +lambdaProxyContext.requestContext.requestId.slice(prefix.length);
+      expect(randomNumber).to.be.a('number');
+    });
+
     it('should match fixed attributes', () => {
       expectFixedAttributes(lambdaProxyContext);
     });


### PR DESCRIPTION
Previously the `createLambdaProxyContext` function did not generate a unique `requestId`, because the referenced `random` function in the `utils.js` was buggy. This PR removes the dependency on the Lodash `random` function, and standardizes random ID generation all over the package. A test case is also added to verify the random `requestId` generation.

Thanks for creating and maintaining this package!