### PR TITLE
Updating serverless for Set-Cookie HttpOnly, Secure, and SameSite additions in HAPI

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -326,6 +326,11 @@ class Offline {
     const connectionOptions = {
       host: this.options.host,
       port: this.options.port,
+      state: {
+        isHttpOnly: false,
+        isSecure: false,
+        isSameSite: false,
+      }
     };
     const httpsDir = this.options.httpsProtocol;
 

--- a/test/integration/offline.js
+++ b/test/integration/offline.js
@@ -711,7 +711,7 @@ describe('Offline', () => {
       const offline = new OfflineBuilder().addFunctionHTTP('test', {
         path: 'fn2',
         method: 'GET',
-      }, (event, context, cb) => cb(null, { "headers": {"Set-Cookie": "mycookie=123"} })).toObject();
+      }, (event, context, cb) => cb(null, { headers: {'Set-Cookie': 'mycookie=123'} })).toObject();
       
       offline.inject({
         method: 'GET',
@@ -727,7 +727,7 @@ describe('Offline', () => {
       const offline = new OfflineBuilder().addFunctionHTTP('test', {
         path: 'fn3',
         method: 'GET',
-      }, (event, context, cb) => cb(null, { "headers": {"Set-Cookie": "mycookie=123"} })).toObject();
+      }, (event, context, cb) => cb(null, { headers: {'Set-Cookie': 'mycookie=123'} })).toObject();
       
       offline.inject({
         method: 'GET',
@@ -743,7 +743,7 @@ describe('Offline', () => {
       const offline = new OfflineBuilder().addFunctionHTTP('test', {
         path: 'fn4',
         method: 'GET',
-      }, (event, context, cb) => cb(null, { "headers": {"Set-Cookie": "mycookie=123"} })).toObject();
+      }, (event, context, cb) => cb(null, { headers: {'Set-Cookie': 'mycookie=123'} })).toObject();
       
       offline.inject({
         method: 'GET',

--- a/test/integration/offline.js
+++ b/test/integration/offline.js
@@ -706,4 +706,55 @@ describe('Offline', () => {
     });
   });
 
+  context('check cookie status', () => {
+    it('check for isHttpOnly off', done => {
+      const offline = new OfflineBuilder().addFunctionHTTP('test', {
+        path: 'fn2',
+        method: 'GET',
+      }, (event, context, cb) => cb(null, { "headers": {"Set-Cookie": "mycookie=123"} })).toObject();
+      
+      offline.inject({
+        method: 'GET',
+        url: '/fn2',
+        headers: {
+        },
+      }, res => {
+        res.headers['set-cookie'].forEach((v) => expect(v.match(/httponly/i)).to.eq(null));
+        done();
+      });
+    })
+    it('check for isSecure off', done => {
+      const offline = new OfflineBuilder().addFunctionHTTP('test', {
+        path: 'fn3',
+        method: 'GET',
+      }, (event, context, cb) => cb(null, { "headers": {"Set-Cookie": "mycookie=123"} })).toObject();
+      
+      offline.inject({
+        method: 'GET',
+        url: '/fn3',
+        headers: {
+        },
+      }, res => {
+        res.headers['set-cookie'].forEach((v) => expect(v.match(/secure/i)).to.eq(null));
+        done();
+      });
+    })
+    it('check for isSameSite off', done => {
+      const offline = new OfflineBuilder().addFunctionHTTP('test', {
+        path: 'fn4',
+        method: 'GET',
+      }, (event, context, cb) => cb(null, { "headers": {"Set-Cookie": "mycookie=123"} })).toObject();
+      
+      offline.inject({
+        method: 'GET',
+        url: '/fn4',
+        headers: {
+        },
+      }, res => {
+        res.headers['set-cookie'].forEach((v) => expect(v.match(/samesite/i)).to.eq(null));
+        done();
+      });
+    })
+  });
+
 });


### PR DESCRIPTION
Updating code to pass along statehood properties and created tests