### PR TITLE
Add async handler support for nodejs8.10 runtime

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "David Bunker (https://github.com/dbunker)",
     "demetriusnunes (https://github.com/demetriusnunes)",
     "DJCrabhat (https://github.com/djcrabhat)",
+    "Domas Lasauskas (https://github.com/domaslasauskas)",
     "Echo Nolan (https://github.com/enolan)",
     "Egor Kislitsyn (https://github.com/minibikini)",
     "Elliott Spira (https://github.com/em0ney)",

--- a/src/index.js
+++ b/src/index.js
@@ -779,7 +779,7 @@ class Offline {
               const x = handler(event, lambdaContext, lambdaContext.done);
 
               // Promise support
-              if (serviceRuntime === 'babel' && !this.requests[requestId].done) {
+              if ((serviceRuntime === 'nodejs8.10' || serviceRuntime === 'babel') && !this.requests[requestId].done) {
                 if (x && typeof x.then === 'function' && typeof x.catch === 'function') x.then(lambdaContext.succeed).catch(lambdaContext.fail);
                 else if (x instanceof Error) lambdaContext.fail(x);
               }


### PR DESCRIPTION
This change will allow using handlers with await/async and handlers returning `Promise` for `nodejs8.10` runtime. More information on await/async handlers are available in [AWS Lambda docs](https://docs.aws.amazon.com/lambda/latest/dg/nodejs-prog-model-handler.html).

Fixes #384 