### PR TITLE
read content-type header in a case insensitive manner

### DIFF
--- a/package.json
+++ b/package.json
@@ -76,6 +76,7 @@
     "Niall Riordan (https://github.com/njriordan)",
     "Norimitsu Yamashita (https://github.com/nori3tsu)",
     "Oliv (https://github.com/obearn)",
+    "Parham Michael Ossareh (https://github.com/ossareh)",
     "Paul Esson (https://github.com/thepont)",
     "Paul Pasmanik (https://github.com/ppasmanik)",
     "Piotr Gasiorowski (https://github.com/WooDzu)",

--- a/src/createLambdaProxyContext.js
+++ b/src/createLambdaProxyContext.js
@@ -23,9 +23,7 @@ module.exports = function createLambdaProxyContext(request, options, stageVariab
     headers['Content-Length'] = Buffer.byteLength(body);
 
     // Set a default Content-Type if not provided.
-    if (!headers['Content-Type']) {
-      headers['Content-Type'] = 'application/json';
-    }
+    headers['Content-Type'] = headers['Content-Type'] || headers['content-type'] || 'application/json';
   }
 
   const pathParams = {};

--- a/test/unit/createLambdaProxyContextTest.js
+++ b/test/unit/createLambdaProxyContextTest.js
@@ -62,7 +62,7 @@ describe('createLambdaProxyContext', () => {
     it('should have a unique requestId', () => {
       const prefix = 'offlineContext_requestId_';
       expect(lambdaProxyContext.requestContext.requestId.length).to.be.greaterThan(prefix.length);
-      
+
       const randomNumber = +lambdaProxyContext.requestContext.requestId.slice(prefix.length);
       expect(randomNumber).to.be.a('number');
     });
@@ -188,6 +188,19 @@ describe('createLambdaProxyContext', () => {
       expect(lambdaProxyContext.requestContext.authorizer.claims).to.be.undefined;
     });
   });
+
+  context('with a POST /fn1 request with a lowercase Content-Type header', () => {
+    it('should assign the value to Content-Type', () => {
+      const requestBuilder = new RequestBuilder('POST', '/fn1')
+      requestBuilder.addBody({ key: 'value' })
+      requestBuilder.addHeader('content-type', 'custom/test')
+      const request = requestBuilder.toObject();
+
+      const lambdaProxyContext = createLambdaProxyContext(request, options, stageVariables);
+
+      expect(lambdaProxyContext.headers['Content-Type']).to.eq('custom/test');
+    });
+  })
 
   context('with a GET /fn1/{id} request with path parameters', () => {
     const requestBuilder = new RequestBuilder('GET', '/fn1/1234');


### PR DESCRIPTION
## summary

I have a simple case where firefox and chrome use different capitalization for the content-type header; serverless-offline looks only for 'Content-Type' and so in local cross browser testing code that relies on this header [1] I'm getting 'application/json' instead of a multipart form-data / boundary header.

Specifically Firefox sets 'content-type' versus Chrome setting 'Content-Type'. 

My fix is simple, and I do not actually agree with this as a course of action. I think it would be more correct to normalize headers earlier in the request process so that everything downstream can be written to support that normalization. I'm happy to take a step back and evaluate what that work would take, however it feels risky as I'm very new to the code of the project. AWS Lambda appears to normalize headers.

Tests pass, including the new test I added.

## details

Without this patch the following curl request results in the following headers in the AWS lambda handler. I have manually verified that AWS lambda reads in a case insensitive manner.

### `curl`

```
curl 'https://localhost:3000/subscribe?__amp_source_origin=http%3A%2F%2Flocalhost%3A1313' \
  -H 'Host: localhost:3000' \
  -H 'User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10.13; rv:60.0) Gecko/20100101 Firefox/60.0' \
  -H 'Accept: application/json' \
  -H 'Accept-Language: en-US,en;q=0.5' \
  -H 'Referer: http://localhost:1313/' \
  -H 'content-type: multipart/form-data; ---------------------------4008310941119962191124777961' \
  -H 'origin: http://localhost:1313' \
  -H 'DNT: 1' \
  -H 'Connection: keep-alive' \
  --data-binary $'---------------------------4008310941119962191124777961\r\nContent-Disposition: form-data; name="email"\r\n\r\nfoo@example.com\r\n---------------------------4008310941119962191124777961--\r\n' \
  --compressed
```

#### `event.headers`
```
{ Host: 'localhost:3000',
  'User-Agent': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10.13; rv:60.0) Gecko/20100101 Firefox/60.0',
  Accept: 'application/json',
  'Accept-Language': 'en-US,en;q=0.5',
  'Accept-Encoding': 'gzip, deflate',
  Referer: 'http://localhost:1313/',
  'Content-Type': 'application/json',
  Origin: 'http://localhost:1313',
  'Content-Length': 187,
  DNT: '1',
  Connection: 'keep-alive' }
```

with the patch:

#### `event.headers`
```
{ Host: 'localhost:3000',
  'User-Agent': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10.13; rv:60.0) Gecko/20100101 Firefox/60.0',
  Accept: 'application/json',
  'Accept-Language': 'en-US,en;q=0.5',
  'Accept-Encoding': 'gzip, deflate',
  Referer: 'http://localhost:1313/',
  'Content-Type': 'multipart/form-data; boundary=---------------------------4008310941119962191124777961',
  Origin: 'http://localhost:1313',
  'Content-Length': 187,
  DNT: '1',
  Connection: 'keep-alive',
  Pragma: 'no-cache',
  'Cache-Control': 'no-cache' }
```

I mention the idea of normalizing headers, were that approach to be taken it would need some testing to make sure headers are normalized correctly. Here's a quick example of how lambda capitalizes headers:

```
curl -H 'foo-bar-baz: custom/value' ... 
>  'Foo-Bar-Baz': 'custom/value',
```

The code above is merely a handler doing: `console.log(event.headers)`. I've not tested how it handles headers like, for example: "AMP-Same-Origin" (which is sent if your page is loaded from an AMP CDN).


[1]: https://github.com/mscdex/busboy