### PR TITLE
adds supported and removes unsupported versions of node for travis tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 language: node_js
 node_js:
   - node
+  - '11'
+  - '10'
   - '8'
   - '6'
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,8 @@
 language: node_js
 node_js:
   - node
-  - '9'
   - '8'
-  - '7'
   - '6'
-  - '5'
 script:
   - npm run lint
   - npm test


### PR DESCRIPTION
removes unsupported (end-of-life) versions of node.js from travis: v5, v7, v9

adds supported versions of node.js: v10, v11

additional information: https://github.com/nodejs/Release