### PR TITLE
Only call end() from the corresponding lifecycle hook

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -131,7 +131,6 @@ class Offline {
 
     this.hooks = {
       'offline:start:init': this.start.bind(this),
-      'offline:start': this.start.bind(this),
       'offline:start:end': this.end.bind(this),
     };
   }
@@ -154,8 +153,7 @@ class Offline {
 
     return Promise.resolve(this._buildServer())
     .then(() => this._listen())
-    .then(() => this.options.exec ? this._executeShellScript() : this._listenForSigInt())
-    .then(() => this.end());
+    .then(() => this.options.exec ? this._executeShellScript() : this._listenForSigInt());
   }
 
   _checkVersion() {


### PR DESCRIPTION
The lifecycle events are called one after another anyway, there is no need to handle cleanup in the `init` lifecycle stage.

Fixes #436.