### PR TITLE
Feature/resource proxy querystring

### DIFF
--- a/manual_test_nodejs/README.md
+++ b/manual_test_nodejs/README.md
@@ -12,3 +12,10 @@ In the plugin directory:
 `node subprocess.js`
 
 It should stop after 10 seconds with the proper halting message
+
+## Testing resource proxy
+
+`npm start -- --resourceRoutes`
+
+Open <http://localhost:3000/echo/foo/bar?baz=qux> in your browser.  Notice how
+querystrings do not work.

--- a/manual_test_nodejs/README.md
+++ b/manual_test_nodejs/README.md
@@ -18,4 +18,4 @@ It should stop after 10 seconds with the proper halting message
 `npm start -- --resourceRoutes`
 
 Open <http://localhost:3000/echo/foo/bar?baz=qux> in your browser.  Notice how
-querystrings do not work.
+querystrings also work now.

--- a/manual_test_nodejs/README.md
+++ b/manual_test_nodejs/README.md
@@ -16,6 +16,3 @@ It should stop after 10 seconds with the proper halting message
 ## Testing resource proxy
 
 `npm start -- --resourceRoutes`
-
-Open <http://localhost:3000/echo/foo/bar?baz=qux> in your browser.  Notice how
-querystrings also work now.

--- a/manual_test_nodejs/serverless.yml
+++ b/manual_test_nodejs/serverless.yml
@@ -172,8 +172,23 @@ functions:
           method: GET
 
 # you can add CloudFormation resource templates here
-#resources:
-#  Resources:
+resources:
+  Resources:
+    EchoProxyResource:
+      Type: AWS::ApiGateway::Resource
+      Properties:
+        PathPart: echo/{proxy+}
+    EchoProxyMethod:
+      Type: AWS::ApiGateway::Method
+      Properties:
+        ResourceId:
+          Ref: EchoProxyResource
+        HttpMethod: ANY
+        Integration:
+          IntegrationHttpMethod: ANY
+          Type: HTTP_PROXY
+          Uri: http://mockbin.org/request/{proxy}
+
 #    NewResource:
 #      Type: AWS::S3::Bucket
 #      Properties:

--- a/src/index.js
+++ b/src/index.js
@@ -1154,6 +1154,7 @@ class Offline {
           Object.keys(params).forEach(key => {
             resultUri = resultUri.replace(`{${key}}`, params[key]);
           });
+          resultUri += request.url.search; // search is empty string by default
           this.serverlessLog(`PROXY ${request.method} ${request.url.path} -> ${resultUri}`);
           reply.proxy({ uri: resultUri, passThrough: true });
         },

--- a/test/integration/offline.js
+++ b/test/integration/offline.js
@@ -760,28 +760,28 @@ describe('Offline', () => {
     before(done => {
       serviceBuilder = new ServerlessBuilder();
       serviceBuilder.serverless.service.resources = {
-        "Resources": {
-          "EchoProxyResource": {
-            "Type": "AWS::ApiGateway::Resource",
-            "Properties": {
-              "PathPart": "echo/{proxy+}"
-            }
+        Resources: {
+          EchoProxyResource: {
+            Type: 'AWS::ApiGateway::Resource',
+            Properties: {
+              PathPart: 'echo/{proxy+}',
+            },
           },
-          "EchoProxyMethod": {
-            "Type": "AWS::ApiGateway::Method",
-            "Properties": {
-              "ResourceId": {
-                "Ref": "EchoProxyResource"
+          EchoProxyMethod: {
+            Type: 'AWS::ApiGateway::Method',
+            Properties: {
+              ResourceId: {
+                Ref: 'EchoProxyResource',
               },
-              "HttpMethod": "ANY",
-              "Integration": {
-                "IntegrationHttpMethod": "ANY",
-                "Type": "HTTP_PROXY",
-                "Uri": "http://mockbin.org/request/{proxy}"
-              }
-            }
-          }
-        }
+              HttpMethod: 'ANY',
+              Integration: {
+                IntegrationHttpMethod: 'ANY',
+                Type: 'HTTP_PROXY',
+                Uri: 'http://mockbin.org/request/{proxy}',
+              },
+            },
+          },
+        },
       };
       done();
     });


### PR DESCRIPTION
Using resource proxy, query strings were not passed along.  This update now will pass query strings.