### PR TITLE
Improves support authorizer.type == request

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -716,9 +716,9 @@ class Offline {
 
                 Object.assign(response.headers, defaultHeaders, result.headers);
                 if (!_.isUndefined(result.body)) {
-                  if(result.isBase64Encoded) {
+                  if (result.isBase64Encoded) {
                     response.encoding = 'binary';
-                    response.source = new Buffer(result.body,'base64');
+                    response.source = new Buffer(result.body, 'base64');
                     response.variety = 'buffer';
                   }
                   else {
@@ -874,8 +874,9 @@ class Offline {
     this.serverlessLog(message);
     if (stackTrace && stackTrace.length > 0) {
       console.log(stackTrace);
-    } else {
-      console.log(err)
+    }
+    else {
+      console.log(err);
     }
 
     /* eslint-disable no-param-reassign */


### PR DESCRIPTION
- moves the strict check to be called only if the type === 'token' (not request)
- capitalizes headers in addition to the lowercase version because on AWS the headers are always capitalized
- fixes a couple of lint errors

Fixes https://github.com/dherault/serverless-offline/issues/375