### PR TITLE
remove nested require.cache under functionHelper's children

### DIFF
--- a/src/functionHelper.js
+++ b/src/functionHelper.js
@@ -98,6 +98,18 @@ module.exports = {
         // Might cause errors, if so please submit an issue.
         if (!key.match(options.cacheInvalidationRegex || /node_modules/)) delete require.cache[key];
       }
+      const currentFilePath = __filename;
+      if (require.cache[currentFilePath] && require.cache[currentFilePath].children) {
+        require.cache[currentFilePath].children = require.cache[currentFilePath].children
+          .map(moduleCache => {
+            if (!moduleCache.filename.match(options.cacheInvalidationRegex || /node_modules/)) {
+              return undefined;
+            }
+
+            return moduleCache;
+          })
+          .filter(moduleCache => !!moduleCache);
+      }
     }
 
     debugLog(`Loading handler... (${funOptions.handlerPath})`);


### PR DESCRIPTION
Retained cache:
<img width="1436" alt="screenshot 2019-01-13 at 6 09 41 pm" src="https://user-images.githubusercontent.com/1743425/51086103-32554f00-1768-11e9-9313-54cb661452fb.png">

There's also an issue on the node repo talking about the cache issue https://github.com/nodejs/node/issues/8443