### PR TITLE
Added support to noEnvironment flag

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "serverless-offline",
-  "version": "3.18.0",
+  "version": "3.19.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "serverless-offline",
-  "version": "3.18.0",
+  "version": "3.19.0",
   "description": "Emulate AWS λ and API Gateway locally when developing your Serverless project",
   "main": "src/index.js",
   "scripts": {

--- a/src/index.js
+++ b/src/index.js
@@ -502,8 +502,9 @@ class Offline {
                 AWS_SECRET_ACCESS_KEY: 'dev',
                 AWS_REGION: 'dev'
               }
-              process.env = _.extend({}, baseEnvironment, this.originalEnvironment);
+              process.env = _.extend({}, baseEnvironment);
               if (!this.options.noEnvironment) Object.assign(process.env, this.service.provider.environment, this.service.functions[key].environment)
+              Object.assign(process.env, this.originalEnvironment)
               handler = functionHelper.createHandler(funOptions, this.options);
             }
             catch (err) {

--- a/src/index.js
+++ b/src/index.js
@@ -496,7 +496,14 @@ class Offline {
             let handler; // The lambda function
 
             try {
-              process.env = _.extend({}, this.service.provider.environment, this.service.functions[key].environment, this.originalEnvironment);
+              // This evict errors in server when we use aws services like ssm
+              const baseEnvironment = {
+                AWS_ACCESS_KEY_ID: 'dev',
+                AWS_SECRET_ACCESS_KEY: 'dev',
+                AWS_REGION: 'dev'
+              }
+              process.env = _.extend({}, baseEnvironment, this.originalEnvironment);
+              if (!this.options.noEnvironment) Object.assign(process.env, this.service.provider.environment, this.service.functions[key].environment)
               handler = functionHelper.createHandler(funOptions, this.options);
             }
             catch (err) {


### PR DESCRIPTION
 - Avoid aws errors when use aws service in serverless.yml like ssm;
 - Don't load serverless environment variables when the flag noEnvironment is passed.