### PR TITLE
Fix protected routes

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "Adam Sweeting (https://github.com/adamelliottsweeting)",
     "Adrien (https://github.com/AdrienGiboire)",
     "Al Pal (https://github.com/againer)",
+    "Alex Blythe (https://github.com/ablythe)", 
     "allenhartwig (https://github.com/allenhartwig)",
     "Andre Rabold (https://github.com/arabold)",
     "Andrei Popovici (https://github.com/andreipopovici)",

--- a/src/index.js
+++ b/src/index.js
@@ -368,10 +368,6 @@ class Offline {
           };
         }
 
-        if (_.eq(event.http.private, true)) {
-          protectedRoutes.push(`${event.http.method.toUpperCase()}#/${event.http.path}`);
-        }
-
         // generate an enpoint via the endpoint class
         const endpoint = new Endpoint(event.http, funOptions).generate();
 
@@ -386,6 +382,10 @@ class Offline {
         let fullPath = this.options.prefix + (epath.startsWith('/') ? epath.slice(1) : epath);
         if (fullPath !== '/' && fullPath.endsWith('/')) fullPath = fullPath.slice(0, -1);
         fullPath = fullPath.replace(/\+}/g, '*}');
+
+        if (_.eq(event.http.private, true)) {
+          protectedRoutes.push(`${method}#${fullPath}`);
+        }
 
         this.serverlessLog(`${method} ${fullPath}`);
 


### PR DESCRIPTION
Possibly related to #364 

**Issue:** Currently serverless-offline is [adding](https://github.com/dherault/serverless-offline/blob/master/src/index.js#L372) a `/` before every path it pushes into the `protectedRoutes` array. So paths that already have a `/` such as `/users` end up as `//users` in the array. 

When a call is made to '/users', it's not registering as protected because [_.includes(['GET#//users'], 'GET#/users')](https://github.com/dherault/serverless-offline/blob/master/src/index.js#L475) returns false.

**Fix:** This change makes it so that the 'protected' attribute works on with functions whose paths begin with `/` and those that don't.


