### PR TITLE
Improved emulation of APIG's urlDecode velocity template function

### DIFF
--- a/src/createVelocityContext.js
+++ b/src/createVelocityContext.js
@@ -69,7 +69,7 @@ module.exports = function createVelocityContext(request, options, payload) {
     util: {
       escapeJavaScript,
       urlEncode: encodeURI,
-      urlDecode: decodeURI,
+      urlDecode: x => decodeURIComponent(x.replace(/\+/g, ' ')),
       base64Encode: x => new Buffer(x.toString(), 'binary').toString('base64'),
       base64Decode: x => new Buffer(x.toString(), 'base64').toString('binary'),
       parseJson: JSON.parse,

--- a/test/unit/velocityContextTest.js
+++ b/test/unit/velocityContextTest.js
@@ -18,7 +18,7 @@ describe('#urlDecode', () => {
       route: {},
     };
 
-    const { util } = createVelocityContext(fakeRequest, {}, {});
+    const velocity = createVelocityContext(fakeRequest, {}, {});
 
     const tests = [
       { '%3E%2C%2F%3F%3A%3B%27%22%5B%5D%5C%7B%7D%7C': '>,/?:;\'"[]\\{}|' },
@@ -31,7 +31,7 @@ describe('#urlDecode', () => {
 
     tests.forEach(test => {
       const key = Object.keys(test)[0];
-      expect(util.urlDecode(key)).to.equal(test[key]);
+      expect(velocity.util.urlDecode(key)).to.equal(test[key]);
     });
   });
 });

--- a/test/unit/velocityContextTest.js
+++ b/test/unit/velocityContextTest.js
@@ -1,0 +1,37 @@
+/* global describe it */
+
+'use strict';
+
+const chai = require('chai');
+
+const expect = chai.expect;
+
+const createVelocityContext = require('../../src/createVelocityContext');
+
+
+describe('#urlDecode', () => {
+  it('should decode url query parameters', () => {
+    const fakeRequest = {
+      method: 'post',
+      info: {},
+      headers: {},
+      route: {},
+    };
+
+    const { util } = createVelocityContext(fakeRequest, {}, {});
+
+    const tests = [
+      { '%3E%2C%2F%3F%3A%3B%27%22%5B%5D%5C%7B%7D%7C': '>,/?:;\'"[]\\{}|' },
+      { '%20%21%40%23%24%25%5E%26%2A%28%29%2B%3D%60%3C': ' !@#$%^&*()+=`<' },
+      { '%D0%80%D0%81%D0%82%D0%83%D0%84%D0%85%D0%86%D0%87%D0%88': 'ЀЁЂЃЄЅІЇЈ' },
+      { 'Rock%2b%26%2bRoll': 'Rock+&+Roll' },
+      { 'Rock%20%26%20Roll': 'Rock & Roll' },
+      { 'Rock+%26+Roll': 'Rock & Roll' },
+    ];
+
+    tests.forEach(test => {
+      const key = Object.keys(test)[0];
+      expect(util.urlDecode(key)).to.equal(test[key]);
+    });
+  });
+});


### PR DESCRIPTION
After experimenting with different implementations of decoding query strings, Node's `decodeURIComponent()` seemed to be the best fit. The only issue with it is the `+` sign, which should be converted into a space. We do that manually before calling `decodeURIComponent()`.

Added `velocityContextTest.js` to fine tune different implementations.

Fixes #521 