### PR TITLE
Add binary support when using lambda integration

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,6 +71,7 @@
     "Matt Jonker (https://github.com/msjonker)",
     "Michael MacDonald (https://github.com/mjmac)",
     "Miso (Mike) Zmiric (https://github.com/mzmiric5)",
+    "Niall Riordan (https://github.com/njriordan)",
     "Norimitsu Yamashita (https://github.com/nori3tsu)",
     "Oliv (https://github.com/obearn)",
     "Paul Esson (https://github.com/thepont)",

--- a/src/index.js
+++ b/src/index.js
@@ -730,7 +730,7 @@ class Offline {
                 response.statusCode = statusCode;
                 if (contentHandling === 'CONVERT_TO_BINARY') {
                   response.encoding = 'binary';
-                  response.source = new Buffer(result, 'base64');
+                  response.source = Buffer.from(result, 'base64');
                   response.variety = 'buffer';
                 }
                 else {
@@ -746,7 +746,7 @@ class Offline {
                 if (!_.isUndefined(result.body)) {
                   if (result.isBase64Encoded) {
                     response.encoding = 'binary';
-                    response.source = new Buffer(result.body, 'base64');
+                    response.source = Buffer.from(result.body, 'base64');
                     response.variety = 'buffer';
                   }
                   else {

--- a/src/index.js
+++ b/src/index.js
@@ -580,6 +580,7 @@ class Offline {
               let result = data;
               let responseName = 'default';
               const responseContentType = endpoint.responseContentType;
+              const contentHandling = endpoint.contentHandling;
 
               /* RESPONSE SELECTION (among endpoint's possible responses) */
 
@@ -727,7 +728,14 @@ class Offline {
                   override: false, // Maybe a responseParameter set it already. See #34
                 });
                 response.statusCode = statusCode;
-                response.source = result;
+                if (contentHandling === 'CONVERT_TO_BINARY') {
+                  response.encoding = 'binary';
+                  response.source = new Buffer(result, 'base64');
+                  response.variety = 'buffer';
+                }
+                else {
+                  response.source = result;
+                }
               }
               else if (integration === 'lambda-proxy') {
                 response.statusCode = statusCode = result.statusCode || 200;


### PR DESCRIPTION
Currently binary responses are only supported when using the lambda-proxy integration. This PR adds support when using the lambda integration. The usage is compatible with https://github.com/ryanmurakami/serverless-apigwy-binary