### PR TITLE
Adding support for request-type authorizers

### DIFF
--- a/package.json
+++ b/package.json
@@ -85,7 +85,8 @@
     "Stewart Gleadow (https://github.com/sgleadow)",
     "Tuan Minh Huynh (https://github.com/tuanmh)",
     "Utku Turunc (https://github.com/utkuturunc)",
-    "Vasiliy Solovey (https://github.com/miltador)"
+    "Vasiliy Solovey (https://github.com/miltador)",
+    "Daniel Cottone (https://github.com/daniel-cottone)"
   ],
   "license": "MIT",
   "bugs": {

--- a/src/createAuthScheme.js
+++ b/src/createAuthScheme.js
@@ -50,16 +50,15 @@ module.exports = function createAuthScheme(authFun, authorizerOptions, funName, 
           headers: request.headers,
           pathParameters: utils.nullIfEmpty(pathParams),
           queryStringParameters: utils.nullIfEmpty(request.query),
-          methodArn: `arn:aws:execute-api:${options.region}:random-account-id:random-api-id/${options.stage}/${request.method.toUpperCase()}${request.path.replace(new RegExp(`^/${options.stage}`), '')}`,
         };
       }
       else {
         event = {
           type: 'TOKEN',
           authorizationToken: authorization,
-          methodArn: `arn:aws:execute-api:${options.region}:random-account-id:random-api-id/${options.stage}/${request.method.toUpperCase()}${request.path.replace(new RegExp(`^/${options.stage}`), '')}`,
         };
       }
+      event.methodArn = `arn:aws:execute-api:${options.region}:random-account-id:random-api-id/${options.stage}/${request.method.toUpperCase()}${request.path.replace(new RegExp(`^/${options.stage}`), '')}`;
 
       // Create the Authorization function handler
       try {

--- a/src/createAuthScheme.js
+++ b/src/createAuthScheme.js
@@ -47,6 +47,8 @@ module.exports = function createAuthScheme(authFun, authorizerOptions, funName, 
       if (authorizerOptions.type === 'request') {
         event = {
           type: 'REQUEST',
+          path: request.path,
+          httpMethod: request.method.toUpperCase(),
           headers: request.headers,
           pathParameters: utils.nullIfEmpty(pathParams),
           queryStringParameters: utils.nullIfEmpty(request.query),


### PR DESCRIPTION
Now that serverless supports request type authorizers, it makes sense for this plugin to also support them. This PR fixes #326 