### PR TITLE
Add support for complex policies with wildcards

### DIFF
--- a/src/authCanExecuteResource.js
+++ b/src/authCanExecuteResource.js
@@ -1,0 +1,17 @@
+const authMatchPolicyResource = require('./authMatchPolicyResource');
+
+module.exports = (policy, resource) => {
+  const Statement = policy.Statement;
+
+  return Statement.some(statement => {
+    if (Array.isArray(statement.Resource)) {
+      return statement.Effect === 'Allow'
+        && statement.Resource.some(policyResource => (
+          authMatchPolicyResource(policyResource, resource)
+        ));
+    }
+
+    return statement.Effect === 'Allow'
+      && authMatchPolicyResource(statement.Resource, resource);
+  });
+};

--- a/src/authMatchPolicyResource.js
+++ b/src/authMatchPolicyResource.js
@@ -1,0 +1,26 @@
+module.exports = (policyResource, resource) => {
+  if (policyResource === resource) {
+    return true;
+  }
+  else if (policyResource.includes('*')) {
+    //Policy contains a wildcard resource
+    const splitPolicyResource = policyResource.split(':');
+    const splitResource = resource.split(':');
+    //These variables contain api id, stage, method and the path
+    //for the requested resource and the resource defined in the policy
+    const splitPolicyResourceApi = splitPolicyResource[5].split('/');
+    const splitResourceApi = splitResource[5].split('/');
+
+    return splitPolicyResourceApi.every((resourceFragment, index) => {
+      if (splitResourceApi.length >= index + 1) {
+        return (splitResourceApi[index] === resourceFragment || resourceFragment === '*');
+      }
+      //The last position in the policy resource is a '*' it matches all
+      //following resource fragments
+
+      return splitPolicyResourceApi[splitPolicyResourceApi.length - 1] === '*';
+    });
+  }
+
+  return false;
+};

--- a/src/createAuthScheme.js
+++ b/src/createAuthScheme.js
@@ -7,6 +7,7 @@ const functionHelper = require('./functionHelper');
 const debugLog = require('./debugLog');
 const utils = require('./utils');
 const _ = require('lodash');
+const authCanExecuteResource = require('./authCanExecuteResource');
 
 module.exports = function createAuthScheme(authFun, authorizerOptions, funName, endpointPath, options, serverlessLog, servicePath, serverless) {
   const authFunName = authorizerOptions.name;
@@ -93,13 +94,13 @@ module.exports = function createAuthScheme(authFun, authorizerOptions, funName, 
             return reply(Boom.forbidden('No principalId set on the Response'));
           }
 
-          serverlessLog(`Authorization function returned a successful response: (λ: ${authFunName})`, policy);
-
-          if (policy.policyDocument.Statement[0].Effect === 'Deny') {
+          if (!authCanExecuteResource(policy.policyDocument, event.methodArn)) {
             serverlessLog(`Authorization response didn't authorize user to access resource: (λ: ${authFunName})`, err);
 
             return reply(Boom.forbidden('User is not authorized to access this resource'));
           }
+
+          serverlessLog(`Authorization function returned a successful response: (λ: ${authFunName})`, policy);
 
           // Set the credentials for the rest of the pipeline
           return reply.continue({ credentials: { user: policy.principalId, context: policy.context } });

--- a/test/unit/authCanExecuteResourceTest.js
+++ b/test/unit/authCanExecuteResourceTest.js
@@ -1,0 +1,156 @@
+/* global describe context it */
+
+'use strict';
+
+const chai = require('chai');
+const dirtyChai = require('dirty-chai');
+const authCanExecuteResource = require('../../src/authCanExecuteResource');
+
+const expect = chai.expect;
+chai.use(dirtyChai);
+
+describe('authCanExecuteResource', () => {
+  context('when the policy has one Statement in an array', () => {
+    const setup = (Effect, Resource) => ({
+      Statement: [
+        {
+          Effect,
+          Resource,
+        },
+      ],
+    });
+    const resource = 'arn:aws:execute-api:eu-west-1:random-account-id:random-api-id/development/GET/dinosaurs';
+
+    context('when the Resource is in an Allow statement', () => {
+      context('and the Resource is an array', () => {
+        it('returns true', () => {
+          const policy = setup(
+            'Allow',
+            [resource]
+          );
+
+          const canExecute = authCanExecuteResource(policy, resource);
+          expect(canExecute).to.eq(true);
+        });
+      });
+
+      it('returns true', () => {
+        const policy = setup(
+          'Allow',
+          resource
+        );
+
+        const canExecute = authCanExecuteResource(policy, resource);
+        expect(canExecute).to.eq(true);
+      });
+    });
+
+    context('when the Resource is in a Deny statement', () => {
+      context('and Resource is an array', () => {
+        it('returns true', () => {
+          const policy = setup(
+            'Deny',
+            [resource]
+          );
+
+          const canExecute = authCanExecuteResource(policy, resource);
+          expect(canExecute).to.eq(false);
+        });
+      });
+      it('returns false', () => {
+        const policy = setup(
+          'Deny',
+          resource
+        );
+
+        const canExecute = authCanExecuteResource(policy, resource);
+        expect(canExecute).to.eq(false);
+      });
+    });
+  });
+
+  context('when the policy has multiple Statements', () => {
+    const setup = statements => (
+      {
+        Statement: statements.map((statement) => (
+          {
+            Effect: statement.Effect,
+            Resource: statement.Resource,
+          }
+        )),
+      }
+    );
+    const resourceOne = 'arn:aws:execute-api:eu-west-1:random-account-id:random-api-id/development/GET/dinosaurs';
+    const resourceTwo = 'arn:aws:execute-api:eu-west-1:random-account-id:random-api-id/development/GET/dogs';
+
+    context('when the Resource is in an Allow statement', () => {
+      context('and the Resource is an array', () => {
+        it('returns true', () => {
+          const policy = setup(
+            [{
+              Effect: 'Allow',
+              Resource: [resourceOne],
+            },
+            {
+              Effect: 'Deny',
+              Resource: [resourceTwo],
+            }]
+          );
+
+          const canExecute = authCanExecuteResource(policy, resourceOne);
+          expect(canExecute).to.eq(true);
+        });
+      });
+
+      it('returns true', () => {
+        const policy = setup(
+          [{
+            Effect: 'Allow',
+            Resource: resourceOne,
+          }],
+          [{
+            Effect: 'Deny',
+            Resource: resourceTwo,
+          }]
+        );
+        const canExecute = authCanExecuteResource(policy, resourceOne);
+        expect(canExecute).to.eq(true);
+      });
+    });
+
+    context('when the resource is in a Deny statement', () => {
+      context('and the Resource is an array', () => {
+        it('returns true', () => {
+          const policy = setup(
+            [{
+              Effect: 'Allow',
+              Resource: [resourceOne],
+            },
+            {
+              Effect: 'Deny',
+              Resource: [resourceTwo],
+            }]
+          );
+
+          const canExecute = authCanExecuteResource(policy, resourceTwo);
+          expect(canExecute).to.eq(false);
+        });
+      });
+      it('returns false', () => {
+        const policy = setup(
+          [{
+            Effect: 'Allow',
+            Resource: resourceOne,
+          }],
+          [{
+            Effect: 'Deny',
+            Resource: resourceTwo,
+          }]
+        );
+
+        const canExecute = authCanExecuteResource(policy, resourceTwo);
+        expect(canExecute).to.eq(false);
+      });
+    });
+  });
+});

--- a/test/unit/authMatchPolicyResourceTest.js
+++ b/test/unit/authMatchPolicyResourceTest.js
@@ -1,0 +1,93 @@
+/* global describe context it */
+
+'use strict';
+
+const chai = require('chai');
+const dirtyChai = require('dirty-chai');
+const authMatchPolicyResource = require('../../src/authMatchPolicyResource');
+
+const expect = chai.expect;
+chai.use(dirtyChai);
+
+describe('authMatchPolicyResource', () => {
+  context('when resource has no wildcards', () => {
+    const resource = 'arn:aws:execute-api:eu-west-1:random-account-id:random-api-id/development/GET/dinosaurs';
+    context('and the resource matches', () => {
+      it('returns true', () => {
+        expect(
+          authMatchPolicyResource(resource, resource)
+        ).to.eq(true);
+      });
+    });
+    context('when the resource has one wildcard to match everything', () => {
+      const wildcardResource = 'arn:aws:execute-api:eu-west-1:random-account-id:random-api-id/*';
+      it('returns true', () => {
+        expect(
+          authMatchPolicyResource(wildcardResource, resource)
+        ).to.eq(true);
+      });
+    });
+    context('when the resource has wildcards', () => {
+      const wildcardResource = 'arn:aws:execute-api:eu-west-1:random-account-id:random-api-id/development/GET/*';
+      context('and it matches', () => {
+        it('returns true', () => {
+          expect(
+            authMatchPolicyResource(wildcardResource, resource)
+          ).to.eq(true);
+        });
+      });
+      context('and it does not match', () => {
+        it('returns false', () => {
+          const resource = 'arn:aws:execute-api:eu-west-1:random-account-id:random-api-id/development/PUT/dinosaurs';
+
+          expect(
+            authMatchPolicyResource(wildcardResource, resource)
+          ).to.eq(false);
+        });
+      });
+      context('when the resource has multiple wildcards', () => {
+        const wildcardResource = 'arn:aws:execute-api:eu-west-1:random-account-id:random-api-id/development/*/*/stats';
+
+        context('and the wildcard is between two fragments', () => {
+          const wildcardResource = 'arn:aws:execute-api:eu-west-1:random-account-id:random-api-id/development/*/dinosaurs/*';
+          context('and it matches', () => {
+            it('returns true', () => {
+              const resource = 'arn:aws:execute-api:eu-west-1:random-account-id:random-api-id/development/GET/dinosaurs/stats';
+
+              expect(
+                authMatchPolicyResource(wildcardResource, resource)
+              ).to.eq(true);
+            });
+          });
+          context('and it does not match', () => {
+            it('returns false', () => {
+              const resource = 'arn:aws:execute-api:eu-west-1:random-account-id:random-api-id/development/GET/cats/stats';
+
+              expect(
+                authMatchPolicyResource(wildcardResource, resource)
+              ).to.eq(false);
+            });
+          });
+        });
+        context('and it matches', () => {
+          it('returns true', () => {
+            const resource = 'arn:aws:execute-api:eu-west-1:random-account-id:random-api-id/development/GET/dinosaurs/stats';
+
+            expect(
+              authMatchPolicyResource(wildcardResource, resource)
+            ).to.eq(true);
+          });
+        });
+        context('and it does not match', () => {
+          it('returns false', () => {
+            const resource = 'arn:aws:execute-api:eu-west-1:random-account-id:random-api-id/development/PUT/dinosaurs/xx';
+
+            expect(
+              authMatchPolicyResource(wildcardResource, resource)
+            ).to.eq(false);
+          });
+        });
+      });
+    });
+  });
+});


### PR DESCRIPTION
As reported in #340 custom authorizers currently only look at the first statement in the returned policy and do not inspect the whole of the policy returned by the authorizer function.

This PR adds support for more complex policies that would be more common in the real world. Wild cards are supported in resources.

