### PR TITLE
Ignore COGNITO_USER_POOLS authorizer

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -844,6 +844,11 @@ class Offline {
 
           return null;
         }
+        if (endpoint.authorizer.type && endpoint.authorizer.type.toUpperCase() === 'COGNITO_USER_POOLS') {
+          this.serverlessLog('WARNING: Serverless Offline does not support the COGNITO_USER_POOLS authorization type');
+
+          return null;
+        }
         if (endpoint.authorizer.arn) {
           this.serverlessLog(`WARNING: Serverless Offline does not support non local authorizers: ${endpoint.authorizer.arn}`);
 


### PR DESCRIPTION
This fix ignores the authorizer.type COGNITO_USER_POOLS.
Currently setup fails if the authorizer type is set to COGNITO_USER_POOLS.

Signed-off-by: Ken Fukuyama <kenfdev@gmail.com>

---

Other than `AWS_IAM`, `COGNITO_USER_POOLS`could be set to authorizer.type. It's also a common use case to set it other than authorizer.arn since [this](https://github.com/serverless/serverless/pull/4197) update in serverless framework.

Currently the serverless-offline only checks for authorizer.type === AWS_IAM or if authorizer.arn is set so if one sets it to authorizer.type === COGNITO_USER_POOLS, starting serverless-offline failes with an error.

```
Serverless: Configuring Authorization: api/sample undefined

  Serverless Error ---------------------------------------

  Function "undefined" doesn't exist in this Service

```

This fix will also ignore `COGNITO_USER_POOLS` with a warning.

```
Serverless: Routes for sampleApi:
Serverless: GET /api/sample
Serverless: WARNING: Serverless Offline does not support the COGNITO_USER_POOLS authorization type
```

Thanks for this awesome project. 