### PR TITLE
Add request validation for lambda integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -261,7 +261,7 @@ Example response velocity template:
 
 [AWS doc](https://docs.aws.amazon.com/apigateway/latest/developerguide/api-gateway-method-request-validation.html)
 
-You can enable request body validation against a request model for lambda-proxy integration type. Instructions are:
+You can enable request body validation against a request model for lambda-proxy or lambda integration types. Instructions are:
 
 * Define a validator resource with ```ValidateRequestBody``` set to true
 * Link the validator to an http event via ```reqValidatorName```

--- a/src/index.js
+++ b/src/index.js
@@ -416,7 +416,7 @@ class Offline {
         const endpoint = new Endpoint(event.http, funOptions).generate();
 
         const integration = endpoint.integration || 'lambda-proxy';
-        const requestBodyValidationModel = (integration === 'lambda-proxy'
+        const requestBodyValidationModel = (['lambda', 'lambda-proxy'].includes(integration)
           ? requestBodyValidator.getModel(this.service.custom, event.http, this.serverlessLog)
           : null);
         const epath = endpoint.path;


### PR DESCRIPTION
PR #589 added request body validation for lambda-proxy integration, but not for lambda integration. This PR adds request body validation for the two types of integrations.