### PR TITLE
save and restore original String prototypes

### DIFF
--- a/src/javaHelpers.js
+++ b/src/javaHelpers.js
@@ -62,25 +62,29 @@ function equalsIgnoreCase(anotherString) {
   (this === anotherString || this.toLowerCase() === anotherString.toLowerCase());
 }
 
-function polluteStringPrototype() {
-  String.prototype.contains = contains;
-  String.prototype.replaceAll = replaceAll;
-  String.prototype.replaceFirst = replaceFirst;
-  String.prototype.matches = matches;
-  String.prototype.regionMatches = regionMatches;
-  String.prototype.equals = equals;
-  String.prototype.equalsIgnoreCase = equalsIgnoreCase;
-}
+const prototypeFunctions = {
+  contains,
+  replaceAll,
+  replaceFirst,
+  matches,
+  regionMatches,
+  equals,
+  equalsIgnoreCase
+};
 
-function depolluteStringPrototype() {
-  delete String.prototype.contains;
-  delete String.prototype.replaceAll;
-  delete String.prototype.replaceFirst;
-  delete String.prototype.matches;
-  delete String.prototype.regionMatches;
-  delete String.prototype.equals;
-  delete String.prototype.equalsIgnoreCase;
-}
+module.exports = function polluteStringPrototype() {
+  // Save a copy of any potential original prototype functions
+  const originalValues = Object.keys(prototypeFunctions).reduce(function(map, key) {
+    map[key] = String.prototype[key];
+    String.prototype[key] = prototypeFunctions[key];
+    return map;
+  }, {});
 
-// No particular exports
-module.exports = { polluteStringPrototype, depolluteStringPrototype };
+  // After the process is complete that needs these prototypes, restore
+  // the original functions.
+  return function depolluteStringPrototype() {
+    Object.keys(originalValues).forEach(function(key) {
+      String.prototype[key] = originalValues[key];
+    })
+  }
+};

--- a/src/renderVelocityTemplateObject.js
+++ b/src/renderVelocityTemplateObject.js
@@ -4,7 +4,7 @@ const Velocity = require('velocityjs');
 const isPlainObject = require('lodash').isPlainObject;
 
 const debugLog = require('./debugLog');
-const { polluteStringPrototype, depolluteStringPrototype } = require('./javaHelpers');
+const polluteStringPrototype = require('./javaHelpers');
 
 const Compile = Velocity.Compile;
 const parse = Velocity.parse;
@@ -24,7 +24,7 @@ function tryToParseJSON(string) {
 function renderVelocityString(velocityString, context) {
 
   // Add Java helpers to String prototype
-  polluteStringPrototype();
+  const depolluteStringPrototype = polluteStringPrototype();
 
   // This line can throw, but this function does not handle errors
   // Quick args explanation:


### PR DESCRIPTION
Related to #426 this change makes the String prototype mutation even safer by saving and restoring any original values.