### PR TITLE
Minor Readme update to reflect Node v8.10.0 Lambda support

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ To do so, it starts an HTTP server that handles the request's lifecycle like API
 
 **Features:**
 
-* Nodejs λ only.
+* Node.js λ only.
 * Velocity templates support.
 * Lazy loading of your files with require cache invalidation: no need for a reloading tool like Nodemon.
 * And more: integrations, authorizers, proxies, timeouts, responseParameters, HTTPS, Babel runtime, CORS, etc...
@@ -164,7 +164,7 @@ custom:
       presets: ["env", "flow"]
 ```
 
-## Token Authorizers
+## Token authorizers
 
 As defined in the [Serverless Documentation](https://serverless.com/framework/docs/providers/aws/events/apigateway/#setting-api-keys-for-your-rest-api) you can use API Keys as a simple authentication method.
 
@@ -371,7 +371,8 @@ Serverless offline plugin can invoke shell scripts when a simulated server has b
 ## Simulation quality
 
 This plugin simulates API Gateway for many practical purposes, good enough for development - but is not a perfect simulator.
-Specifically, Lambda currently runs on Node v4.3.2 and v6.10.0, whereas _Offline_ runs on your own runtime where no memory limits are enforced.
+Specifically, Lambda currently runs on Node v6.10.0 and v8.10.0 ([AWS Docs](https://docs.aws.amazon.com/lambda/latest/dg/current-supported-versions.html)), whereas _Offline_ runs on your own runtime where no memory limits are enforced.
+
 
 ## Usage with serverless-offline and serverless-webpack plugin
 


### PR DESCRIPTION
About as minor of a nitpick as it gets, but wanted to keep the readme's mention of currently supported Node versions by AWS Lambda in sync.

#### Changes
- Update mention of supported Lambda versions to reflect deprecation of Node v4.3.2 and new support of Node v8.10.0, and add relevant link to AWS docs
- Change subheading "Token Authorizers" to "Token authorizes" for consistency with other subheadings (`</ocd>`) 