### PR TITLE
Update offline-default.req.vm

### DIFF
--- a/src/offline-default.req.vm
+++ b/src/offline-default.req.vm
@@ -11,7 +11,7 @@
   "body": $input.json("$"),
   "method": "$context.httpMethod",
   "principalId": "$context.authorizer.principalId",
-  #set( $map = $input.params().header )
+  #set( $map = $input.params().headers )
   "headers": $loop,
   #set( $map = $input.params().querystring )
   "query": $loop,


### PR DESCRIPTION
For me the headers are missing from the request and this seems to be due to an error in this file. In so much that the `createVelocityContext.js` file creates the variable: `input.params.headers` however this template is using `input.params().header`