### PR TITLE
enforces upper case on method names for protected routes mapping

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -354,7 +354,7 @@ class Offline {
         }
 
         if (_.eq(event.http.private, true)) {
-          protectedRoutes.push(`${event.http.method}#/${event.http.path}`);
+          protectedRoutes.push(`${event.http.method.toUpperCase()}#/${event.http.path}`);
         }
 
         // generate an enpoint via the endpoint class


### PR DESCRIPTION
- fixes #336 
- fixes #288 