### PR TITLE
Fix stage and region option precedence bug (Closes #338)

### DIFF
--- a/package.json
+++ b/package.json
@@ -111,7 +111,8 @@
     "Manuel Böhm (https://github.com/boehmers)",
     "Bob Thomas (https://github.com/bob-thomas)",
     "Alessandro Palumbo (https://github.com/apalumbo)",
-    "Selcuk Cihan (https://github.com/selcukcihan)"
+    "Selcuk Cihan (https://github.com/selcukcihan)",
+    "G Roques (https://github.com/gbroques)"
   ],
   "dependencies": {
     "boom": "^7.3.0",

--- a/src/index.js
+++ b/src/index.js
@@ -270,11 +270,12 @@ class Offline {
       disableModelValidation: false,
     };
 
-    this.options = Object.assign({}, defaultOptions, (this.service.custom || {})['serverless-offline'], this.options);
-
     // In the constructor, stage and regions are set to undefined
-    if (!this.options.stage) this.options.stage = this.service.provider.stage;
-    if (!this.options.region) this.options.region = this.service.provider.region;
+    if (this.options.stage === undefined) delete this.options.stage;
+    if (this.options.region === undefined) delete this.options.region;
+
+    const yamlOptions = (this.service.custom || {})['serverless-offline'];
+    this.options = Object.assign({}, defaultOptions, yamlOptions, this.options);
 
     // Prefix must start and end with '/'
     if (!this.options.prefix.startsWith('/')) this.options.prefix = `/${this.options.prefix}`;


### PR DESCRIPTION
Fixes a bug where `stage` will always be set to `service.provider.stage` and **ignore** the custom YAML option (`custom.serverless-offline.stage`) if provided.

The same bug existed for `region`.