### PR TITLE
Added option to set "authorizer"-property using process.env.AUTHORIZER

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ This plugin is updated by its users, I just do maintenance and ensure that PRs a
 * [Usage with Babel](#usage-with-babel)
 * [Token authorizers](#token-authorizers)
 * [Custom authorizers](#custom-authorizers)
+* [Remote authorizers](#remote-authorizers)
 * [AWS API Gateway features](#aws-api-gateway-features)
 * [Velocity nuances](#velocity-nuances)
 * [Debug process](#debug-process)
@@ -196,6 +197,13 @@ The plugin only supports retrieving Tokens from headers. You can configure the h
   "authorizerResultTtlInSeconds": "0"
 }
 ```
+## Remote authorizers
+You are able to mock the response from remote authorizers by setting the environmental variable `AUTHORIZER` before running `sls offline start`
+
+Example:
+> Unix: `export AUTHORIZER='{"principalId": "123"}'`
+
+> Windows: `SET AUTHORIZER='{"principalId": "123"}'`
 
 ## AWS API Gateway Features
 

--- a/src/createLambdaProxyContext.js
+++ b/src/createLambdaProxyContext.js
@@ -10,6 +10,7 @@ const jwt = require('jsonwebtoken');
 module.exports = function createLambdaProxyContext(request, options, stageVariables) {
   const authPrincipalId = request.auth && request.auth.credentials && request.auth.credentials.user;
   const authContext = (request.auth && request.auth.credentials && request.auth.credentials.context) || {};
+  const authAuthorizer = process.env.AUTHORIZER ? JSON.parse(process.env.AUTHORIZER) : undefined;
 
   let body = request.payload;
 
@@ -73,7 +74,7 @@ module.exports = function createLambdaProxyContext(request, options, stageVariab
         userAgent: request.headers['user-agent'] || '',
         user: 'offlineContext_user',
       },
-      authorizer: Object.assign(authContext, { // 'principalId' should have higher priority
+      authorizer: authAuthorizer || Object.assign(authContext, { // 'principalId' should have higher priority
         principalId: authPrincipalId || process.env.PRINCIPAL_ID || 'offlineContext_authorizer_principalId', // See #24
         claims,
       }),


### PR DESCRIPTION
This pull request was made to make life simpler for people using remote authorizers (lambda-arn).