### PR TITLE
Fixed the splitting of handler path and handler name when multiple de…

### DIFF
--- a/src/functionHelper.js
+++ b/src/functionHelper.js
@@ -13,13 +13,15 @@ module.exports = {
   getFunctionOptions(fun, funName, servicePath) {
 
     // Split handler into method name and path i.e. handler.run
-    const handlerPath = fun.handler.split('.')[0];
-    const handlerName = fun.handler.split('/').pop().split('.')[1];
+    // Support nested paths i.e. ./src/somefolder/.handlers/handler.run
+    const lastIndexOfDelimiter = fun.handler.lastIndexOf('.');
+    const handlerPath = fun.handler.substr(0, lastIndexOfDelimiter);
+    const handlerName = fun.handler.substr(lastIndexOfDelimiter + 1);
 
     return {
       funName,
       handlerName, // i.e. run
-      handlerPath: `${servicePath}/${handlerPath}`,
+      handlerPath: path.join(servicePath, handlerPath),
       funTimeout: (fun.timeout || 30) * 1000,
       babelOptions: ((fun.custom || {}).runtime || {}).babel,
     };

--- a/test/unit/functionHelperTest.js
+++ b/test/unit/functionHelperTest.js
@@ -43,6 +43,15 @@ describe('functionHelper', () => {
       expect(result.babelOptions).to.be.undefined();
     });
 
+    it('nested folders for handlers', () => {
+      const fun = {
+        handler: './somefolder/.handlers/handler.run',
+      };
+      const result = functionHelper.getFunctionOptions(fun, funName, servicePath);
+      expect(result.handlerName).to.eq('run');
+      expect(result.handlerPath).to.eq('src/somefolder/.handlers/handler');
+    });
+
     context('with a timeout', () => {
       before(() => {
         const fun = {


### PR DESCRIPTION
Fixed the splitting of handler path and handler name when multiple delimiters (dot) are present in path:

I had an issue with the plugin when using subpaths: ./src/.....

