### PR TITLE
Made check for Content-Type header case insensitive before setting

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "serverless-offline",
-  "version": "3.15.3",
+  "version": "3.16.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/createLambdaProxyContext.js
+++ b/src/createLambdaProxyContext.js
@@ -21,8 +21,8 @@ module.exports = function createLambdaProxyContext(request, options, stageVariab
     }
     headers['Content-Length'] = Buffer.byteLength(body);
 
-    // Set a default Content-Type if not provided.
-    if (!headers['Content-Type']) {
+    // Set a default Content-Type if not provided. Perform a case insensitive search for the content type header
+    if (!Object.keys(headers).some(key => key.equalsIgnoreCase('Content-Type'))) {
       headers['Content-Type'] = 'application/json';
     }
   }
@@ -35,7 +35,7 @@ module.exports = function createLambdaProxyContext(request, options, stageVariab
   });
 
   let token = headers.Authorization;
-  
+
   if (token && token.split(' ')[0] === 'Bearer') {
     token = token.split(' ')[1];
   }


### PR DESCRIPTION
I am using fetch (I tried isomorphic-fetch and node-fetch) to post multipart/form-data. Before posting, both libraries convert the headers to all lower-case. createLambdaProxyContent looks for the header Content-Type with case sensitivity, so the header was not found and Content-Type was set to 'application/json'

When multer (a package for multipart decoding) checked for the content-type header it found application/json and did not decode the form. This PR fixes that problem. I suspect this is not the best way to solve this problem, but it did work for my needs.

It seems like it would be better to either convert all the keys for the headers to lower case up front, then change all checks to lower case or to wrap the header object(s) with a proxy to handle case insensitive lookup. I started with this approach because it is the least invasive for the rest of the code.

I will be happy to update the fix to a more complete solution if you have a preference.