### PR TITLE
Set response headers defined in serverless config 

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "Brandon Evans (https://github.com/BrandonE)",
     "Cameron Cooper (https://github.com/cameroncooper)",
     "Chris Trevino (https://github.com/darthtrevino)",
+    "Chris Watson (https://github.com/c24w)",
     "Christoph Gysin (https://github.com/christophgysin)",
     "Daniel Parker (https://github.com/rlgod)",
     "Dave Sole (https://github.com/dsole)",

--- a/src/Endpoint.js
+++ b/src/Endpoint.js
@@ -103,8 +103,7 @@ class Endpoint {
      */
   generate() {
 
-    let fullEndpoint = {};
-    _.merge(fullEndpoint, endpointStruct, this.httpData);
+    let fullEndpoint = _.merge({}, endpointStruct, this.httpData);
 
     if (this.httpData.integration && this.httpData.integration === 'lambda') {
       // determine request and response templates or use defaults

--- a/src/index.js
+++ b/src/index.js
@@ -24,6 +24,8 @@ const Endpoint = require('./Endpoint');
 const parseResources = require('./parseResources');
 const utils = require('./utils');
 
+const isNestedString = RegExp.prototype.test.bind(/^'.*?'$/);
+
 /*
  I'm against monolithic code like this file, but splitting it induces unneeded complexity.
  */
@@ -552,8 +554,8 @@ class Offline {
               else {
                 Object.assign(
                   process.env,
-                  { AWS_REGION: this.service.provider.region }, 
-                  this.service.provider.environment, 
+                  { AWS_REGION: this.service.provider.region },
+                  this.service.provider.environment,
                   this.service.functions[key].environment
                 );
               }
@@ -738,6 +740,12 @@ class Offline {
               let statusCode = 200;
 
               if (integration === 'lambda') {
+
+                _(endpoint.response.headers)
+                  .pickBy(isNestedString)
+                  .mapValues(v => _.trim(v, '\''))
+                  .forEach((v, k) => response.header(k, v));
+
                 /* RESPONSE TEMPLATE PROCCESSING */
                 // If there is a responseTemplate, we apply it to the result
                 const responseTemplates = chosenResponse.responseTemplates;

--- a/src/offline-endpoint.json
+++ b/src/offline-endpoint.json
@@ -1,7 +1,7 @@
 {
   "responses": {
     "default": {
-      "statusCode": "200",
+      "statusCode": 200,
       "responseModels": {
         "application/json;charset=UTF-8": "Empty"
       },

--- a/test/integration/offline.js
+++ b/test/integration/offline.js
@@ -116,7 +116,7 @@ describe('Offline', () => {
 
       offline.inject('/index', res => {
         expect(res.headers['content-type']).to.contains('text/html');
-        expect(res.statusCode).to.satisfy(status => status === 200 || status === '200');
+        expect(res.statusCode).to.eq(200);
         done();
       });
     });


### PR DESCRIPTION
Only supports static string values for successful responses.

AWS requires double-quoted strings as header values to avoid "Invalid mapping expression specified" errors when trying to interpret them as an integration response variables (e.g. integration.response.header.Content-Type).

<sub>Fixes #493</sub>