### PR TITLE
--noEnvironment Upgrade

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -563,7 +563,7 @@ class Offline {
                   AWS_REGION: 'dev',
                 };
 
-                process.env = Object.assign({}, baseEnvironment);
+                process.env = Object.assign(baseEnvironment, process.env);
               }
               else {
                 Object.assign(


### PR DESCRIPTION
Allow users to provide environment variables outside of node without  the --noEnvironment flag blowing them away