### PR TITLE
add `cacheInvalidationIgnore` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ All CLI options are optional:
 --dontPrintOutput           Turns off logging of your lambda outputs in the terminal.
 --httpsProtocol         -H  To enable HTTPS, specify directory (relative to your cwd, typically your project dir) for both cert.pem and key.pem files.
 --skipCacheInvalidation -c  Tells the plugin to skip require cache invalidation. A script reloading tool like Nodemon might then be needed.
---cacheInvalidationIgnore   Provide the plugin with a regexp to use for ignoring cache invalidation. Default: 'node_modules'
+--cacheInvalidationRegex    Provide the plugin with a regexp to use for ignoring cache invalidation. Default: 'node_modules'
 --useSeparateProcesses      Run handlers in separate Node processes
 --corsAllowOrigin           Used as default Access-Control-Allow-Origin header value for responses. Delimit multiple values with commas. Default: '*'
 --corsAllowHeaders          Used as default Access-Control-Allow-Headers header value for responses. Delimit multiple values with commas. Default: 'accept,content-type,x-api-key'

--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ All CLI options are optional:
 --dontPrintOutput           Turns off logging of your lambda outputs in the terminal.
 --httpsProtocol         -H  To enable HTTPS, specify directory (relative to your cwd, typically your project dir) for both cert.pem and key.pem files.
 --skipCacheInvalidation -c  Tells the plugin to skip require cache invalidation. A script reloading tool like Nodemon might then be needed.
+--cacheInvalidationIgnore   Provide the plugin with a regexp to use for ignoring cache invalidation. Default: /node_modules/
 --useSeparateProcesses      Run handlers in separate Node processes
 --corsAllowOrigin           Used as default Access-Control-Allow-Origin header value for responses. Delimit multiple values with commas. Default: '*'
 --corsAllowHeaders          Used as default Access-Control-Allow-Headers header value for responses. Delimit multiple values with commas. Default: 'accept,content-type,x-api-key'

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ All CLI options are optional:
 --dontPrintOutput           Turns off logging of your lambda outputs in the terminal.
 --httpsProtocol         -H  To enable HTTPS, specify directory (relative to your cwd, typically your project dir) for both cert.pem and key.pem files.
 --skipCacheInvalidation -c  Tells the plugin to skip require cache invalidation. A script reloading tool like Nodemon might then be needed.
---cacheInvalidationIgnore   Provide the plugin with a regexp to use for ignoring cache invalidation. Default: /node_modules/
+--cacheInvalidationIgnore   Provide the plugin with a regexp to use for ignoring cache invalidation. Default: 'node_modules'
 --useSeparateProcesses      Run handlers in separate Node processes
 --corsAllowOrigin           Used as default Access-Control-Allow-Origin header value for responses. Delimit multiple values with commas. Default: '*'
 --corsAllowHeaders          Used as default Access-Control-Allow-Headers header value for responses. Delimit multiple values with commas. Default: 'accept,content-type,x-api-key'

--- a/src/functionHelper.js
+++ b/src/functionHelper.js
@@ -96,7 +96,7 @@ module.exports = {
       for (const key in require.cache) {
         // Require cache invalidation, brutal and fragile.
         // Might cause errors, if so please submit an issue.
-        if (!key.match(options.cacheInvalidationIgnore || /node_modules/)) delete require.cache[key];
+        if (!key.match(options.cacheInvalidationRegex || /node_modules/)) delete require.cache[key];
       }
     }
 

--- a/src/functionHelper.js
+++ b/src/functionHelper.js
@@ -96,7 +96,7 @@ module.exports = {
       for (const key in require.cache) {
         // Require cache invalidation, brutal and fragile.
         // Might cause errors, if so please submit an issue.
-        if (!key.match('node_modules')) delete require.cache[key];
+        if (!key.match(options.cacheInvalidationIgnore || /node_modules/)) delete require.cache[key];
       }
     }
 

--- a/src/index.js
+++ b/src/index.js
@@ -79,6 +79,9 @@ class Offline {
             usage: 'Tells the plugin to skip require cache invalidation. A script reloading tool like Nodemon might then be needed',
             shortcut: 'c',
           },
+          cacheInvalidationIgnore: {
+            usage: 'Provide the plugin with a regexp to use for cache invalidation. Default: /node_modules/'
+          },
           httpsProtocol: {
             usage: 'To enable HTTPS, specify directory (relative to your cwd, typically your project dir) for both cert.pem and key.pem files.',
             shortcut: 'H',
@@ -243,6 +246,7 @@ class Offline {
       dontPrintOutput: false,
       httpsProtocol: '',
       skipCacheInvalidation: false,
+      cacheInvalidationIgnore: 'node_modules',
       noAuth: false,
       corsAllowOrigin: '*',
       corsExposedHeaders: 'WWW-Authenticate,Server-Authorization',
@@ -279,6 +283,8 @@ class Offline {
       credentials: this.options.corsAllowCredentials,
       exposedHeaders: this.options.corsExposedHeaders,
     };
+
+    this.options.cacheInvalidationIgnore = new RegExp(this.options.cacheInvalidationIgnore)
 
     this.serverlessLog(`Starting Offline: ${this.options.stage}/${this.options.region}.`);
     debugLog('options:', this.options);

--- a/src/index.js
+++ b/src/index.js
@@ -79,7 +79,7 @@ class Offline {
             usage: 'Tells the plugin to skip require cache invalidation. A script reloading tool like Nodemon might then be needed',
             shortcut: 'c',
           },
-          cacheInvalidationIgnore: {
+          cacheInvalidationRegex: {
             usage: 'Provide the plugin with a regexp to use for cache invalidation. Default: node_modules'
           },
           httpsProtocol: {
@@ -246,7 +246,7 @@ class Offline {
       dontPrintOutput: false,
       httpsProtocol: '',
       skipCacheInvalidation: false,
-      cacheInvalidationIgnore: 'node_modules',
+      cacheInvalidationRegex: 'node_modules',
       noAuth: false,
       corsAllowOrigin: '*',
       corsExposedHeaders: 'WWW-Authenticate,Server-Authorization',
@@ -284,7 +284,7 @@ class Offline {
       exposedHeaders: this.options.corsExposedHeaders,
     };
 
-    this.options.cacheInvalidationIgnore = new RegExp(this.options.cacheInvalidationIgnore)
+    this.options.cacheInvalidationRegex = new RegExp(this.options.cacheInvalidationRegex)
 
     this.serverlessLog(`Starting Offline: ${this.options.stage}/${this.options.region}.`);
     debugLog('options:', this.options);

--- a/src/index.js
+++ b/src/index.js
@@ -80,7 +80,7 @@ class Offline {
             shortcut: 'c',
           },
           cacheInvalidationIgnore: {
-            usage: 'Provide the plugin with a regexp to use for cache invalidation. Default: /node_modules/'
+            usage: 'Provide the plugin with a regexp to use for cache invalidation. Default: node_modules'
           },
           httpsProtocol: {
             usage: 'To enable HTTPS, specify directory (relative to your cwd, typically your project dir) for both cert.pem and key.pem files.',


### PR DESCRIPTION
allow for a customized cache invalidation mask. this is especially useful when testing external libs that are npm link'd as `cacheInvalidationIgnore: /node_modules/(?!my-lib/)`