### PR TITLE
Fix failing tests on windows 

### DIFF
--- a/test/unit/functionHelperTest.js
+++ b/test/unit/functionHelperTest.js
@@ -1,6 +1,7 @@
 /* global describe before context it */
 const chai = require('chai');
 const dirtyChai = require('dirty-chai');
+const path = require('path');
 const functionHelper = require('../../src/functionHelper');
 
 const expect = chai.expect;
@@ -29,7 +30,7 @@ describe('functionHelper', () => {
     });
 
     it('should have the correct handler path', () => {
-      expect(result.handlerPath).to.eq('src/handler');
+      expect(result.handlerPath).to.eq(path.join('src', 'handler'));
     });
 
     it('should have the default timeout', () => {
@@ -46,7 +47,7 @@ describe('functionHelper', () => {
       };
       const result = functionHelper.getFunctionOptions(fun, funName, servicePath);
       expect(result.handlerName).to.eq('run');
-      expect(result.handlerPath).to.eq('src/somefolder/.handlers/handler');
+      expect(result.handlerPath).to.eq(path.join('src', 'somefolder', '.handlers', 'handler'));
     });
 
     context('with a timeout', () => {


### PR DESCRIPTION
As windows use different path separators 2 tests were failing. 
![image](https://user-images.githubusercontent.com/13507001/53267917-4daf6480-36ed-11e9-81c4-4fbbc0246595.png)
This pr addresses them.