### PR TITLE
Check if usageIdentifierKey returned by an authorizer is a valid API key

### DIFF
--- a/src/createAuthScheme.js
+++ b/src/createAuthScheme.js
@@ -21,7 +21,7 @@ module.exports = function createAuthScheme(authFun, authorizerOptions, funName, 
     }
     identityHeader = identitySourceMatch[1].toLowerCase();
   }
-  
+
   const funOptions = functionHelper.getFunctionOptions(authFun, funName, servicePath);
 
   const serviceRuntime = serverless.service.provider.runtime;
@@ -121,7 +121,7 @@ module.exports = function createAuthScheme(authFun, authorizerOptions, funName, 
           serverlessLog(`Authorization function returned a successful response: (λ: ${authFunName})`, policy);
 
           // Set the credentials for the rest of the pipeline
-          return reply.continue({ credentials: { user: policy.principalId, context: policy.context } });
+          return reply.continue({ credentials: { user: policy.principalId, context: policy.context, usageIdentifierKey: policy.usageIdentifierKey } });
         };
 
         if (result && typeof result.then === 'function' && typeof result.catch === 'function') {

--- a/src/index.js
+++ b/src/index.js
@@ -480,7 +480,14 @@ class Offline {
                   return errorResponse(reply);
                 }
               }
-              else {
+              else if (request.auth && request.auth.credentials && 'usageIdentifierKey' in request.auth.credentials) {
+                const usageIdentifierKey = request.auth.credentials['usageIdentifierKey'];
+                if (usageIdentifierKey !== this.options.apiKey) {
+                  debugLog(`Method ${method} of function ${funName} token ${usageIdentifierKey} not valid`);
+
+                  return errorResponse(reply);
+                }
+              } else {
                 debugLog(`Missing x-api-key on private function ${funName}`);
 
                 return errorResponse(reply);


### PR DESCRIPTION
AWS API Gateway allows providing an API key from authorizer functions: https://docs.aws.amazon.com/apigateway/latest/developerguide/api-gateway-api-usage-plans.html#api-gateway-create-usage-plans

This fixes the bug that API keys returned from authorizer functions were not considered valid by serverless-offline.

