### PR TITLE
Prevent uncaught error with invalid token

### DIFF
--- a/src/createLambdaProxyContext.js
+++ b/src/createLambdaProxyContext.js
@@ -62,7 +62,8 @@ module.exports = function createLambdaProxyContext(request, options, stageVariab
   if (token) {
     try {
       claims = jwt.decode(token) || undefined;
-    } catch (err) {
+    }
+    catch (err) {
       // Do nothing
     }
   }

--- a/src/createLambdaProxyContext.js
+++ b/src/createLambdaProxyContext.js
@@ -60,7 +60,11 @@ module.exports = function createLambdaProxyContext(request, options, stageVariab
   let claims;
 
   if (token) {
-    claims = jwt.decode(token) || undefined;
+    try {
+      claims = jwt.decode(token) || undefined;
+    } catch (err) {
+      // Do nothing
+    }
   }
 
   return {


### PR DESCRIPTION
Should an invalid token be passed in the headers, the handler fails with an uncaught error. The error should be ignored instead.