### PR TITLE
Gracefully shut down hapi server on SIGTERM

### DIFF
--- a/manual_test/README.md
+++ b/manual_test/README.md
@@ -6,3 +6,9 @@ In the plugin directory:
 `npm link`
 `cd manual_test`
 `npm link serverless-offline`
+
+## Testing signals
+
+`node subprocess.js`
+
+It should stop after 10 seconds with the proper halting message

--- a/manual_test/subprocess.js
+++ b/manual_test/subprocess.js
@@ -1,0 +1,12 @@
+const { exec } = require('child_process');
+
+console.log('Spawning offline as a separate process...');
+
+const subprocess = exec('npm run start');
+
+subprocess.stdout.pipe(process.stdout);
+
+setTimeout(() => {
+  console.log('Stopping main process and sending SIGTERM to subprocess...');
+  subprocess.kill();
+}, 10000);


### PR DESCRIPTION
Hey-oh! 👋 

Big thanks to the whole team of this project for doing such an awesome work!

I recently stumbled upon the issue where the hapi server that is used by `serverless-offline` would just go rogue and continue running even when the `sls offline` should be shut down correctly with `SIGTERM`. 

I tracked it to `serverless-offline` not handling `SIGTERM` as another signal for calling `this.end` and as the fix was pretty obvious I decided to open PR right away, instead of creating an issue first

ℹ️ This is just a suggested solution and I'm happy to adjust it if you feel that some changes are needed. If you want me to just open an issue instead of creating the PR, this is also fine by me 😊 
