### PR TITLE
Feature: param to disable cookie validation in hapi.js

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,7 @@ All CLI options are optional:
 --exec "<script>"           When provided, a shell script is executed when the server starts up, and the server will shut down after handling this command.
 --noAuth                    Turns off all authorizers
 --preserveTrailingSlash     Used to keep trailing slashes on the request path
+--disableCookieValidation   Used to disable cookie-validation on hapi.js-server
 ```
 
 Any of the CLI options can be added to your `serverless.yml`. For example:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "serverless-offline",
-  "version": "3.25.17",
+  "version": "3.28.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -101,7 +101,8 @@
     "Utku Turunc (https://github.com/utkuturunc)",
     "Vasiliy Solovey (https://github.com/miltador)",
     "Daniel Cottone <daniel.cottone@gmail.com> (https://github.com/daniel-cottone)",
-    "Jaryd Carolin (https://github.com/horyd)"
+    "Jaryd Carolin (https://github.com/horyd)",
+    "Manuel Böhm (https://github.com/boehmers)"
   ],
   "license": "MIT",
   "bugs": {

--- a/src/index.js
+++ b/src/index.js
@@ -80,7 +80,7 @@ class Offline {
             shortcut: 'c',
           },
           cacheInvalidationRegex: {
-            usage: 'Provide the plugin with a regexp to use for cache invalidation. Default: node_modules'
+            usage: 'Provide the plugin with a regexp to use for cache invalidation. Default: node_modules',
           },
           httpsProtocol: {
             usage: 'To enable HTTPS, specify directory (relative to your cwd, typically your project dir) for both cert.pem and key.pem files.',
@@ -287,7 +287,7 @@ class Offline {
       exposedHeaders: this.options.corsExposedHeaders,
     };
 
-    this.options.cacheInvalidationRegex = new RegExp(this.options.cacheInvalidationRegex)
+    this.options.cacheInvalidationRegex = new RegExp(this.options.cacheInvalidationRegex);
 
     this.serverlessLog(`Starting Offline: ${this.options.stage}/${this.options.region}.`);
     debugLog('options:', this.options);

--- a/src/index.js
+++ b/src/index.js
@@ -130,6 +130,9 @@ class Offline {
           preserveTrailingSlash: {
             usage: 'Used to keep trailing slashes on the request path',
           },
+          disableCookieValidation: {
+            usage: 'Used to disable cookie-validation on hapi.js-server',
+          },
         },
       },
     };
@@ -420,10 +423,19 @@ class Offline {
 
         // Route creation
         const routeMethod = method === 'ANY' ? '*' : method;
+
+        const state = this.options.disableCookieValidation ? {
+          parse: false,
+          failAction: 'ignore',
+        } : {
+          parse: true,
+          failAction: 'error',
+        };
         const routeConfig = {
           cors,
           auth: authStrategyName,
           timeout: { socket: false },
+          state,
         };
 
         // skip HEAD routes as hapi will fail with 'Method name not allowed: HEAD ...'

--- a/test/integration/offline.js
+++ b/test/integration/offline.js
@@ -97,7 +97,7 @@ describe('Offline', () => {
 
   context('with private function and noAuth option set', () => {
     let offline;
-    const validToken = 'valid-token'
+    const validToken = 'valid-token';
 
     before(done => {
       offline = new OfflineBuilder(new ServerlessBuilder(), { apiKey: validToken, noAuth: true }).addFunctionConfig('fn2', {

--- a/test/integration/offline.js
+++ b/test/integration/offline.js
@@ -666,4 +666,43 @@ describe('Offline', () => {
     });
   });
 
+  context('disable cookie validation', () => {
+    it('should return bad reqeust by default if invalid cookies are passed by the request', done => {
+      const offline = new OfflineBuilder().addFunctionHTTP('test', {
+        path: 'fn1',
+        method: 'GET',
+      }, (event, context, cb) => cb(null, {})).toObject();
+
+      offline.inject({
+        method: 'GET',
+        url: '/fn1',
+        headers: {
+          Cookie: 'a.strange.cookie.with.newline.at.the.end=yummie123utuiwi-32432fe3-f3e2e32\n',
+        },
+      }, res => {
+        expect(res.statusCode).to.eq(400);
+        done();
+      });
+    });
+
+    it('should return 200 if the "disableCookieValidation"-flag is set', done => {
+      const offline = new OfflineBuilder(new ServerlessBuilder(), { disableCookieValidation: true })
+        .addFunctionHTTP('test', {
+          path: 'fn1',
+          method: 'GET',
+        }, (event, context, cb) => cb(null, {})).toObject();
+
+      offline.inject({
+        method: 'GET',
+        url: '/fn1',
+        headers: {
+          Cookie: 'a.strange.cookie.with.newline.at.the.end=yummie123utuiwi-32432fe3-f3e2e32\n',
+        },
+      }, res => {
+        expect(res.statusCode).to.eq(200);
+        done();
+      });
+    });
+  });
+
 });


### PR DESCRIPTION
Hi,

in our environment, we experienced the issue that we have some strange cookies on our site to send to a running serverless-offline instance via GET. The server then responds with bad request. This behaviour can be configured in the underlying hapi.js-instance. 

I added a param to trigger this, of course optional and tested. 

I also took the time and fixed 3 eslint-warnings.

Would appreciate to see this in a future version!

Thx in advance.