### PR TITLE
Fix hooks for sls offline start

### DIFF
--- a/package.json
+++ b/package.json
@@ -112,7 +112,8 @@
     "Bob Thomas (https://github.com/bob-thomas)",
     "Alessandro Palumbo (https://github.com/apalumbo)",
     "Selcuk Cihan (https://github.com/selcukcihan)",
-    "G Roques (https://github.com/gbroques)"
+    "G Roques (https://github.com/gbroques)",
+    "Dustin Belliston (https://github.com/dwbelliston)"
   ],
   "dependencies": {
     "boom": "^7.3.0",

--- a/src/index.js
+++ b/src/index.js
@@ -172,7 +172,7 @@ class Offline {
 
     return Promise.resolve(this._buildServer())
       .then(() => this._listen())
-      .then(() => this.options.exec ? this._executeShellScript() : this._listenForTermination())
+      .then(() => this.options.exec ? this._executeShellScript() : this._listenForTermination());
   }
 
   /**


### PR DESCRIPTION
The call to this.end() would terminate the process before 'offline:start:end' could be consumed by downstream plugins. When running sls offline that can be expected, but docs say that 'sls offline start' will provide the init and end hooks for other plugins to consume.

This just moves the entry points for start and the base offline commands to different functions so that this.end doesnt terminate when other plugins are expecting to run off the 'end' hook.
