### PR TITLE
Prevent overriding exported AWS_PROFILE 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "serverless-offline",
-  "version": "4.1.4",
+  "version": "4.2.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/index.js
+++ b/src/index.js
@@ -565,11 +565,13 @@ class Offline {
             try {
               if (this.options.noEnvironment) {
                 // This evict errors in server when we use aws services like ssm
-                const baseEnvironment = {
-                  AWS_ACCESS_KEY_ID: 'dev',
-                  AWS_SECRET_ACCESS_KEY: 'dev',
-                  AWS_REGION: 'dev',
+                var baseEnvironment = {
+                   AWS_REGION: 'dev'
                 };
+                if (!process.env.AWS_PROFILE){
+                  baseEnvironment.AWS_ACCESS_KEY_ID = 'dev';
+                  baseEnvironment.AWS_SECRET_ACCESS_KEY = 'dev';
+                }
 
                 process.env = Object.assign(baseEnvironment, process.env);
               }

--- a/src/index.js
+++ b/src/index.js
@@ -568,7 +568,7 @@ class Offline {
                 var baseEnvironment = {
                    AWS_REGION: 'dev'
                 };
-                if (!process.env.AWS_PROFILE){
+                if (!process.env.AWS_PROFILE) {
                   baseEnvironment.AWS_ACCESS_KEY_ID = 'dev';
                   baseEnvironment.AWS_SECRET_ACCESS_KEY = 'dev';
                 }

--- a/src/index.js
+++ b/src/index.js
@@ -565,8 +565,8 @@ class Offline {
             try {
               if (this.options.noEnvironment) {
                 // This evict errors in server when we use aws services like ssm
-                var baseEnvironment = {
-                   AWS_REGION: 'dev'
+                const baseEnvironment = {
+                  AWS_REGION: 'dev',
                 };
                 if (!process.env.AWS_PROFILE) {
                   baseEnvironment.AWS_ACCESS_KEY_ID = 'dev';


### PR DESCRIPTION
Prevent overriding exported AWS_PROFILE with fake 'dev' explicit credentials when using --noEnvironment option