### PR TITLE
Add --binPath to options

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ All CLI options are optional:
 --stage                 -s  The stage used to populate your templates. Default: the first stage found in your project.
 --region                -r  The region used to populate your templates. Default: the first region for the first stage found.
 --noTimeout             -t  Disables the timeout feature.
+--binPath               -b  Path to the Serverless binary. Default: globally-installed `sls`
 --noEnvironment             Turns off loading of your environment variables from serverless.yml. Allows the usage of tools such as PM2 or docker-compose
 --resourceRoutes            Turns on loading of your HTTP proxy settings from serverless.yml
 --printOutput               Turns on logging of your lambda outputs in the terminal.

--- a/src/functionHelper.js
+++ b/src/functionHelper.js
@@ -18,7 +18,11 @@ function runProxyHandler(funOptions, options) {
 
     if (stage) args.push('-s', stage);
 
-    const process = spawn('sls', args, {
+    // Use path to binary if provided, otherwise assume globally-installed
+    const binPath = options.b || options.binPath;
+    const cmd = binPath || 'sls';
+
+    const process = spawn(cmd, args, {
       stdio: ['pipe', 'pipe', 'pipe'],
       shell: true,
       cwd: funOptions.servicePath,

--- a/src/index.js
+++ b/src/index.js
@@ -90,6 +90,10 @@ class Offline {
             usage: 'Disable the timeout feature.',
             shortcut: 't',
           },
+          binPath: {
+            usage: 'Path to the Serverless binary.',
+            shortcut: 'b',
+          },
           noEnvironment: {
             usage: 'Turns off loading of your environment variables from serverless.yml. Allows the usage of tools such as PM2 or docker-compose.',
           },


### PR DESCRIPTION
`serverless-offline` attempts to spawn a child process to run the `sls` command, which breaks if a user does not have Serverless installed globally. This pull request allows a user to optionally specify the path to their Serverless install.

Usage:

```
$ serverless offline                                  # Defaults to global install
$ serverless offline --binPath node_modules/.bin/sls  # Project install
$ serverless offline -b /usr/local/bin/sls            # Short-hand flag
```

There were not currently any tests that ensured the validity of the `spawn('sls', ...)` call, ie. changing that to `span('asdf asdf', ...)` still had passing test suite.

See https://github.com/dherault/serverless-offline/issues/645 for discussion