### PR TITLE
Add cognito-authentication-provider as header

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ This plugin is updated by its users, I just do maintenance and ensure that PRs a
 * [Token authorizers](#token-authorizers)
 * [Custom authorizers](#custom-authorizers)
 * [Remote authorizers](#remote-authorizers)
+* [Custom headers](#custom-headers)
 * [AWS API Gateway features](#aws-api-gateway-features)
 * [Velocity nuances](#velocity-nuances)
 * [Debug process](#debug-process)
@@ -191,6 +192,16 @@ Example:
 > Unix: `export AUTHORIZER='{"principalId": "123"}'`
 
 > Windows: `SET AUTHORIZER='{"principalId": "123"}'`
+
+## Custom headers
+You are able to use some custom headers in your request to gain more control over the requestContext object.
+
+| Header | Event key |
+|--------|-----------|
+| cognito-identity-id | event.requestContext.identity.cognitoIdentityId |
+| cognito-authentication-provider | event.requestContext.identity.cognitoAuthenticationProvider |
+
+By doing this you are now able to change those values using a custom header. This can help you with easier authentication or retrieving the userId from a `cognitoAuthenticationProvider` value.
 
 ## AWS API Gateway Features
 

--- a/package.json
+++ b/package.json
@@ -102,7 +102,8 @@
     "Vasiliy Solovey (https://github.com/miltador)",
     "Daniel Cottone <daniel.cottone@gmail.com> (https://github.com/daniel-cottone)",
     "Jaryd Carolin (https://github.com/horyd)",
-    "Manuel Böhm (https://github.com/boehmers)"
+    "Manuel Böhm (https://github.com/boehmers)",
+    "Bob Thomas (https://github.com/bob-thomas)"
   ],
   "license": "MIT",
   "bugs": {

--- a/src/createLambdaProxyContext.js
+++ b/src/createLambdaProxyContext.js
@@ -81,7 +81,7 @@ module.exports = function createLambdaProxyContext(request, options, stageVariab
         apiKey: 'offlineContext_apiKey',
         sourceIp: request.info.remoteAddress,
         cognitoAuthenticationType: 'offlineContext_cognitoAuthenticationType',
-        cognitoAuthenticationProvider: 'offlineContext_cognitoAuthenticationProvider',
+        cognitoAuthenticationProvider: request.headers['cognito-authentication-provider'] || 'offlineContext_cognitoAuthenticationProvider',
         userArn: 'offlineContext_userArn',
         userAgent: request.headers['user-agent'] || '',
         user: 'offlineContext_user',

--- a/test/unit/createLambdaProxyContextTest.js
+++ b/test/unit/createLambdaProxyContextTest.js
@@ -416,4 +416,25 @@ describe('createLambdaProxyContext', () => {
       expect(lambdaProxyContext.headers['cognito-identity-id']).to.eq(testId);
     });
   });
+
+  context('with a request that includes cognito-authentication-provider header', () => {
+    const requestBuilder = new RequestBuilder('GET', '/fn1');
+    const testId = 'lorem:ipsum:test-id';
+    requestBuilder.addHeader('cognito-authentication-provider', testId);
+    const request = requestBuilder.toObject();
+    let lambdaProxyContext;
+
+    before(() => {
+      lambdaProxyContext = createLambdaProxyContext(request, options, stageVariables);
+    });
+
+    it('should have the expected cognitoAuthenticationProvider', () => {
+      expect(lambdaProxyContext.requestContext.identity.cognitoAuthenticationProvider).to.eq(testId);
+    });
+
+    it('should have the expected headers', () => {
+      expect(Object.keys(lambdaProxyContext.headers).length).to.eq(1);
+      expect(lambdaProxyContext.headers['cognito-authentication-provider']).to.eq(testId);
+    });
+  });
 });


### PR DESCRIPTION
By merging this we allow a developer to be able to retrieve a userId from the congitoAuthenticationProvider and in my case it allows me to load in my userData from my local dynamodb.

