### PR TITLE
Adds special encoding for multipart/form-data

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -23,6 +23,7 @@ const createAuthScheme = require('./createAuthScheme');
 const functionHelper = require('./functionHelper');
 const Endpoint = require('./Endpoint');
 const parseResources = require('./parseResources');
+const utils = require('./utils');
 
 /*
  I'm against monolithic code like this file, but splitting it induces unneeded complexity.
@@ -406,7 +407,9 @@ class Offline {
           config: routeConfig,
           handler: (request, reply) => { // Here we go
             // Payload processing
-            request.payload = request.payload && request.payload.toString();
+            const encoding = utils.detectEncoding(request);
+
+            request.payload = request.payload && request.payload.toString(encoding);
             request.rawPayload = request.payload;
 
             // Headers processing

--- a/src/utils.js
+++ b/src/utils.js
@@ -14,4 +14,7 @@ module.exports = {
 
     return capitalized;
   },
+  // Detect the toString encoding from the request headers content-type
+  // enhance if further content types need to be non utf8 encoded.
+  detectEncoding: request => _.includes(request.headers['content-type'], 'multipart/form-data') ? 'binary' : 'utf8',
 };

--- a/test/unit/utilsTest.js
+++ b/test/unit/utilsTest.js
@@ -40,4 +40,27 @@ describe('utils', () => {
       });
     });
   });
+
+  describe('#detectEncoding', () => {
+    context('with application/json content-type', () => {
+      it('should return utf8', () => {
+        const request = {
+          headers: {
+            'content-type': 'application/json',
+          },
+        };
+        expect(utils.detectEncoding(request)).to.eq('utf8');
+      });
+    });
+    context('with multipart/form-data content-type', () => {
+      it('should return binary', () => {
+        const request = {
+          headers: {
+            'content-type': 'multipart/form-data',
+          },
+        };
+        expect(utils.detectEncoding(request)).to.eq('binary');
+      });
+    });
+  });
 });


### PR DESCRIPTION
Hello,

This PR resolves #230 with a quick fix change to allow `serverless-offline` to handle `multipart/form-data` which is surely never a `utf8` string in most use cases.

I didn't have a fantastic general solution but it has come up a couple of times from people out there per the referenced issue.

I did replace a fork that I use to test this and found that it works as expected with test data that is used to send to aws.