### PR TITLE
Fix noAuth option not working

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -482,7 +482,7 @@ class Offline {
 
             // this.serverlessLog(protectedRoutes);
             // Check for APIKey
-            if (_.includes(protectedRoutes, `${routeMethod}#${fullPath}`) || _.includes(protectedRoutes, `ANY#${fullPath}`)) {
+            if ((_.includes(protectedRoutes, `${routeMethod}#${fullPath}`) || _.includes(protectedRoutes, `ANY#${fullPath}`)) && !this.options.noAuth) {
               const errorResponse = response => response({ message: 'Forbidden' }).code(403).type('application/json').header('x-amzn-ErrorType', 'ForbiddenException');
               if ('x-api-key' in request.headers) {
                 const requestToken = request.headers['x-api-key'];

--- a/test/integration/offline.js
+++ b/test/integration/offline.js
@@ -135,6 +135,7 @@ describe('Offline', () => {
       offline.inject({
         method: 'GET',
         url: '/fn3',
+        headers: { 'x-api-key': validToken },
       }, res => {
         expect(res.statusCode).to.eq(200);
         done();

--- a/test/integration/offline.js
+++ b/test/integration/offline.js
@@ -95,6 +95,53 @@ describe('Offline', () => {
 
   });
 
+  context('with private function and noAuth option set', () => {
+    let offline;
+    const validToken = 'valid-token'
+
+    before(done => {
+      offline = new OfflineBuilder(new ServerlessBuilder(), { apiKey: validToken, noAuth: true }).addFunctionConfig('fn2', {
+        handler: 'handler.basicAuthentication',
+        events: [{
+          http: {
+            path: 'fn3',
+            method: 'GET',
+            private: true,
+          },
+        }],
+      }, (event, context, cb) => {
+        const response = {
+          statusCode: 200,
+          body: JSON.stringify({
+            message: 'Private Function Executed Correctly',
+          }),
+        };
+        cb(null, response);
+      }).addApiKeys(['token']).toObject();
+      done();
+    });
+
+    it('should execute the function correctly if no API key is provided', done => {
+      offline.inject({
+        method: 'GET',
+        url: '/fn3',
+      }, res => {
+        expect(res.statusCode).to.eq(200);
+        done();
+      });
+    });
+
+    it('should execute the function correctly if API key is provided', done => {
+      offline.inject({
+        method: 'GET',
+        url: '/fn3',
+      }, res => {
+        expect(res.statusCode).to.eq(200);
+        done();
+      });
+    });
+  });
+
   context('lambda integration', () => {
     it('should use event defined response template and headers', done => {
       const offline = new OfflineBuilder().addFunctionConfig('index', {


### PR DESCRIPTION
This should fix #503. I'm still not sure if I understood how this should work correctly, but it seems to do what I wanted it to do. Any guidance in case I missed something would be welcome.

I still don't understand why `authStrategyName` passed to `routeConfig` needs to be set to `null` in case `noAuth` is set. It doesn't seem to do anything, but I'm afraid to remove it because I'm not sure if all use cases are covered by tests.