### PR TITLE
Case insensitive header handling

### DIFF
--- a/package.json
+++ b/package.json
@@ -76,6 +76,7 @@
     "Niall Riordan (https://github.com/njriordan)",
     "Norimitsu Yamashita (https://github.com/nori3tsu)",
     "Oliv (https://github.com/obearn)",
+    "Parham Michael Ossareh (https://github.com/ossareh)",
     "Paul Esson (https://github.com/thepont)",
     "Paul Pasmanik (https://github.com/ppasmanik)",
     "Piotr Gasiorowski (https://github.com/WooDzu)",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "serverless-offline",
-  "version": "3.23.0",
+  "version": "3.24.0",
   "description": "Emulate AWS λ and API Gateway locally when developing your Serverless project",
   "main": "src/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "Al Pal (https://github.com/againer)",
     "allenhartwig (https://github.com/allenhartwig)",
     "Andre Rabold (https://github.com/arabold)",
+    "Andras Streichardt (https://github.com/m0ppers)",
     "Andrei Popovici (https://github.com/andreipopovici)",
     "Anthony Liatsis (https://github.com/aliatsis)",
     "Austen (https://github.com/ac360)",

--- a/src/createLambdaProxyContext.js
+++ b/src/createLambdaProxyContext.js
@@ -23,9 +23,7 @@ module.exports = function createLambdaProxyContext(request, options, stageVariab
     headers['Content-Length'] = Buffer.byteLength(body);
 
     // Set a default Content-Type if not provided.
-    if (!headers['Content-Type']) {
-      headers['Content-Type'] = 'application/json';
-    }
+    headers['Content-Type'] = headers['Content-Type'] || headers['content-type'] || 'application/json';
   }
 
   const pathParams = {};

--- a/test/unit/createLambdaProxyContextTest.js
+++ b/test/unit/createLambdaProxyContextTest.js
@@ -62,7 +62,7 @@ describe('createLambdaProxyContext', () => {
     it('should have a unique requestId', () => {
       const prefix = 'offlineContext_requestId_';
       expect(lambdaProxyContext.requestContext.requestId.length).to.be.greaterThan(prefix.length);
-      
+
       const randomNumber = +lambdaProxyContext.requestContext.requestId.slice(prefix.length);
       expect(randomNumber).to.be.a('number');
     });
@@ -188,6 +188,19 @@ describe('createLambdaProxyContext', () => {
       expect(lambdaProxyContext.requestContext.authorizer.claims).to.be.undefined;
     });
   });
+
+  context('with a POST /fn1 request with a lowercase Content-Type header', () => {
+    it('should assign the value to Content-Type', () => {
+      const requestBuilder = new RequestBuilder('POST', '/fn1')
+      requestBuilder.addBody({ key: 'value' })
+      requestBuilder.addHeader('content-type', 'custom/test')
+      const request = requestBuilder.toObject();
+
+      const lambdaProxyContext = createLambdaProxyContext(request, options, stageVariables);
+
+      expect(lambdaProxyContext.headers['Content-Type']).to.eq('custom/test');
+    });
+  })
 
   context('with a GET /fn1/{id} request with path parameters', () => {
     const requestBuilder = new RequestBuilder('GET', '/fn1/1234');

--- a/test/unit/createLambdaProxyContextTest.js
+++ b/test/unit/createLambdaProxyContextTest.js
@@ -202,6 +202,20 @@ describe('createLambdaProxyContext', () => {
     });
   })
 
+  context('with a POST /fn1 request with a set Content-length', () => {
+    it('should have one content-length header only', () => {
+      const requestBuilder = new RequestBuilder('POST', '/fn1')
+      requestBuilder.addBody({ key: 'value' })
+      requestBuilder.addHeader('content-type', 'custom/test')
+      requestBuilder.addHeader('Content-length', '2')
+      const request = requestBuilder.toObject();
+
+      const lambdaProxyContext = createLambdaProxyContext(request, options, stageVariables);
+
+      expect(Object.keys(lambdaProxyContext.headers).filter(header => header.toLowerCase() == 'content-length')).to.have.lengthOf(1);
+    });
+  })
+
   context('with a GET /fn1/{id} request with path parameters', () => {
     const requestBuilder = new RequestBuilder('GET', '/fn1/1234');
     requestBuilder.addParam('id', '1234');


### PR DESCRIPTION
Had a case where a proxy would lowercase all the headers. that way this plugin messed my content-type. After finding the cause I saw that it was fixed in the latest version (was using an older version). However as headers must always be interpreted case insensitive I think there are more hidden problems with it (the content-length unittest I added being one).

So I thought I could also provide a fix for it.