### PR TITLE
added support for multiValueQueryStringParameters

### DIFF
--- a/package.json
+++ b/package.json
@@ -77,6 +77,7 @@
     "Martin Micunda (https://github.com/martinmicunda)",
     "Matt Hodgson (https://github.com/mhodgson)",
     "Matt Jonker (https://github.com/msjonker)",
+    "Melvin Vermeer (https://github.com/melvinvermeer)",
     "Michael MacDonald (https://github.com/mjmac)",
     "Miso (Mike) Zmiric (https://github.com/mzmiric5)",
     "Niall Riordan (https://github.com/njriordan)",

--- a/src/createLambdaProxyContext.js
+++ b/src/createLambdaProxyContext.js
@@ -97,6 +97,7 @@ module.exports = function createLambdaProxyContext(request, options, stageVariab
     resource: request.route.path,
     httpMethod: request.method.toUpperCase(),
     queryStringParameters: utils.nullIfEmpty(utils.normalizeQuery(request.query)),
+    multiValueQueryStringParameters: utils.nullIfEmpty(utils.normalizeMultiValueQuery(request.query)),
     stageVariables: utils.nullIfEmpty(stageVariables),
     body,
   };

--- a/src/utils.js
+++ b/src/utils.js
@@ -13,6 +13,13 @@ module.exports = {
 
       return q;
     }, {}),
+  normalizeMultiValueQuery: query => 
+    // foreach key, ensure that the value is an array
+    Object.keys(query).reduce((q, param) => {
+      q[param] = [].concat(query[param]);
+      
+      return q;
+    }, {}),
   capitalizeKeys: o => {
     const capitalized = {};
     for (let key in o) { // eslint-disable-line prefer-const

--- a/test/unit/createLambdaProxyContextTest.js
+++ b/test/unit/createLambdaProxyContextTest.js
@@ -332,6 +332,11 @@ describe('createLambdaProxyContext', () => {
       expect(Object.keys(lambdaProxyContext.queryStringParameters).length).to.eq(1);
       expect(lambdaProxyContext.queryStringParameters.param).to.eq('1');
     });
+
+    it('should have a multi value query parameter', () => {
+      expect(Array.isArray(lambdaProxyContext.multiValueQueryStringParameters.param)).to.eq(true);
+      expect(lambdaProxyContext.multiValueQueryStringParameters.param[0]).to.eq('1');
+    });
   });
 
   context('with a GET /fn1?param=1&param2=1 request with double parameters in query string', () => {
@@ -369,6 +374,25 @@ describe('createLambdaProxyContext', () => {
     it('should have a two query parameters', () => {
       expect(Object.keys(lambdaProxyContext.queryStringParameters).length).to.eq(1);
       expect(lambdaProxyContext.queryStringParameters.param).to.eq('2');
+    });
+  });
+
+  context('with a GET /fn1?param=1&param=2 request with multiValueQueryStringParameters', () => {
+    const requestBuilder = new RequestBuilder('GET', '/fn1?param=1&param=2');
+    // emaulate HAPI `query` as described here:
+    // https://futurestud.io/tutorials/hapi-how-to-use-query-parameters#multiplequeryparametersofthesamename
+    requestBuilder.addQuery('param', ['1', '2']);
+    const request = requestBuilder.toObject();
+
+    let lambdaProxyContext;
+
+    before(() => {
+      lambdaProxyContext = createLambdaProxyContext(request, options, stageVariables);
+    });
+
+    it('multi value param should have a two values', () => {
+      expect(Object.keys(lambdaProxyContext.multiValueQueryStringParameters).length).to.eq(1);
+      expect(lambdaProxyContext.multiValueQueryStringParameters.param.length).to.eq(2);
     });
   });
 


### PR DESCRIPTION
Possible solution for [Issue 469 - query params inconsistencies with api gateway for duplicate keys](https://github.com/dherault/serverless-offline/issues/469).

Aligns with AWS' implementation of `multiValueQueryStringParameters` as described over [here](https://docs.aws.amazon.com/apigateway/latest/developerguide/set-up-lambda-proxy-integrations.html#api-gateway-simple-proxy-for-lambda-output-format).