### PR TITLE
Normalize Hapi queryParameters to be compliant with API Gateway

### DIFF
--- a/src/createLambdaProxyContext.js
+++ b/src/createLambdaProxyContext.js
@@ -82,7 +82,7 @@ module.exports = function createLambdaProxyContext(request, options, stageVariab
     },
     resource: request.route.path,
     httpMethod: request.method.toUpperCase(),
-    queryStringParameters: utils.nullIfEmpty(request.query),
+    queryStringParameters: utils.nullIfEmpty(utils.normalizeQuery(request.query)),
     stageVariables: utils.nullIfEmpty(stageVariables),
     body,
   };

--- a/src/utils.js
+++ b/src/utils.js
@@ -6,6 +6,13 @@ module.exports = {
   toPlainOrEmptyObject: obj => _.isPlainObject(obj) ? obj : {},
   randomId: () => Math.random().toString(10).slice(2),
   nullIfEmpty: o => o && (Object.keys(o).length > 0 ? o : null),
+  normalizeQuery: query =>
+    // foreach key, get the last element if it's an array
+    Object.keys(query).reduce((q, param) => {
+      q[param] = [].concat(query[param]).pop();
+
+      return q;
+    }, {}),
   capitalizeKeys: o => {
     const capitalized = {};
     for (let key in o) { // eslint-disable-line prefer-const

--- a/test/support/RequestBuilder.js
+++ b/test/support/RequestBuilder.js
@@ -35,6 +35,10 @@ module.exports = class RequestBuilder {
     this.request.params[key] = value;
   }
 
+  addQuery(key, value) {
+    this.request.query[key] = value;
+  }
+
   toObject() {
     return this.request;
   }

--- a/test/unit/createLambdaProxyContextTest.js
+++ b/test/unit/createLambdaProxyContextTest.js
@@ -316,4 +316,59 @@ describe('createLambdaProxyContext', () => {
       expect(lambdaProxyContext.pathParameters.id).to.eq('test%7C1234');
     });
   });
+
+  context('with a GET /fn1?param=1 request with single parameter in query string', () => {
+    const requestBuilder = new RequestBuilder('GET', '/fn1?param=1');
+    requestBuilder.addQuery('param', '1');
+    const request = requestBuilder.toObject();
+
+    let lambdaProxyContext;
+
+    before(() => {
+      lambdaProxyContext = createLambdaProxyContext(request, options, stageVariables);
+    });
+
+    it('should have a query parameter named param', () => {
+      expect(Object.keys(lambdaProxyContext.queryStringParameters).length).to.eq(1);
+      expect(lambdaProxyContext.queryStringParameters.param).to.eq('1');
+    });
+  });
+
+  context('with a GET /fn1?param=1&param2=1 request with double parameters in query string', () => {
+    const requestBuilder = new RequestBuilder('GET', '/fn1?param=1');
+    requestBuilder.addQuery('param', '1');
+    requestBuilder.addQuery('param2', '1');
+    const request = requestBuilder.toObject();
+
+    let lambdaProxyContext;
+
+    before(() => {
+      lambdaProxyContext = createLambdaProxyContext(request, options, stageVariables);
+    });
+
+    it('should have a two query parameters', () => {
+      expect(Object.keys(lambdaProxyContext.queryStringParameters).length).to.eq(2);
+      expect(lambdaProxyContext.queryStringParameters.param).to.eq('1');
+      expect(lambdaProxyContext.queryStringParameters.param2).to.eq('1');
+    });
+  });
+
+  context('with a GET /fn1?param=1&param=1 request with single query string', () => {
+    const requestBuilder = new RequestBuilder('GET', '/fn1?param=1');
+    // emaulate HAPI `query` as described here:
+    // https://futurestud.io/tutorials/hapi-how-to-use-query-parameters#multiplequeryparametersofthesamename
+    requestBuilder.addQuery('param', ['1', '2']);
+    const request = requestBuilder.toObject();
+
+    let lambdaProxyContext;
+
+    before(() => {
+      lambdaProxyContext = createLambdaProxyContext(request, options, stageVariables);
+    });
+
+    it('should have a two query parameters', () => {
+      expect(Object.keys(lambdaProxyContext.queryStringParameters).length).to.eq(1);
+      expect(lambdaProxyContext.queryStringParameters.param).to.eq('2');
+    });
+  });
 });


### PR DESCRIPTION
Related to #428 

### Problem
Querystring parameters with the same name are merged into arrays as Hapi feature described [here](https://futurestud.io/tutorials/hapi-how-to-use-query-parameters#multiplequeryparametersofthesamename). API Gateway instead get only the last parameter, because it requires parameter names are unique. 

E.g.
```
URL: /my-url?param=1&param=2
Expected value for event.queryStringParameters: {param: 2}
Actual value for event.queryStringParameters: {param: [1, 2]}
```

### Fix
In `createLambdaProxyContext`, every parameter in `request.query` is mapped into his last item.
