### PR TITLE
Fix detection of undefined endpoint response headers

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -788,7 +788,8 @@ class Offline {
 
               if (integration === 'lambda') {
 
-                const endpointResponseHeaders = endpoint.response ? endpoint.response.headers : {};
+                const endpointResponseHeaders = (typeof endpoint.response != 'undefined'
+                  && typeof endpoint.response.headers != 'undefined') ? endpoint.response.headers : {};
 
                 Object.keys(endpointResponseHeaders)
                   .filter(key => typeof endpointResponseHeaders[key] === 'string' && /^'.*?'$/.test(endpointResponseHeaders[key]))

--- a/src/index.js
+++ b/src/index.js
@@ -788,8 +788,8 @@ class Offline {
 
               if (integration === 'lambda') {
 
-                const endpointResponseHeaders = (typeof endpoint.response != 'undefined'
-                  && typeof endpoint.response.headers != 'undefined') ? endpoint.response.headers : {};
+                const endpointResponseHeaders = (typeof endpoint.response !== 'undefined'
+                  && typeof endpoint.response.headers !== 'undefined') ? endpoint.response.headers : {};
 
                 Object.keys(endpointResponseHeaders)
                   .filter(key => typeof endpointResponseHeaders[key] === 'string' && /^'.*?'$/.test(endpointResponseHeaders[key]))


### PR DESCRIPTION
My serverless lambda responses have no headers configured which was causing this error:

```javascript
Debug: internal, implementation, error
TypeError: Uncaught error: Cannot convert undefined or null to object
at Function.keys (<anonymous>)
at createLambdaContext (/api/client/node_modules/serverless-offline/src/index.js:793:24)
at Object.fail (/api/client/node_modules/serverless-offline/src/createLambdaContext.js:17:21)
at ChildProcess.process.on.code (/api/client/node_modules/serverless-offline/src/functionHelper.js:68:19)
at ChildProcess.emit (events.js:197:13)
at ChildProcess.EventEmitter.emit (domain.js:504:23)
at maybeClose (internal/child_process.js:988:16)
at Process.ChildProcess._handle.onexit (internal/child_process.js:265:5)
```

Example Lambda:
```yaml
example_lambda:
    handler: code.handler
    events:
      - http:
          method: POST
          path: /example/lambda
          integration: lambda
          request:
            passThrough: WHEN_NO_TEMPLATES
            template:
              application/json: ''
          response:
            statusCodes: ${file(./responses.yml):statusCodes}
```

This PR fixes the check for the lack of headers configured in the response template. The check on `response.endpoint` may be unnecessary (I can remove that if that's the case).