### PR TITLE
Accept lower case auth header

### DIFF
--- a/src/createLambdaProxyContext.js
+++ b/src/createLambdaProxyContext.js
@@ -34,7 +34,7 @@ module.exports = function createLambdaProxyContext(request, options, stageVariab
     pathParams[key] = encodeURIComponent(request.params[key]);
   });
 
-  let token = headers.Authorization;
+  let token = headers.Authorization || headers.authorization;
   
   if (token && token.split(' ')[0] === 'Bearer') {
     token = token.split(' ')[1];


### PR DESCRIPTION
HTTP specs define headers as case insensitive and some frameworks normalise to lower-case as a result.
I've provided a pretty basic change to make this usable with code bases that behave this way.