### PR TITLE
Use header (singular) to follow API Gateway conventions

### DIFF
--- a/src/createVelocityContext.js
+++ b/src/createVelocityContext.js
@@ -61,7 +61,7 @@ module.exports = function createVelocityContext(request, options, payload) {
         ({
           path: Object.assign({}, request.params),
           querystring: Object.assign({}, request.query),
-          headers,
+          header: headers,
         }),
       path,
     },


### PR DESCRIPTION
Api Gateway's request templates use the header object to get the values for the headers.