### PR TITLE
Add request body validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,6 +256,60 @@ Example response velocity template:
 },
 ```
 
+### Request body validation
+
+[AWS doc](https://docs.aws.amazon.com/apigateway/latest/developerguide/api-gateway-method-request-validation.html)
+
+You can enable request body validation against a request model for lambda-proxy integration type. Instructions are:
+
+* Define a validator resource with ```ValidateRequestBody``` set to true
+* Link the validator to an http event via ```reqValidatorName```
+* Define a model
+* Link the model to the http event via ```documentation.requestModels```
+
+In case of an invalid request body, the server will respond 400.
+
+Example serverless.yml:
+
+```
+custom:
+  documentation:
+    models:
+      -
+        name: HelloModel
+        contentType: application/json
+        schema:
+          type: object
+          properties:
+            message:
+              type: string
+              minLength: 2
+          required:
+            - message
+functions:
+  helloWorld:
+    handler: handler.helloWorld
+    events:
+      - http:
+          path: hello-world
+          method: post
+          cors: true
+          reqValidatorName: myValidator
+          documentation:
+            requestModels:
+              "application/json": HelloModel
+resources:
+  Resources:
+    myValidator:
+      Type: "AWS::ApiGateway::RequestValidator"
+      Properties:
+        Name: 'my-validator'
+        RestApiId:
+          Ref: ApiGatewayRestApi
+        ValidateRequestBody: true
+        ValidateRequestParameters: false
+```
+
 ## Usage with Webpack
 
 Use [serverless-webpack](https://github.com/serverless-heaven/serverless-webpack) to compile and bundle your ES-next code

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "serverless-offline",
-  "version": "4.1.4",
+  "version": "4.2.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1447,6 +1447,11 @@
       "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-4.0.1.tgz",
       "integrity": "sha1-T9kss04OnbPInIYi7PUfm5eMbLk=",
       "dev": true
+    },
+    "jsonschema": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/jsonschema/-/jsonschema-1.2.4.tgz",
+      "integrity": "sha512-lz1nOH69GbsVHeVgEdvyavc/33oymY1AZwtePMiMj4HZPMbP5OIKK3zT9INMWjwua/V4Z4yq7wSlBbSG+g4AEw=="
     },
     "jsonwebtoken": {
       "version": "8.3.0",

--- a/package.json
+++ b/package.json
@@ -110,7 +110,8 @@
     "Jaryd Carolin (https://github.com/horyd)",
     "Manuel Böhm (https://github.com/boehmers)",
     "Bob Thomas (https://github.com/bob-thomas)",
-    "Alessandro Palumbo (https://github.com/apalumbo)"
+    "Alessandro Palumbo (https://github.com/apalumbo)",
+    "Selcuk Cihan (https://github.com/selcukcihan)"
   ],
   "dependencies": {
     "boom": "^7.3.0",
@@ -120,6 +121,7 @@
     "hapi-cors-headers": "^1.0.3",
     "js-string-escape": "^1.0.1",
     "jsonpath-plus": "^0.16.0",
+    "jsonschema": "^1.2.4",
     "jsonwebtoken": "^8.3.0",
     "trim-newlines": "^2.0.0",
     "velocityjs": "^1.1.2"

--- a/src/requestBodyValidator.js
+++ b/src/requestBodyValidator.js
@@ -1,0 +1,23 @@
+const validator = require('jsonschema').validate;
+
+module.exports = {
+  getModel(custom, eventHttp, serverlessLog) {
+    if (eventHttp.documentation && eventHttp.documentation.requestModels) {
+      const modelName = eventHttp.documentation.requestModels['application/json'];
+      const models = custom.documentation.models.filter(model => model.name === modelName);
+      if (models.length === 1) {
+        return models[0];
+      }
+      serverlessLog(`Warning: can't find '${modelName}' within ${JSON.stringify(eventHttp.documentation.requestModels)}`);
+    }
+
+    return null;
+  },
+
+  validate(model, body) {
+    const result = validator(JSON.parse(body), model.schema);
+    if (result.errors.length > 0) {
+      throw new Error(`Request body validation failed.\n${result.errors.map(e => e.message).join(',')}`);
+    }
+  },
+};

--- a/test/unit/requestBodyValidatorTest.js
+++ b/test/unit/requestBodyValidatorTest.js
@@ -1,0 +1,113 @@
+/* global describe before context it */
+const chai = require('chai');
+const dirtyChai = require('dirty-chai');
+const requestBodyValidator = require('../../src/requestBodyValidator');
+
+const expect = chai.expect;
+chai.use(dirtyChai);
+
+describe('requestBodyValidator', () => {
+  describe('#getModel', () => {
+    const modelName = 'myModel';
+    const custom = {
+      documentation: {
+        models: [
+          {
+            name: modelName,
+          },
+        ],
+      },
+    };
+
+    let result;
+    before(() => {
+      const eventHttp = {
+        documentation: {
+          requestModels: {
+            'application/json': modelName,
+          },
+        },
+      };
+      result = requestBodyValidator.getModel(custom, eventHttp);
+    });
+
+    it('should have the correct model name', () => {
+      expect(result.name).to.eq(modelName);
+    });
+
+    context('without documentation', () => {
+      before(() => {
+        result = requestBodyValidator.getModel({}, {});
+      });
+
+      it('should return null', () => {
+        expect(result).to.eq(null);
+      });
+    });
+
+    context('without requestModels', () => {
+      before(() => {
+        const eventHttp = {
+          documentation: {},
+        };
+        result = requestBodyValidator.getModel({}, eventHttp);
+      });
+
+      it('should return null', () => {
+        expect(result).to.eq(null);
+      });
+    });
+
+    context('without required request model', () => {
+      const logStorage = [];
+      const anotherModel = 'anotherModel';
+      const eventHttp = {
+        documentation: {
+          requestModels: {
+            'application/json': anotherModel,
+          },
+        },
+      };
+      before(() => {
+        result = requestBodyValidator.getModel(custom, eventHttp, log => logStorage.push(log));
+      });
+
+      it('should return null', () => {
+        expect(result).to.eq(null);
+      });
+      it('should add a warning log', () => {
+        expect(logStorage.length).to.eq(1);
+        expect(logStorage[0]).to.eq(`Warning: can't find '${anotherModel}' within ${JSON.stringify(eventHttp.documentation.requestModels)}`);
+      });
+    });
+  });
+
+  describe('#validate', () => {
+    const model = {
+      schema: {
+        type: 'object',
+        properties: {
+          message: {
+            type: 'number',
+          },
+        },
+      },
+    };
+
+    before(() => {
+      const body = JSON.stringify({
+        message: 12,
+      });
+      requestBodyValidator.validate(model, body);
+    });
+
+    context('json not conforming to the schema', () => {
+      const body = JSON.stringify({
+        message: 'foo',
+      });
+      it('should throw error', () => {
+        expect(() => requestBodyValidator.validate(model, body)).to.throw(/Request body validation failed.*/);
+      });
+    });
+  });
+});


### PR DESCRIPTION
If request validation is enabled for http lambda-proxy integration,
the request body is validated against the request model.

### Testing done

```
npm test

  120 passing (551ms)
```

#### Manual testing

I've linked my local experimental project to serverless-offline that has the changes in this PR. I've used the following serverless.yml file:

##### serverless.yml

```
# Welcome to serverless. Read the docs
# https://serverless.com/framework/docs/

# Serverless.yml is the configuration the CLI
# uses to deploy your code to your provider of choice

# The `service` block is the name of the service
service: serverless-hello-world

plugins:
  - serverless-offline
  - serverless-reqvalidator-plugin
  - serverless-aws-documentation

# The `provider` block defines where your service will be deployed
provider:
  name: aws
  runtime: nodejs6.10

custom:
  documentation:
    api:
      info:
        version: v0.0.0
        title: Experimental API
        description: This is an experiment
    models:
      -
        name: HelloModel
        contentType: application/json
        schema:
          type: object
          properties:
            message:
              type: string
              minLength: 2
          required:
            - message

# The `functions` block defines what code to deploy
functions:
  helloWorld:
    handler: handler.helloWorld
    # The `events` block defines how to trigger the handler.helloWorld code
    events:
      - http:
          path: hello-world
          method: post
          cors: true
          reqValidatorName: myValidator
          documentation:
            requestModels:
              "application/json": HelloModel
      - http:
          path: foo
          method: post
          cors: true

resources:
  Resources:
    myValidator:
      Type: "AWS::ApiGateway::RequestValidator"
      Properties:
        Name: 'my-validator'
        RestApiId:
          Ref: ApiGatewayRestApi
        ValidateRequestBody: true
        ValidateRequestParameters: false
```

##### Starting the server
```
sls offline

[offline] helloWorld runtime nodejs6.10
Serverless: Routes for helloWorld:
Serverless: POST /hello-world - request body will be validated against HelloModel

Serverless: Offline listening on http://localhost:3000
```

##### Example request

```
POST http://localhost:3000/hello-world

{
  "message": "b"
}
```

##### Response

```
400 Bad Request

{
    "errorMessage": "Invalid request body for 'helloWorld' handler",
    "errorType": "Error",
    "stackTrace": [
        "Error: Request body validation failed.",
        "does not meet minimum length of 2",
        "at Object.validate (/Users/selcukcihan/node/serverless-offline/src/requestBodyValidator.js:20:13)",
        "at handler (/Users/selcukcihan/node/serverless-offline/src/index.js:917:38)",
        "at Object.internals.handler (/Users/selcukcihan/node/serverless-offline/node_modules/hapi/lib/handler.js:101:51)",
        "at request._protect.run (/Users/selcukcihan/node/serverless-offline/node_modules/hapi/lib/handler.js:32:23)",
        "at module.exports.internals.Protect.internals.Protect.run (/Users/selcukcihan/node/serverless-offline/node_modules/hapi/lib/protect.js:60:12)",
        "at exports.execute (/Users/selcukcihan/node/serverless-offline/node_modules/hapi/lib/handler.js:26:22)",
        "at each (/Users/selcukcihan/node/serverless-offline/node_modules/hapi/lib/request.js:401:16)",
        "at iterate (/Users/selcukcihan/node/serverless-offline/node_modules/items/lib/index.js:36:13)",
        "at done (/Users/selcukcihan/node/serverless-offline/node_modules/items/lib/index.js:28:25)",
        "at internals.Auth.payload (/Users/selcukcihan/node/serverless-offline/node_modules/hapi/lib/auth.js:235:16)",
        "at each (/Users/selcukcihan/node/serverless-offline/node_modules/hapi/lib/request.js:401:16)",
        "at iterate (/Users/selcukcihan/node/serverless-offline/node_modules/items/lib/index.js:36:13)",
        "at done (/Users/selcukcihan/node/serverless-offline/node_modules/items/lib/index.js:28:25)",
        "at onParsed (/Users/selcukcihan/node/serverless-offline/node_modules/hapi/lib/route.js:341:20)",
        "at Subtext.parse (/Users/selcukcihan/node/serverless-offline/node_modules/hapi/lib/route.js:380:20)",
        "at next (/Users/selcukcihan/node/serverless-offline/node_modules/subtext/lib/index.js:45:26)",
        "at Wreck.read (/Users/selcukcihan/node/serverless-offline/node_modules/subtext/lib/index.js:242:16)",
        "at finish (/Users/selcukcihan/node/serverless-offline/node_modules/wreck/lib/index.js:374:20)",
        "at wrapped (/Users/selcukcihan/node/serverless-offline/node_modules/hoek/lib/index.js:879:20)",
        "at module.exports.internals.Recorder.onReaderFinish (/Users/selcukcihan/node/serverless-offline/node_modules/wreck/lib/index.js:449:16)",
        "at Object.onceWrapper (events.js:313:30)",
        "at emitNone (events.js:111:20)",
        "at module.exports.internals.Recorder.emit (events.js:208:7)",
        "at finishMaybe (_stream_writable.js:613:14)",
        "at endWritable (_stream_writable.js:621:3)",
        "at module.exports.internals.Recorder.Writable.end (_stream_writable.js:572:5)",
        "at IncomingMessage.onend (_stream_readable.js:595:10)",
        "at Object.onceWrapper (events.js:313:30)",
        "at emitNone (events.js:111:20)",
        "at IncomingMessage.emit (events.js:208:7)",
        "at endReadableNT (_stream_readable.js:1064:12)",
        "at _combinedTickCallback (internal/process/next_tick.js:139:11)"
    ],
    "offlineInfo": "If you believe this is an issue with the plugin please submit it, thanks. https://github.com/dherault/serverless-offline/issues"
}
```