### PR TITLE
Fix for broken AWS resources

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
   "maintainers": [
     "Bilal Soylu (https://github.com/Bilal-S)",
     "Leonardo Alifraco (https://github.com/leonardoalifraco)",
-    "Michael Staub (https://github.com/mikestaub)"
+    "Michael Staub (https://github.com/mikestaub)",
+    "Daniel Cottone <daniel.cottone@gmail.com> (https://github.com/daniel-cottone)"
   ],
   "contributors": [
     "Adam Sweeting (https://github.com/adamelliottsweeting)",
@@ -87,7 +88,7 @@
     "Tuan Minh Huynh (https://github.com/tuanmh)",
     "Utku Turunc (https://github.com/utkuturunc)",
     "Vasiliy Solovey (https://github.com/miltador)",
-    "Daniel Cottone (https://github.com/daniel-cottone)",
+    "Daniel Cottone <daniel.cottone@gmail.com> (https://github.com/daniel-cottone)",
     "Jaryd Carolin (https://github.com/horyd)"
   ],
   "license": "MIT",

--- a/src/index.js
+++ b/src/index.js
@@ -496,15 +496,19 @@ class Offline {
             let handler; // The lambda function
 
             try {
-              // This evict errors in server when we use aws services like ssm
-              const baseEnvironment = {
-                AWS_ACCESS_KEY_ID: 'dev',
-                AWS_SECRET_ACCESS_KEY: 'dev',
-                AWS_REGION: 'dev'
+              if (this.options.noEnvironment) {
+                // This evict errors in server when we use aws services like ssm
+                const baseEnvironment = {
+                  AWS_ACCESS_KEY_ID: 'dev',
+                  AWS_SECRET_ACCESS_KEY: 'dev',
+                  AWS_REGION: 'dev'
+                }
+                process.env = _.extend({}, baseEnvironment);
               }
-              process.env = _.extend({}, baseEnvironment);
-              if (!this.options.noEnvironment) Object.assign(process.env, this.service.provider.environment, this.service.functions[key].environment)
-              Object.assign(process.env, this.originalEnvironment)
+              else {
+                Object.assign(process.env, this.service.provider.environment, this.service.functions[key].environment);
+              }
+              Object.assign(process.env, this.originalEnvironment);
               handler = functionHelper.createHandler(funOptions, this.options);
             }
             catch (err) {


### PR DESCRIPTION
This PR fixes https://github.com/dherault/serverless-offline/issues/383

Serverless-offline `3.20` breaks usage of aws resources. This resolves that by only overriding environment variables for AWS credentials when specifying the `--noEnvironment` flag,