### PR TITLE
fix: error feedback when using --useSeparateProcesses flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ All CLI options are optional:
 --dontPrintOutput           Turns off logging of your lambda outputs in the terminal.
 --httpsProtocol         -H  To enable HTTPS, specify directory (relative to your cwd, typically your project dir) for both cert.pem and key.pem files.
 --skipCacheInvalidation -c  Tells the plugin to skip require cache invalidation. A script reloading tool like Nodemon might then be needed.
+--useSeparateProcesses      Run handlers in separate Node processes
 --corsAllowOrigin           Used as default Access-Control-Allow-Origin header value for responses. Delimit multiple values with commas. Default: '*'
 --corsAllowHeaders          Used as default Access-Control-Allow-Headers header value for responses. Delimit multiple values with commas. Default: 'accept,content-type,x-api-key'
 --corsExposedHeaders        Used as additional Access-Control-Exposed-Headers header value for responses. Delimit multiple values with commas. Default: 'WWW-Authenticate,Server-Authorization'

--- a/package.json
+++ b/package.json
@@ -70,6 +70,7 @@
     "Leonardo Alifraco (https://github.com/lalifraco-devspark)",
     "Luke Chavers (https://github.com/vmadman)",
     "Marc Campbell (https://github.com/marccampbell)",
+    "Marco Lüthy (https://github.com/adieuadieu)",
     "Mark Tse (https://github.com/neverendingqs)",
     "Martin Micunda (https://github.com/martinmicunda)",
     "Matt Hodgson (https://github.com/mhodgson)",

--- a/src/index.js
+++ b/src/index.js
@@ -767,7 +767,7 @@ class Offline {
                 }
                 else {
                   if (result.body && typeof result.body !== 'string') {
-                    return this._reply500(response, `According to the API Gateway specs, the body content must be stringified. Check your Lambda response and make sure you are invoking JSON.stringify(YOUR_CONTENT) on your body object`, {}, requestId);
+                    return this._reply500(response, 'According to the API Gateway specs, the body content must be stringified. Check your Lambda response and make sure you are invoking JSON.stringify(YOUR_CONTENT) on your body object', {}, requestId);
                   }
                   response.source = result;
                 }
@@ -790,9 +790,9 @@ class Offline {
                     response.variety = 'buffer';
                   }
                   else {
-                      if (result.body && typeof result.body !== 'string') {
-                        return this._reply500(response, `According to the API Gateway specs, the body content must be stringified. Check your Lambda response and make sure you are invoking JSON.stringify(YOUR_CONTENT) on your body object`, {}, requestId);
-                      }
+                    if (result.body && typeof result.body !== 'string') {
+                      return this._reply500(response, 'According to the API Gateway specs, the body content must be stringified. Check your Lambda response and make sure you are invoking JSON.stringify(YOUR_CONTENT) on your body object', {}, requestId);
+                    }
                     response.source = result.body;
                   }
                 }

--- a/src/ipcHelper.js
+++ b/src/ipcHelper.js
@@ -1,7 +1,15 @@
 'use strict';
 
 process.on('uncaughtException', e => {
-  process.send({ error: e });
+  process.send({
+    // process.send() can't serialize an Error object, so we help it out a bit
+    error: {
+      ipcException: true,
+      message: e.message,
+      constructor: { name: e.constructor.name },
+      stack: e.stack,
+    },
+  });
 });
 
 const handler = require(process.argv[2]);

--- a/test/integration/offline.js
+++ b/test/integration/offline.js
@@ -310,7 +310,7 @@ describe('Offline', () => {
           http: {
             path: 'fn2',
             method: 'POST',
-            payload: { data: 'data' }
+            payload: { data: 'data' },
           },
         }],
       }, (event, context, cb) => {
@@ -454,8 +454,8 @@ describe('Offline', () => {
           stage: 'dev',
           region: 'us-east-1',
           runtime: 'nodejs8.10',
-        }
-      }
+        },
+      },
     };
 
     it('should support handler returning Promise', done => {

--- a/test/unit/createLambdaProxyContextTest.js
+++ b/test/unit/createLambdaProxyContextTest.js
@@ -390,6 +390,6 @@ describe('createLambdaProxyContext', () => {
     it('should have the expected headers', () => {
       expect(Object.keys(lambdaProxyContext.headers).length).to.eq(1);
       expect(lambdaProxyContext.headers['cognito-identity-id']).to.eq(testId);
-    })
-  })
+    });
+  });
 });


### PR DESCRIPTION
There is an issue when using the `--useSeparateProcesses` flag in error reporting. When using the `--useSeparateProcesses` flag, the lambda function handler is loaded in a separate process, and serverless-offline communicates with this child process over IPC. When an `unhandledException` error occurs in the handler code, the Error object wasn't being properly serialized. Then, due to the asynchronous loading of the handler code (require() in the ipcHelper), fatal errors were not being reported correctly to the request-client in the same way that they are for non-separate-processes [handler loading](https://github.com/dherault/serverless-offline/blob/master/src/index.js#L540).

This PR implements the simplest fix to address these issues. It unfortunately does not include a test because there is currently no mechanism in the `OfflineBuilder` helper for testing the ipcHandler code, and adding support would require lots of code change.

An alternative solution would have been to make handler loading in [`index.js:540`](https://github.com/dherault/serverless-offline/blob/master/src/index.js#L540) asynchronous. But, this would require lots more code change.

## Example

Given a handler along the lines of this:

```js

lolFoobarThisWillBreakThings

export default function(event, context, callback) {
  callback(null, 'okie dokie')
}
```

### Before
```sh
curl http://localhost:3000/ -v

> GET / HTTP/1.1
> Host: localhost:3000
> User-Agent: curl/7.54.0
> Accept: */*
>
< HTTP/1.1 200 OK
< content-type: application/json; charset=utf-8
< cache-control: no-cache
< content-length: 0
< Date: Fri, 27 Jul 2018 13:48:02 GMT
< Connection: keep-alive
```
 
```sh
SLS_DEBUG=* ./node_modules/.bin/serverless offline start --useSeparateProcesses

...

[offline] External handler received message {"error":{}}
[offline] External handler receieved fatal error {}
[offline] _____ HANDLER RESOLVED _____
Serverless: Failure: [object Object]
[offline] Using response 'default'
```

### After

```sh
curl http://localhost:3000/ -v
> GET / HTTP/1.1
> Host: localhost:3000
> User-Agent: curl/7.54.0
> Accept: */*
>
< HTTP/1.1 200 OK
< content-type: application/json; charset=utf-8
< cache-control: no-cache
< content-length: 926
< accept-ranges: bytes
< Date: Fri, 27 Jul 2018 12:50:37 GMT
< Connection: keep-alive
<
{"errorMessage":"Error while loading [handler name]","errorType":"ReferenceError","stackTrace":["ReferenceError: lolFoobarThisWillBreakThings is not defined","at eval (webpack-internal:///./src/handlers/api.ts:20:1)","at Module../src/handlers/api.ts (/Users/marco/src/allthings/rope/dist/src/handlers/api.js:11483:1)","at __webpack_require__ (/Users/marco/src/allthings/rope/dist/src/handlers/api.js:20:30)","at /Users/marco/src/allthings/rope/dist/src/handlers/api.js:84:18","at Object.<anonymous> (/Users/marco/src/allthings/rope/dist/src/handlers/api.js:87:10)","at Module._compile (internal/modules/cjs/loader.js:678:30)","at Object.Module._extensions..js(internal/modules/cjs/loader.js:689:10)","at Module.load (internal/modules/cjs/loader.js:589:32)","at tryModuleLoad (internal/modules/cjs/loader.js:528:12)"],"offlineInfo":"If you believe this is an issue with the plugin please submit it, thanks. https://github.com/dherault/serverless-offline/issues"}
```

```log
SLS_DEBUG=* ./node_modules/.bin/serverless offline start --useSeparateProcesses

...

[offline] _____ HANDLER RESOLVED _____
Serverless: Error while loading [handler name]
[ 'ReferenceError: lolFoobarThisWillBreakThings is not defined',
  'at eval (webpack-internal:///./src/handlers/api.ts:20:1)',
  'at Module../src/handlers/api.ts (/Users/marco/src/allthings/rope/dist/src/handlers/api.js:11483:1)',
  'at __webpack_require__ (/Users/marco/src/allthings/rope/dist/src/handlers/api.js:20:30)',
  'at /Users/marco/src/allthings/rope/dist/src/handlers/api.js:84:18',
  'at Object.<anonymous> (/Users/marco/src/allthings/rope/dist/src/handlers/api.js:87:10)',
  'at Module._compile (internal/modules/cjs/loader.js:678:30)',
  'at Object.Module._extensions..js (internal/modules/cjs/loader.js:689:10)',
  'at Module.load (internal/modules/cjs/loader.js:589:32)',
  'at tryModuleLoad (internal/modules/cjs/loader.js:528:12)' ]
Serverless: Replying error in handler
```