### PR TITLE
Add some requestContext to auth event and fix resouce with colon

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "serverless-offline",
-  "version": "3.28.1",
+  "version": "3.31.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/authMatchPolicyResource.js
+++ b/src/authMatchPolicyResource.js
@@ -5,15 +5,14 @@ module.exports = (policyResource, resource) => {
   else if (policyResource === '*') {
     return true;
   }
+  else if (policyResource === 'arn:aws:execute-api:**') {
+    //better fix for #523
+    return true;
+  }
   else if (policyResource.includes('*')) {
     //Policy contains a wildcard resource
     const splitPolicyResource = policyResource.split(':');
     const splitResource = resource.split(':');
-
-    // This line is complete BS and fixes #523
-    if (!splitPolicyResource[5] || !splitResource[5]) {
-      return true;
-    }
 
     //These variables contain api id, stage, method and the path
     //for the requested resource and the resource defined in the policy

--- a/src/createAuthScheme.js
+++ b/src/createAuthScheme.js
@@ -78,7 +78,23 @@ module.exports = function createAuthScheme(authFun, authorizerOptions, funName, 
           authorizationToken: authorization,
         };
       }
-      event.methodArn = `arn:aws:execute-api:${options.region}:random-account-id:random-api-id/${options.stage}/${request.method.toUpperCase()}${request.path.replace(new RegExp(`^/${options.stage}`), '')}`;
+
+      const httpMethod = request.method.toUpperCase();
+      const apiId = 'random-api-id';
+      const accountId = 'random-account-id';
+      const resourcePath = request.path.replace(new RegExp(`^/${options.stage}`), '');
+
+      event.methodArn = `arn:aws:execute-api:${options.region}:${accountId}:${apiId}/${options.stage}/${httpMethod}${resourcePath}`;
+
+      event.requestContext = {
+        accountId,
+        resourceId: 'random-resource-id',
+        stage: options.stage,
+        requestId: 'random-request-id',
+        resourcePath,
+        httpMethod,
+        apiId
+      };
 
       // Create the Authorization function handler
       try {

--- a/test/unit/authMatchPolicyResourceTest.js
+++ b/test/unit/authMatchPolicyResourceTest.js
@@ -45,6 +45,39 @@ describe('authMatchPolicyResource', () => {
           ).to.eq(false);
         });
       });
+      context('and the resource contains colons', () => {
+        it('returns true', () => {
+          const resource = 'arn:aws:execute-api:eu-west-1:random-account-id:random-api-id/development/GET/dinosaurs:extinct';
+          expect(
+            authMatchPolicyResource(wildcardResource, resource)
+          ).to.eq(true);
+        });
+      });
+
+      //test for #560
+      context('when the resource has wildcards and colons', () => {
+        const wildcardResource = 'arn:aws:execute-api:eu-west-1:random-account-id:random-api-id/development/GET/*/stats';
+        context('and it matches', () => {
+          it('returns true', () => {
+            const resource = 'arn:aws:execute-api:eu-west-1:random-account-id:random-api-id/development/GET/dinosaurs:extinct/stats';
+
+            expect(
+              authMatchPolicyResource(wildcardResource, resource)
+            ).to.eq(true);
+          });
+        });
+        context('and it does not match', () => {
+          it('returns false', () => {
+            const resource = 'arn:aws:execute-api:eu-west-1:random-account-id:random-api-id/development/GET/dinosaurs/all-stats';
+
+            expect(
+              authMatchPolicyResource(wildcardResource, resource)
+            ).to.eq(false);
+          });
+        });
+      });
+
+
       context('when the resource has multiple wildcards', () => {
         const wildcardResource = 'arn:aws:execute-api:eu-west-1:random-account-id:random-api-id/development/*/*/stats';
 


### PR DESCRIPTION
The event object for an authorizer request in the live environment has a requestContext object. I am using that to extract a few variables and therefore need them in the serverless-offline plugin as well. 

Added the ones that are easy to gather/have already been included in the event.methodArn string.

https://docs.aws.amazon.com/apigateway/latest/developerguide/set-up-lambda-proxy-integrations.html#api-gateway-simple-proxy-for-lambda-input-format has details on the requestContext format.