### PR TITLE
Adding process.env._HANDLER

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -509,6 +509,7 @@ class Offline {
                 Object.assign(process.env, this.service.provider.environment, this.service.functions[key].environment);
               }
               Object.assign(process.env, this.originalEnvironment);
+              process.env._HANDLER = fun.handler;
               handler = functionHelper.createHandler(funOptions, this.options);
             }
             catch (err) {


### PR DESCRIPTION
When calling lambdas functions using API Gateway at AWS environments the environment variable `_HANDLER` is set.

Some plugins are using this variable but it's not possible to use them with `serverless-offline` because the lack of this variable (see: https://github.com/trek10inc/serverless-secrets/issues/22).

Also I think we want to keep `serverless-offline` environment as similar as possible to a real AWS environment.