### PR TITLE
Cleanup on a promise continuation when handler is async to fix #659

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -957,8 +957,10 @@ class Offline {
 
             // Finally we call the handler
             debugLog('_____ CALLING HANDLER _____');
+
+            let x;
             try {
-              const x = handler(event, lambdaContext, lambdaContext.done);
+              x = handler(event, lambdaContext, lambdaContext.done);
 
               // Promise support
               if (!this.requests[requestId].done) {
@@ -970,10 +972,13 @@ class Offline {
               return this._reply500(response, `Uncaught error in your '${funName}' handler`, error);
             }
             finally {
-              setTimeout(() => {
+              const cleanup = () => {
                 this._clearTimeout(requestId);
                 delete this.requests[requestId];
-              }, 0);
+              };
+
+              if (x && typeof x.then === 'function' && typeof x.catch === 'function') x.then(cleanup, cleanup);
+              else setTimeout(cleanup, 0);
             }
           },
         });

--- a/test/integration/offline.js
+++ b/test/integration/offline.js
@@ -546,6 +546,34 @@ describe('Offline', () => {
         done();
       });
     });
+
+    it('should support handler returning Promise that defers', done => {
+      const offline = new OfflineBuilder(new ServerlessBuilder(serverless))
+        .addFunctionHTTP('index', {
+          path: 'index',
+          method: 'GET',
+        }, () => 
+          new Promise((resolve, reject) => 
+            setTimeout(() => 
+              resolve({
+                statusCode: 200,
+                body: JSON.stringify({ message: 'Hello World' }),
+              }), 
+              10)
+            )
+        ).toObject();
+
+      offline.inject({
+        method: 'GET',
+        url: '/index',
+        payload: { data: 'input' },
+      }, res => {
+        expect(res.headers).to.have.property('content-type').which.contains('application/json');
+        expect(res.statusCode).to.eq(200);
+        expect(res.payload).to.eq('{"message":"Hello World"}');
+        done();
+      });
+    });
   });
 
   context('with HEAD support', () => {

--- a/test/integration/offline.js
+++ b/test/integration/offline.js
@@ -553,14 +553,14 @@ describe('Offline', () => {
           path: 'index',
           method: 'GET',
         }, () => 
-          new Promise((resolve, reject) => 
+          new Promise(resolve => 
             setTimeout(() => 
               resolve({
                 statusCode: 200,
                 body: JSON.stringify({ message: 'Hello World' }),
               }), 
-              10)
-            )
+            10)
+          )
         ).toObject();
 
       offline.inject({


### PR DESCRIPTION
It looks like when the lambda handler is async and defers execution, the function scheduled in the setTimeout call would clean up the requests object.  The problem is that the handler is still in flight and when it resumes execution, the request object is gone.

This fix keeps the original behavior when the handler is not created or is not a promise, but will try clean up on a promise continuation if it is a promise.  I'd like to use `.finally(cleanup)` but that isn't supported in node 8, so that's why I went with `.then(cleanup, cleanup)`.  It looks like we don't care about the resolved value, so I think that should work fine.