### PR TITLE
Change startup log message if noAuth is enabled

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -359,7 +359,13 @@ class Offline {
     // for simple API Key authentication model
     if (!_.isEmpty(apiKeys)) {
       this.serverlessLog(`Key with token: ${this.options.apiKey}`);
-      this.serverlessLog('Remember to use x-api-key on the request headers');
+
+      if (this.options.noAuth) {
+        this.serverlessLog('Authorizers are turned off. You do not need to use x-api-key header.');
+      }
+      else {
+        this.serverlessLog('Remember to use x-api-key on the request headers');
+      }
     }
 
     Object.keys(this.service.functions).forEach(key => {


### PR DESCRIPTION
It was confusing that starting `serverless offline` with `--noAuth` flag still said that I need to use `x-api-key` header. I wasn't sure if it'd make more sense to remove the message with key altogether or just add that authorizers are disabled. I'm open for suggestions / better wording.