### PR TITLE
Stop stripping newlines and tabs from body

### DIFF
--- a/src/createLambdaProxyContext.js
+++ b/src/createLambdaProxyContext.js
@@ -17,7 +17,8 @@ module.exports = function createLambdaProxyContext(request, options, stageVariab
 
   if (body) {
     if (typeof body !== 'string') {
-      body = JSON.stringify(body);
+      // JSON.stringify(JSON.parse(request.payload)) is NOT the same as the rawPayload
+      body = request.rawPayload;
     }
     headers['Content-Length'] = Buffer.byteLength(body);
 

--- a/src/index.js
+++ b/src/index.js
@@ -407,6 +407,7 @@ class Offline {
           handler: (request, reply) => { // Here we go
             // Payload processing
             request.payload = request.payload && request.payload.toString();
+            request.rawPayload = request.payload;
 
             // Headers processing
             // Hapi lowercases the headers whereas AWS does not

--- a/test/support/RequestBuilder.js
+++ b/test/support/RequestBuilder.js
@@ -12,6 +12,7 @@ module.exports = class RequestBuilder {
       },
       query: {},
       payload: null,
+      rawPayload: null,
       info: {
         remoteAddress: '127.0.0.1',
       },
@@ -25,6 +26,9 @@ module.exports = class RequestBuilder {
 
   addBody(body) {
     this.request.payload = body;
+
+    // The rawPayload would normally be the string version of the given body
+    this.request.rawPayload = JSON.stringify(body);
   }
 
   addParam(key, value) {


### PR DESCRIPTION
This change introduces request.rawPayload to the Hapi request
and uses that if request.payload is not a string.

Before, JSON.stringify(JSON.parse(request.payload)) was being
used, which is not the same as the rawPayload that should be
passed along.

---

I noticed when using the Intercom API that serverless-offline was stripping out newlines and tabs from the request body, which makes it impossible to test webhooks that use a `x-hub-signature`. I checked and the current behavior from serverless-offline does not emulate the behavior of AWS Lambda in this respect.

I have changed `createLambdaProxyContent` so that it passes the raw payload through instead of stringifying the payload.

I have also added some tests that fail on the current version of serverless-offline.