### PR TITLE
improved error logging

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -871,7 +871,11 @@ class Offline {
     const stackTrace = this._getArrayStackTrace(err.stack);
 
     this.serverlessLog(message);
-    console.log(stackTrace || err);
+    if (stackTrace && stackTrace.length > 0) {
+      console.log(stackTrace);
+    } else {
+      console.log(err)
+    }
 
     /* eslint-disable no-param-reassign */
     response.statusCode = 200; // APIG replies 200 by default on failures


### PR DESCRIPTION
Log error in _reply500 if stack trace is empty. Fixes #361.

I'm still not sure though, maybe error should be logged unconditionally instead? Because I see there're two error messages generated: one comes from the exception that triggered error 500 generation, the other comes from the code that handled that exception. It's a little confusing, what would be better…