### PR TITLE
Fix Scheme creation to not throw on missing auth header

### DIFF
--- a/src/createAuthScheme.js
+++ b/src/createAuthScheme.js
@@ -78,7 +78,7 @@ function createAuthScheme(
       else {
         const authorization = req.headers[identityHeader];
         
-        const matchedAuthorization = authorization.match(authorizerOptions.identityValidationExpression);
+        const matchedAuthorization = authorization && authorization.match(authorizerOptions.identityValidationExpression);
         const finalAuthorization = (matchedAuthorization && matchedAuthorization[1]) || '';
         debugLog(`Retrieved ${identityHeader} header ${finalAuthorization}`);
         event = {


### PR DESCRIPTION
I think that the fix is pretty self-explanatory.

If the auth header is missing you get `TypeError: Uncaught error: Cannot read property 'match' of undefined` and you shouldn't.

Please ask if any clarification is needed.