### PR TITLE
Show the right waning on promise vs callback conflict.

### DIFF
--- a/src/createLambdaContext.js
+++ b/src/createLambdaContext.js
@@ -15,8 +15,8 @@ module.exports = function createLambdaContext(fun, cb) {
   return {
     /* Methods */
     done,
-    succeed: res => done(null, res),
-    fail:    err => done(err, null),
+    succeed: res => done(null, res, true),
+    fail:    err => done(err, null, true),
     getRemainingTimeInMillis: () => endTime - new Date().getTime(),
 
     /* Properties */

--- a/src/index.js
+++ b/src/index.js
@@ -580,7 +580,7 @@ class Offline {
             debugLog('event:', event);
 
             // We create the context, its callback (context.done/succeed/fail) will send the HTTP response
-            const lambdaContext = createLambdaContext(fun, (err, data) => {
+            const lambdaContext = createLambdaContext(fun, (err, data, fromPromise) => {
               // Everything in this block happens once the lambda function has resolved
               debugLog('_____ HANDLER RESOLVED _____');
 
@@ -590,6 +590,9 @@ class Offline {
               // User should not call context.done twice
               if (this.requests[requestId].done) {
                 this.printBlankLine();
+                const warning = fromPromise
+                  ? `Warning: handler '${funName}' returned a promise and also use a callback!\nThis is problematic and might cause issues in you lambda.`
+                  : `Warning: context.done called twice within handler '${funName}'!`
                 this.serverlessLog(`Warning: context.done called twice within handler '${funName}'!`);
                 debugLog('requestId:', requestId);
 


### PR DESCRIPTION
Closes #405 

The warning is legit but the message is a bit off.

The problem is very simple. However, the solution is very hard.

The problem, as pointed out in the issue, is at https://github.com/dherault/serverless-offline/blob/f3903a76d8ccd02550b5a1b5a733224abee3a50f/src/index.js#L813-L819

The function is async so returns immediately and returns a promise. Thus, being resolved as a promise.
Asynchronously, at some point in the future, the callback will be called. Thus, getting the warning.
I don't think there is any way to know when the callback will be called, if ever. So the only thing that we can do is to add a better warning message.

This is not a problem that affects only this library. Running async handlers that use the callback in AWS lambda also produce weird issues and doesn't work as expected. 
In all the projects I currently work that use lambda we have had to decide to go all the way callback or all the way async. But no mixing them.
So I think that it is correct to warn the users.