### PR TITLE
Replace deprecated Buffer constructor call with Buffer.from.

### DIFF
--- a/src/createVelocityContext.js
+++ b/src/createVelocityContext.js
@@ -67,8 +67,8 @@ module.exports = function createVelocityContext(request, options, payload) {
       escapeJavaScript,
       urlEncode: encodeURI,
       urlDecode: x => decodeURIComponent(x.replace(/\+/g, ' ')),
-      base64Encode: x => new Buffer(x.toString(), 'binary').toString('base64'),
-      base64Decode: x => new Buffer(x.toString(), 'base64').toString('binary'),
+      base64Encode: x => Buffer.from(x.toString(), 'binary').toString('base64'),
+      base64Decode: x => Buffer.from(x.toString(), 'base64').toString('binary'),
       parseJson: JSON.parse,
     },
   };


### PR DESCRIPTION
background: https://nodejs.org/en/docs/guides/buffer-constructor-deprecation/