### PR TITLE
Use Response.header rather than Response.headers

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -714,11 +714,14 @@ class Offline {
 
                 const defaultHeaders = { 'Content-Type': 'application/json' };
 
-                Object.assign(response.headers, defaultHeaders, result.headers);
+                Object.assign(defaultHeaders, result.headers);
+                Object.keys(defaultHeaders).forEach(header => {
+                  response.header(header, defaultHeaders[header]);
+                })
                 if (!_.isUndefined(result.body)) {
-                  if(result.isBase64Encoded) {
+                  if (result.isBase64Encoded) {
                     response.encoding = 'binary';
-                    response.source = new Buffer(result.body,'base64');
+                    response.source = new Buffer(result.body, 'base64');
                     response.variety = 'buffer';
                   }
                   else {
@@ -874,7 +877,8 @@ class Offline {
     this.serverlessLog(message);
     if (stackTrace && stackTrace.length > 0) {
       console.log(stackTrace);
-    } else {
+    } 
+    else {
       console.log(err)
     }
 

--- a/test/integration/offline.js
+++ b/test/integration/offline.js
@@ -190,7 +190,7 @@ describe('Offline', () => {
         url: '/fn1',
         payload: { data: 'data' },
       }, res => {
-        expect(res.headers).to.have.property('content-type', 'application/json; charset=utf-8');
+        expect(res.headers).to.have.property('content-type').which.contains('application/json');
         done();
       });
     });
@@ -216,7 +216,7 @@ describe('Offline', () => {
         },
         payload: { data: 'data' },
       }, res => {
-        expect(res.headers).to.have.property('content-type', 'application/json; charset=utf-8');
+        expect(res.headers).to.have.property('content-type').which.contains('application/json');
         done();
       });
     });
@@ -262,7 +262,7 @@ describe('Offline', () => {
         method: 'GET',
         url: '/fn1',
       }, res => {
-        expect(res.headers).to.have.property('content-type', 'application/json; charset=utf-8');
+        expect(res.headers).to.have.property('content-type').which.contains('application/json');
         done();
       });
     });
@@ -444,7 +444,7 @@ describe('Offline', () => {
         url: '/index',
         payload: { data: 'input' },
       }, res => {
-        expect(res.headers).to.have.property('content-type', 'application/json');
+        expect(res.headers).to.have.property('content-type').which.contains('application/json');
         expect(res.statusCode).to.eq(200);
         expect(res.payload).to.eq('{"message":"Hello World"}');
         done();

--- a/test/integration/offline.js
+++ b/test/integration/offline.js
@@ -190,7 +190,7 @@ describe('Offline', () => {
         url: '/fn1',
         payload: { data: 'data' },
       }, res => {
-        expect(res.headers).to.have.property('content-type', 'application/json');
+        expect(res.headers).to.have.property('content-type', 'application/json; charset=utf-8');
         done();
       });
     });
@@ -262,7 +262,7 @@ describe('Offline', () => {
         method: 'GET',
         url: '/fn1',
       }, res => {
-        expect(res.headers).to.have.property('content-type', 'application/json');
+        expect(res.headers).to.have.property('content-type', 'application/json; charset=utf-8');
         done();
       });
     });


### PR DESCRIPTION
Changed the way that the response headers are set, and opted to use the response.header function rather than setting response.headers directly. This allows for some of the headers which hapi sets to be handled better (e.g. CORS)