### PR TITLE
Include environment variables defined for the authorizer function when the authorizer function runs.

### DIFF
--- a/src/createAuthScheme.js
+++ b/src/createAuthScheme.js
@@ -21,7 +21,7 @@ module.exports = function createAuthScheme(authFun, authorizerOptions, funName, 
   // Create Auth Scheme
   return () => ({
     authenticate(request, reply) {
-      process.env = _.extend({}, serverless.service.provider.environment, process.env);
+      process.env = _.extend({}, serverless.service.provider.environment, authFun.environment, process.env);
       console.log(''); // Just to make things a little pretty
       serverlessLog(`Running Authorization function for ${request.method} ${request.path} (λ: ${authFunName})`);
 


### PR DESCRIPTION
Environment variables that are defined for an authorizer function are not set when the authorizer function runs.

Given this serverless.yml:
```yml
provider:
  environment:
    SOME_VAR: 'foo'
functions:
  hello:
    handler: index.hello
    events:
      - http:
          path: hello
          method: get
          authorizer: authorizerFunc
  authorizerFunc:
    handler: index.authorizerFunc
    environment:
      OTHER_VAR: 'bar'
```

`process.env.OTHER_VAR` will be `undefined` when the authorizer function runs.

----

#254 assigned environment variables on a per request basis, so that environment variables that were defined on a specific function would not be overridden by variables defined for a different function. But, this meant that environment variables were not set for authorizer function(s).

#263 partially fixed environment variables for authorizer functions by including provider level environment variables when the authorizer function runs.

With this pull request, any environment variables that are defined specific to the authorizer function will also be included when the authorizer runs.