### PR TITLE
Fix async handler support for handlers running in separate processes

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "Andrei Popovici (https://github.com/andreipopovici)",
     "Anthony Liatsis (https://github.com/aliatsis)",
     "Austen (https://github.com/ac360)",
+    "Austin Payne (https://github.com/austin-payne)",
     "Ayush Gupta (https://github.com/AyushG3112)",
     "Ben Cooling (https://github.com/bencooling)",
     "Brandon Evans (https://github.com/BrandonE)",

--- a/src/ipcHelper.js
+++ b/src/ipcHelper.js
@@ -25,5 +25,7 @@ process.on('message', opts => {
     fail:    err => done(err, null),
     // TODO implement getRemainingTimeInMillis
   });
-  handler[opts.name](opts.event, context, done);
+  const x = handler[opts.name](opts.event, context, done);
+  if (x && typeof x.then === 'function' && typeof x.catch === 'function') x.then(context.succeed).catch(context.fail);
+  else if (x instanceof Error) context.fail(x);
 });


### PR DESCRIPTION
Support for async handlers in nodejs8.10 runtime was added [here](https://github.com/dherault/serverless-offline/pull/398) and works by checking if the handler returned a promise and if so, hooking it up to the "done" callback. However it doesn't work if `useSeparateProcesses` option is true. In that case the handler is created in a child process with ipcHelper.js which calls the handler itself and has to link the callback up across the IPC channel. In order for async handlers to be supported in the child process, ipcHelper also needs the logic to hook up the promise returned by the handler to the callback.