### PR TITLE
Support for authorizerId

### DIFF
--- a/manual_test/serverless.yml
+++ b/manual_test/serverless.yml
@@ -74,6 +74,15 @@ functions:
           method: get
           authorizer:
             arn: sometest
+  helloAuthorizerWithAuthorizerId:
+    handler: handler.hello
+    events:
+      - http:
+          path: helloAuthorizerWithAuthorizerId
+          method: get
+          authorizer:
+            type: CUSTOM
+            authorizerId: commonAuthorizerId
 
   helloAuthorizerWithFunctionName:
     handler: handler.hello

--- a/package.json
+++ b/package.json
@@ -104,7 +104,8 @@
     "Daniel Cottone <daniel.cottone@gmail.com> (https://github.com/daniel-cottone)",
     "Jaryd Carolin (https://github.com/horyd)",
     "Manuel Böhm (https://github.com/boehmers)",
-    "Bob Thomas (https://github.com/bob-thomas)"
+    "Bob Thomas (https://github.com/bob-thomas)",
+    "Alessandro Palumbo (https://github.com/apalumbo)"
   ],
   "license": "MIT",
   "bugs": {

--- a/src/authFunctionNameExtractor.js
+++ b/src/authFunctionNameExtractor.js
@@ -1,0 +1,57 @@
+'use strict';
+
+const extract = (endpoint, logFunction) => {
+  const buildFailureResult = warningMessage => {
+    logFunction(warningMessage);
+
+    return { unsupportedAuth: true };
+  };
+
+  const buildSuccessResult = authorizerName => ({ authorizerName });
+
+  const handleStringAuthorizer = authorizerString => {
+    if (authorizerString.toUpperCase() === 'AWS_IAM') {
+      return buildFailureResult('WARNING: Serverless Offline does not support the AWS_IAM authorization type');
+    }
+
+    return buildSuccessResult(authorizerString);
+  };
+
+  const handleObjectAuthorizer = authorizerObject => {
+    if (authorizerObject.type && authorizerObject.type.toUpperCase() === 'AWS_IAM') {
+      return buildFailureResult('WARNING: Serverless Offline does not support the AWS_IAM authorization type');
+    }
+    if (authorizerObject.arn) {
+      return buildFailureResult(`WARNING: Serverless Offline does not support non local authorizers (arn): ${authorizerObject.arn}`);
+    }
+    if (authorizerObject.authorizerId) {
+      return buildFailureResult(`WARNING: Serverless Offline does not support non local authorizers (authorizerId): ${authorizerObject.authorizerId}`);
+    }
+
+    const name = authorizerObject.name;
+
+    if (!name) {
+      return buildFailureResult('WARNING: Serverless Offline supports local authorizers but authorizer name is missing');
+    }
+
+    return buildSuccessResult(name);
+  };
+
+  if (!endpoint.authorizer) {
+    return buildSuccessResult(null);
+  }
+
+  const authorizer = endpoint.authorizer;
+
+  if (typeof authorizer === 'string') {
+    return handleStringAuthorizer(authorizer);
+  }
+
+  if (typeof authorizer === 'object') {
+    return handleObjectAuthorizer(authorizer);
+  }
+
+  return buildFailureResult('WARNING: Serverless Offline supports only local authorizers defined as string or object');
+};
+
+module.exports = { extract };

--- a/src/authFunctionNameExtractor.js
+++ b/src/authFunctionNameExtractor.js
@@ -54,4 +54,4 @@ const extract = (endpoint, logFunction) => {
   return buildFailureResult('WARNING: Serverless Offline supports only local authorizers defined as string or object');
 };
 
-module.exports = { extract };
+module.exports = extract;

--- a/src/index.js
+++ b/src/index.js
@@ -23,7 +23,7 @@ const functionHelper = require('./functionHelper');
 const Endpoint = require('./Endpoint');
 const parseResources = require('./parseResources');
 const utils = require('./utils');
-const { extract } = require('./authFunctionNameExtractor');
+const authFunctionNameExtractor = require('./authFunctionNameExtractor');
 
 const isNestedString = RegExp.prototype.test.bind(/^'.*?'$/);
 
@@ -925,7 +925,7 @@ class Offline {
   }
 
   _extractAuthFunctionName(endpoint) {
-    const result = extract(endpoint, this.serverlessLog);
+    const result = authFunctionNameExtractor(endpoint, this.serverlessLog);
 
     return result.unsupportedAuth ? null : result.authorizerName;
   }

--- a/src/index.js
+++ b/src/index.js
@@ -23,6 +23,7 @@ const functionHelper = require('./functionHelper');
 const Endpoint = require('./Endpoint');
 const parseResources = require('./parseResources');
 const utils = require('./utils');
+const { extract } = require('./authFunctionNameExtractor');
 
 const isNestedString = RegExp.prototype.test.bind(/^'.*?'$/);
 
@@ -923,71 +924,64 @@ class Offline {
     });
   }
 
+  _extractAuthFunctionName(endpoint) {
+    const result = extract(endpoint, this.serverlessLog);
+
+    return result.unsupportedAuth ? null : result.authorizerName;
+  }
+
   _configureAuthorization(endpoint, funName, method, epath, servicePath) {
-    let authStrategyName = null;
-    if (endpoint.authorizer) {
-      let authFunctionName = endpoint.authorizer;
-      if (typeof authFunctionName === 'string' && authFunctionName.toUpperCase() === 'AWS_IAM') {
-        this.serverlessLog('WARNING: Serverless Offline does not support the AWS_IAM authorization type');
-
-        return null;
-      }
-      if (typeof endpoint.authorizer === 'object') {
-        if (endpoint.authorizer.type && endpoint.authorizer.type.toUpperCase() === 'AWS_IAM') {
-          this.serverlessLog('WARNING: Serverless Offline does not support the AWS_IAM authorization type');
-
-          return null;
-        }
-        if (endpoint.authorizer.arn) {
-          this.serverlessLog(`WARNING: Serverless Offline does not support non local authorizers: ${endpoint.authorizer.arn}`);
-
-          return authStrategyName;
-        }
-        authFunctionName = endpoint.authorizer.name;
-      }
-
-      this.serverlessLog(`Configuring Authorization: ${endpoint.path} ${authFunctionName}`);
-
-      const authFunction = this.service.getFunction(authFunctionName);
-
-      if (!authFunction) return this.serverlessLog(`WARNING: Authorization function ${authFunctionName} does not exist`);
-
-      const authorizerOptions = {
-        resultTtlInSeconds: '300',
-        identitySource: 'method.request.header.Authorization',
-      };
-
-      if (typeof endpoint.authorizer === 'string') {
-        authorizerOptions.name = authFunctionName;
-      }
-      else {
-        Object.assign(authorizerOptions, endpoint.authorizer);
-      }
-
-      // Create a unique scheme per endpoint
-      // This allows the methodArn on the event property to be set appropriately
-      const authKey = `${funName}-${authFunctionName}-${method}-${epath}`;
-      const authSchemeName = `scheme-${authKey}`;
-      authStrategyName = `strategy-${authKey}`; // set strategy name for the route config
-
-      debugLog(`Creating Authorization scheme for ${authKey}`);
-
-      // Create the Auth Scheme for the endpoint
-      const scheme = createAuthScheme(
-        authFunction,
-        authorizerOptions,
-        funName,
-        epath,
-        this.options,
-        this.serverlessLog,
-        servicePath,
-        this.serverless
-      );
-
-      // Set the auth scheme and strategy on the server
-      this.server.auth.scheme(authSchemeName, scheme);
-      this.server.auth.strategy(authStrategyName, authSchemeName);
+    if (!endpoint.authorizer) {
+      return null;
     }
+
+    const authFunctionName = this._extractAuthFunctionName(endpoint);
+
+    if (!authFunctionName) {
+      return null;
+    }
+
+    this.serverlessLog(`Configuring Authorization: ${endpoint.path} ${authFunctionName}`);
+
+    const authFunction = this.service.getFunction(authFunctionName);
+
+    if (!authFunction) return this.serverlessLog(`WARNING: Authorization function ${authFunctionName} does not exist`);
+
+    const authorizerOptions = {
+      resultTtlInSeconds: '300',
+      identitySource: 'method.request.header.Authorization',
+    };
+
+    if (typeof endpoint.authorizer === 'string') {
+      authorizerOptions.name = authFunctionName;
+    }
+    else {
+      Object.assign(authorizerOptions, endpoint.authorizer);
+    }
+
+    // Create a unique scheme per endpoint
+    // This allows the methodArn on the event property to be set appropriately
+    const authKey = `${funName}-${authFunctionName}-${method}-${epath}`;
+    const authSchemeName = `scheme-${authKey}`;
+    const authStrategyName = `strategy-${authKey}`; // set strategy name for the route config
+
+    debugLog(`Creating Authorization scheme for ${authKey}`);
+
+    // Create the Auth Scheme for the endpoint
+    const scheme = createAuthScheme(
+      authFunction,
+      authorizerOptions,
+      funName,
+      epath,
+      this.options,
+      this.serverlessLog,
+      servicePath,
+      this.serverless
+    );
+
+    // Set the auth scheme and strategy on the server
+    this.server.auth.scheme(authSchemeName, scheme);
+    this.server.auth.strategy(authStrategyName, authSchemeName);
 
     return authStrategyName;
   }

--- a/test/unit/authFunctionNameExtractorTest.js
+++ b/test/unit/authFunctionNameExtractorTest.js
@@ -1,0 +1,97 @@
+/* global describe context it */
+
+'use strict';
+
+const chai = require('chai');
+const dirtyChai = require('dirty-chai');
+const { extract } = require('../../src/authFunctionNameExtractor');
+
+const expect = chai.expect;
+chai.use(dirtyChai);
+
+describe('authFunctionNameExtractor', () => {
+
+  describe('#extract', () => {
+    const dummyLogging = arrayStore => message => {
+      arrayStore.push(message);
+    };
+
+    context('Unsupported auth method', () => {
+      const unsupportedAuthTest = (authorizer, expectedWarningMessage) => () => {
+        const endpoint = { authorizer };
+        const logStorage = [];
+        const result = extract(endpoint, dummyLogging(logStorage));
+
+        expect(result.unsupportedAuth).to.eq(true);
+        expect(logStorage.length).to.eq(1);
+        expect(logStorage[0]).to.eq(expectedWarningMessage);
+      };
+
+      context('authorizer is a string', () => {
+        it('aws_iam',
+          unsupportedAuthTest('aws_iam',
+            'WARNING: Serverless Offline does not support the AWS_IAM authorization type'));
+
+        it('AWS_IAM',
+          unsupportedAuthTest('AWS_IAM',
+            'WARNING: Serverless Offline does not support the AWS_IAM authorization type'));
+
+        it('AwS_IaM',
+          unsupportedAuthTest('AwS_IaM',
+            'WARNING: Serverless Offline does not support the AWS_IAM authorization type'));
+      });
+
+      context('authorizer is an object', () => {
+        it('type: aws_iam', unsupportedAuthTest({ type: 'aws_iam' },
+          'WARNING: Serverless Offline does not support the AWS_IAM authorization type'));
+
+        it('type: AWS_IAM', unsupportedAuthTest({ type: 'AWS_IAM' },
+          'WARNING: Serverless Offline does not support the AWS_IAM authorization type'));
+
+        it('type: AwS_IaM', unsupportedAuthTest({ type: 'AwS_IaM' },
+          'WARNING: Serverless Offline does not support the AWS_IAM authorization type'));
+
+        it('arn is specified',
+          unsupportedAuthTest({ arn: 'anArnValue'},
+            'WARNING: Serverless Offline does not support non local authorizers (arn): anArnValue'));
+
+        it('authorizerId is specified',
+          unsupportedAuthTest({ authorizerId: 'anAuthorizerId'},
+            'WARNING: Serverless Offline does not support non local authorizers (authorizerId): anAuthorizerId'));
+
+        it('missing name attribute', () => {
+          unsupportedAuthTest({}, 'WARNING: Serverless Offline supports local authorizers but authorizer name is missing');
+        });
+      });
+
+      context('authorizer is not a string or oject', () => {
+        it('a number', unsupportedAuthTest(4,
+          'WARNING: Serverless Offline supports only local authorizers defined as string or object'));
+
+        it('a boolean', unsupportedAuthTest(true,
+          'WARNING: Serverless Offline supports only local authorizers defined as string or object'));
+      });
+    });
+
+    context('supported auth method', () => {
+      const supportedAuthTest = (authorizer, expectedAuthorizerName) => () => {
+        const endpoint = { authorizer };
+        const logStorage = [];
+        const result = extract(endpoint, dummyLogging(logStorage));
+
+        expect(result.unsupportedAuth).to.be.undefined();
+        expect(logStorage.length).to.eq(0);
+        expect(result.authorizerName).to.eq(expectedAuthorizerName);
+      };
+
+      context('authorizer is a string', () => {
+        it('is a string anAuthorizerName', supportedAuthTest('anAuthorizerName', 'anAuthorizerName'));
+      });
+      context('authorizer is an object', () => {
+        it('named anAuthorizerName', supportedAuthTest({ name : 'anAuthorizerName'}, 'anAuthorizerName'));
+      });
+
+    });
+  });
+
+});

--- a/test/unit/authFunctionNameExtractorTest.js
+++ b/test/unit/authFunctionNameExtractorTest.js
@@ -4,94 +4,93 @@
 
 const chai = require('chai');
 const dirtyChai = require('dirty-chai');
-const { extract } = require('../../src/authFunctionNameExtractor');
+const authFunctionNameExtractor = require('../../src/authFunctionNameExtractor');
 
 const expect = chai.expect;
 chai.use(dirtyChai);
 
 describe('authFunctionNameExtractor', () => {
 
-  describe('#extract', () => {
-    const dummyLogging = arrayStore => message => {
-      arrayStore.push(message);
+
+  const dummyLogging = arrayStore => message => {
+    arrayStore.push(message);
+  };
+
+  context('Unsupported auth method', () => {
+    const unsupportedAuthTest = (authorizer, expectedWarningMessage) => () => {
+      const endpoint = { authorizer };
+      const logStorage = [];
+      const result = authFunctionNameExtractor(endpoint, dummyLogging(logStorage));
+
+      expect(result.unsupportedAuth).to.eq(true);
+      expect(logStorage.length).to.eq(1);
+      expect(logStorage[0]).to.eq(expectedWarningMessage);
     };
 
-    context('Unsupported auth method', () => {
-      const unsupportedAuthTest = (authorizer, expectedWarningMessage) => () => {
-        const endpoint = { authorizer };
-        const logStorage = [];
-        const result = extract(endpoint, dummyLogging(logStorage));
-
-        expect(result.unsupportedAuth).to.eq(true);
-        expect(logStorage.length).to.eq(1);
-        expect(logStorage[0]).to.eq(expectedWarningMessage);
-      };
-
-      context('authorizer is a string', () => {
-        it('aws_iam',
-          unsupportedAuthTest('aws_iam',
-            'WARNING: Serverless Offline does not support the AWS_IAM authorization type'));
-
-        it('AWS_IAM',
-          unsupportedAuthTest('AWS_IAM',
-            'WARNING: Serverless Offline does not support the AWS_IAM authorization type'));
-
-        it('AwS_IaM',
-          unsupportedAuthTest('AwS_IaM',
-            'WARNING: Serverless Offline does not support the AWS_IAM authorization type'));
-      });
-
-      context('authorizer is an object', () => {
-        it('type: aws_iam', unsupportedAuthTest({ type: 'aws_iam' },
+    context('authorizer is a string', () => {
+      it('aws_iam',
+        unsupportedAuthTest('aws_iam',
           'WARNING: Serverless Offline does not support the AWS_IAM authorization type'));
 
-        it('type: AWS_IAM', unsupportedAuthTest({ type: 'AWS_IAM' },
+      it('AWS_IAM',
+        unsupportedAuthTest('AWS_IAM',
           'WARNING: Serverless Offline does not support the AWS_IAM authorization type'));
 
-        it('type: AwS_IaM', unsupportedAuthTest({ type: 'AwS_IaM' },
+      it('AwS_IaM',
+        unsupportedAuthTest('AwS_IaM',
           'WARNING: Serverless Offline does not support the AWS_IAM authorization type'));
+    });
 
-        it('arn is specified',
-          unsupportedAuthTest({ arn: 'anArnValue'},
-            'WARNING: Serverless Offline does not support non local authorizers (arn): anArnValue'));
+    context('authorizer is an object', () => {
+      it('type: aws_iam', unsupportedAuthTest({ type: 'aws_iam' },
+        'WARNING: Serverless Offline does not support the AWS_IAM authorization type'));
 
-        it('authorizerId is specified',
-          unsupportedAuthTest({ authorizerId: 'anAuthorizerId'},
-            'WARNING: Serverless Offline does not support non local authorizers (authorizerId): anAuthorizerId'));
+      it('type: AWS_IAM', unsupportedAuthTest({ type: 'AWS_IAM' },
+        'WARNING: Serverless Offline does not support the AWS_IAM authorization type'));
 
-        it('missing name attribute', () => {
-          unsupportedAuthTest({}, 'WARNING: Serverless Offline supports local authorizers but authorizer name is missing');
-        });
-      });
+      it('type: AwS_IaM', unsupportedAuthTest({ type: 'AwS_IaM' },
+        'WARNING: Serverless Offline does not support the AWS_IAM authorization type'));
 
-      context('authorizer is not a string or oject', () => {
-        it('a number', unsupportedAuthTest(4,
-          'WARNING: Serverless Offline supports only local authorizers defined as string or object'));
+      it('arn is specified',
+        unsupportedAuthTest({ arn: 'anArnValue'},
+          'WARNING: Serverless Offline does not support non local authorizers (arn): anArnValue'));
 
-        it('a boolean', unsupportedAuthTest(true,
-          'WARNING: Serverless Offline supports only local authorizers defined as string or object'));
+      it('authorizerId is specified',
+        unsupportedAuthTest({ authorizerId: 'anAuthorizerId'},
+          'WARNING: Serverless Offline does not support non local authorizers (authorizerId): anAuthorizerId'));
+
+      it('missing name attribute', () => {
+        unsupportedAuthTest({}, 'WARNING: Serverless Offline supports local authorizers but authorizer name is missing');
       });
     });
 
-    context('supported auth method', () => {
-      const supportedAuthTest = (authorizer, expectedAuthorizerName) => () => {
-        const endpoint = { authorizer };
-        const logStorage = [];
-        const result = extract(endpoint, dummyLogging(logStorage));
+    context('authorizer is not a string or oject', () => {
+      it('a number', unsupportedAuthTest(4,
+        'WARNING: Serverless Offline supports only local authorizers defined as string or object'));
 
-        expect(result.unsupportedAuth).to.be.undefined();
-        expect(logStorage.length).to.eq(0);
-        expect(result.authorizerName).to.eq(expectedAuthorizerName);
-      };
-
-      context('authorizer is a string', () => {
-        it('is a string anAuthorizerName', supportedAuthTest('anAuthorizerName', 'anAuthorizerName'));
-      });
-      context('authorizer is an object', () => {
-        it('named anAuthorizerName', supportedAuthTest({ name : 'anAuthorizerName'}, 'anAuthorizerName'));
-      });
-
+      it('a boolean', unsupportedAuthTest(true,
+        'WARNING: Serverless Offline supports only local authorizers defined as string or object'));
     });
+  });
+
+  context('supported auth method', () => {
+    const supportedAuthTest = (authorizer, expectedAuthorizerName) => () => {
+      const endpoint = { authorizer };
+      const logStorage = [];
+      const result = authFunctionNameExtractor(endpoint, dummyLogging(logStorage));
+
+      expect(result.unsupportedAuth).to.be.undefined();
+      expect(logStorage.length).to.eq(0);
+      expect(result.authorizerName).to.eq(expectedAuthorizerName);
+    };
+
+    context('authorizer is a string', () => {
+      it('is a string anAuthorizerName', supportedAuthTest('anAuthorizerName', 'anAuthorizerName'));
+    });
+    context('authorizer is an object', () => {
+      it('named anAuthorizerName', supportedAuthTest({ name : 'anAuthorizerName'}, 'anAuthorizerName'));
+    });
+
   });
 
 });


### PR DESCRIPTION
This PR includes basic support for handling authorizerId in cusom authorizers, in the current version it  is not recognized as an external authorizer. With the PR it is recognized and skipped like the other externals identifier.

- [x] Extracted authFunctionName in external function, added unit test
- [x] Added authorizerId support dherault/serverless-offline/#529
- [x] Added manual test for authorizerId