### PR TITLE
Ensure external handlers are cleaned up on exit

### DIFF
--- a/package.json
+++ b/package.json
@@ -123,7 +123,6 @@
     "jsonpath-plus": "^0.16.0",
     "jsonwebtoken": "^8.3.0",
     "trim-newlines": "^2.0.0",
-    "uuid": "^3.3.2",
     "velocityjs": "^1.1.2"
   },
   "devDependencies": {

--- a/src/functionHelper.js
+++ b/src/functionHelper.js
@@ -151,7 +151,7 @@ module.exports = {
       const id = utils.randomId();
       messageCallbacks[id] = done;
       handlerContext.inflight.add(id);
-      handlerContext.process.send({ ...funOptions, id, event, context });
+      handlerContext.process.send(Object.assign({}, funOptions, { id, event, context }));
     };
   },
 

--- a/src/index.js
+++ b/src/index.js
@@ -998,6 +998,7 @@ class Offline {
 
   end() {
     this.serverlessLog('Halting offline server');
+    functionHelper.cleanup();
     this.server.stop({ timeout: 5000 })
     .then(() => process.exit(this.exitCode));
   }

--- a/src/ipcHelper.js
+++ b/src/ipcHelper.js
@@ -10,20 +10,38 @@ process.on('uncaughtException', e => {
   });
 });
 
-const handler = require(process.argv[2]);
+const fun = require(process.argv[2]);
 
 process.on('message', opts => {
   function done(error, ret) {
     process.send({ id: opts.id, error, ret });
   }
 
+  const handler = fun[opts.handlerName];
+  if (typeof handler !== 'function') {
+    throw new Error(`Serverless-offline: handler for '${opts.handlerName}' is not a function`);
+  }
+  const endTime = new Date().getTime() + (opts.funTimeout ? opts.funTimeout * 1000 : 6000);
+
+  const functionName = opts.funName;
   const context = Object.assign(opts.context, {
     done,
     succeed: res => done(null, res),
     fail:    err => done(err, null),
-    // TODO implement getRemainingTimeInMillis
+    getRemainingTimeInMillis: () => endTime - new Date().getTime(),
+
+    /* Properties */
+    functionName,
+    memoryLimitInMB:    opts.memorySize,
+    functionVersion:    `offline_functionVersion_for_${functionName}`,
+    invokedFunctionArn: `offline_invokedFunctionArn_for_${functionName}`,
+    awsRequestId:       `offline_awsRequestId_${opts.id}`,
+    logGroupName:       `offline_logGroupName_for_${functionName}`,
+    logStreamName:      `offline_logStreamName_for_${functionName}`,
+    identity:           {},
+    clientContext:      {},
   });
-  const x = handler[opts.name](opts.event, context, done);
+  const x = handler(opts.event, context, done);
   if (x && typeof x.then === 'function' && typeof x.catch === 'function') x.then(context.succeed).catch(context.fail);
   else if (x instanceof Error) context.fail(x);
 });


### PR DESCRIPTION
This solves a few issues, notably:
- The flag `--useSeparateProcesses` along with `--skipCacheInvalidation` would leave these handlers running after exit. Added a cleanup hook to `functionHelper`.
- Reimplements removing `undefined` values from `process.env` to match the behavior before commit c5cba66652ddec8e3b73c9fea5d0834aac783ef1
- Implemented `getRemainingTimeInMillis` and other properties that have been added to `createLambdaContext`.
- Clarifies naming issues with `function` vs `handler`.