### PR TITLE
Add option to run handlers in separate node processes

### DIFF
--- a/package.json
+++ b/package.json
@@ -104,6 +104,7 @@
     "jsonpath-plus": "^0.16.0",
     "jsonwebtoken": "^7.4.3",
     "lodash": "^4.17.4",
+    "uuid": "^3.2.1",
     "velocityjs": "^0.9.3"
   },
   "devDependencies": {

--- a/src/index.js
+++ b/src/index.js
@@ -116,6 +116,9 @@ class Offline {
           noAuth: {
             usage: 'Turns off all authorizers',
           },
+          useSeparateProcesses: {
+            usage: 'Uses separate node processes for handlers',
+          }
         },
       },
     };
@@ -228,6 +231,7 @@ class Offline {
       corsAllowHeaders: 'accept,content-type,x-api-key',
       corsAllowCredentials: true,
       apiKey: crypto.createHash('md5').digest('hex'),
+      useSeparateProcesses: false,
     };
 
     this.options = _.merge({}, defaultOpts, (this.service.custom || {})['serverless-offline'], this.options);

--- a/src/ipcHelper.js
+++ b/src/ipcHelper.js
@@ -1,0 +1,22 @@
+'use strict';
+
+process.on('uncaughtException', e => {
+  Error.captureStackTrace(e);
+  process.send({ error: e });
+});
+
+const handler = require(process.argv[2]);
+
+process.on('message', opts => {
+  function done(error, ret) {
+    process.send({ id: opts.id, error, ret });
+  }
+
+  handler[opts.name](opts.event, {
+    ...opts.context,
+    done,
+    succeed: res => done(null, res),
+    fail:    err => done(err, null),
+    // TODO implement getRemainingTimeInMillis
+  }, done);
+});

--- a/src/ipcHelper.js
+++ b/src/ipcHelper.js
@@ -12,11 +12,11 @@ process.on('message', opts => {
     process.send({ id: opts.id, error, ret });
   }
 
-  handler[opts.name](opts.event, {
-    ...opts.context,
+  const context = Object.assign(opts.context, {
     done,
     succeed: res => done(null, res),
     fail:    err => done(err, null),
     // TODO implement getRemainingTimeInMillis
-  }, done);
+  });
+  handler[opts.name](opts.event, context, done);
 });

--- a/src/ipcHelper.js
+++ b/src/ipcHelper.js
@@ -1,7 +1,6 @@
 'use strict';
 
 process.on('uncaughtException', e => {
-  Error.captureStackTrace(e);
   process.send({ error: e });
 });
 


### PR DESCRIPTION
This feature stemmed from issues getting our app working properly with cache invalidation enabled. Old handlers weren't being removed fully, database connections not being closed, etc.

Instead, I've gone the route of allowing each handler to run in its own node process, which is simply destroyed after the request returns. (Or kept running/cached if `--skipCacheInvalidation` is provided)

This feature is activated using `--useSeparateProcesses`. This does add a bit of overhead to each request, but it's useful for avoiding restarting serverless every time a change is made.

If you're interested in having this feature upstreamed, I'll go fix the few remaining `TODO`s and clean it up.

(This also addresses the issues outlined in #313)