### PR TITLE
fix: prioritize handler environment variable values over the originals

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "Austen (https://github.com/ac360)",
     "Ayush Gupta (https://github.com/AyushG3112)",
     "Ben Cooling (https://github.com/bencooling)",
+    "Brandon Evans (https://github.com/BrandonE)",
     "Cameron Cooper (https://github.com/cameroncooper)",
     "Chris Trevino (https://github.com/darthtrevino)",
     "Christoph Gysin (https://github.com/christophgysin)",

--- a/src/index.js
+++ b/src/index.js
@@ -520,6 +520,7 @@ class Offline {
             /* HANDLER LAZY LOADING */
 
             let handler; // The lambda function
+            Object.assign(process.env, this.originalEnvironment);
 
             try {
               if (this.options.noEnvironment) {
@@ -535,7 +536,6 @@ class Offline {
               else {
                 Object.assign(process.env, this.service.provider.environment, this.service.functions[key].environment);
               }
-              Object.assign(process.env, this.originalEnvironment);
               process.env._HANDLER = fun.handler;
               handler = functionHelper.createHandler(funOptions, this.options);
             }


### PR DESCRIPTION
Let's say I want to define two functions that both use the same environment variable with different values. One is triggered by HTTP and the other is triggered by a schedule using the [serverless-offline-scheduler](https://github.com/ajmath/serverless-offline-scheduler) plugin:

```
plugins:
    - serverless-offline-scheduler
    - serverless-offline

functions:
    httpFunc:
    	handler: httpFunc.func
    	environment:
    		ENV_VAR: val1
    	events:
    		- http:
    			path: http-func
    			method: get

    scheduledFunc:
    	handler: scheduledFunc.func
    	environment:
    		ENV_VAR: val2
    	events:
    		- schedule:
    			rate: rate(10 minutes)
```

As seen on [this line](https://github.com/ajmath/serverless-offline-scheduler/blob/master/lib/scheduler.js#L86), the `serverless-offline-scheduler` plugin sets `process.env` to the environment variables provided to the scheduled functions on initialization. However, when the HTTP function is executed, the environment variable values that were defined when `serverless-offline` was initialized [are prioritized](https://github.com/dherault/serverless-offline/blob/master/src/index.js#L538). Thus, because `serverless-offline-scheduler` is initialized first, the HTTP function handler will see that `ENV_VAR` is defined as `val2` instead of `val1`.

This small pull request reorders the `Object.assign` calls such that the `originalEnvironment` values are overwritten by those that the HTTP-triggered function's configuration specifies.