### PR TITLE
Support binary responses using isBase64Encoded flag

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -715,7 +715,13 @@ class Offline {
 
                 Object.assign(response.headers, defaultHeaders, result.headers);
                 if (!_.isUndefined(result.body)) {
-                  response.source = result.body;
+                  if (result.isBase64Encoded) {
+                    response.source = new Buffer(result.body, 'base64');
+                    response.variety = 'buffer';
+                  }
+                  else {
+                    response.source = result.body;
+                  }
                 }
               }
 


### PR DESCRIPTION
API Gateway will treat lambda-proxy responses with `isBase64Encoded` set
to `true` as binary as long as the mime-type matches one of the allowed
binary types.

This change checks the flag and responds with a Buffer created from the
encoded string, instead of the string itself.

If one was being thorough one would probably also support this guy:
https://github.com/maciejtreder/serverless-apigw-binary

But I suspect the binary type configuration in APIG is an mostly an
additional layer of security?