### PR TITLE
add cognito identity id header

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "serverless-offline",
-  "version": "3.25.4",
+  "version": "3.25.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/createLambdaProxyContext.js
+++ b/src/createLambdaProxyContext.js
@@ -63,7 +63,7 @@ module.exports = function createLambdaProxyContext(request, options, stageVariab
       identity: {
         cognitoIdentityPoolId: 'offlineContext_cognitoIdentityPoolId',
         accountId: 'offlineContext_accountId',
-        cognitoIdentityId: 'offlineContext_cognitoIdentityId',
+        cognitoIdentityId: request.headers['cognito-identity-id'] || 'offlineContext_cognitoIdentityId',
         caller: 'offlineContext_caller',
         apiKey: 'offlineContext_apiKey',
         sourceIp: request.info.remoteAddress,

--- a/test/unit/createLambdaProxyContextTest.js
+++ b/test/unit/createLambdaProxyContextTest.js
@@ -254,7 +254,7 @@ describe('createLambdaProxyContext', () => {
       expect(Object.keys(lambdaProxyContext.headers).filter(header => header === 'content-length')).to.have.lengthOf(1);
     });
   });
-  
+
   context('with a POST /fn1 request with a set Content-length', () => {
     it('should have one content-length header only', () => {
       const requestBuilder = new RequestBuilder('POST', '/fn1');
@@ -268,7 +268,7 @@ describe('createLambdaProxyContext', () => {
       expect(Object.keys(lambdaProxyContext.headers).filter(header => header.toLowerCase() === 'content-length')).to.have.lengthOf(1);
     });
   });
-  
+
   context('with a POST /fn1 request with a X-GitHub-Event header', () => {
     it('should assign not change the header case', () => {
       const requestBuilder = new RequestBuilder('POST', '/fn1');
@@ -371,4 +371,25 @@ describe('createLambdaProxyContext', () => {
       expect(lambdaProxyContext.queryStringParameters.param).to.eq('2');
     });
   });
+
+  context('with a request that includes cognito-identity-id header', () => {
+    const requestBuilder = new RequestBuilder('GET', '/fn1');
+    const testId = 'test-id';
+    requestBuilder.addHeader('cognito-identity-id', testId);
+    const request = requestBuilder.toObject();
+    let lambdaProxyContext;
+
+    before(() => {
+      lambdaProxyContext = createLambdaProxyContext(request, options, stageVariables);
+    });
+
+    it('should have the expected cognitoIdentityId', () => {
+      expect(lambdaProxyContext.requestContext.identity.cognitoIdentityId).to.eq(testId);
+    });
+
+    it('should have the expected headers', () => {
+      expect(Object.keys(lambdaProxyContext.headers).length).to.eq(1);
+      expect(lambdaProxyContext.headers['cognito-identity-id']).to.eq(testId);
+    })
+  })
 });


### PR DESCRIPTION
Allow for the ability to provide a Cognito identity id via request headers. 

see #406 