### PR TITLE
Call cleanup in callback and error handler instead of finally block.

### DIFF
--- a/test/integration/offline.js
+++ b/test/integration/offline.js
@@ -574,6 +574,54 @@ describe('Offline', () => {
         done();
       });
     });
+
+    it('should support handler that defers and uses done()', done => {
+      const offline = new OfflineBuilder(new ServerlessBuilder(serverless))
+        .addFunctionHTTP('index', {
+          path: 'index',
+          method: 'GET',
+        }, (request, context, cb) => 
+          setTimeout(() => 
+            cb(null, {
+              statusCode: 200,
+              body: JSON.stringify({ message: 'Hello World' }),
+            }), 
+          10)
+        ).toObject();
+
+      offline.inject({
+        method: 'GET',
+        url: '/index',
+        payload: { data: 'input' },
+      }, res => {
+        expect(res.headers).to.have.property('content-type').which.contains('application/json');
+        expect(res.statusCode).to.eq(200);
+        expect(res.payload).to.eq('{"message":"Hello World"}');
+        done();
+      });
+    });
+
+    it('should support handler that throws and uses done()', done => {
+      const offline = new OfflineBuilder(new ServerlessBuilder(serverless))
+        .addFunctionHTTP('index', {
+          path: 'index',
+          method: 'GET',
+        }, () => {
+          throw new Error('This is an error');
+        }
+        ).toObject();
+
+      offline.inject({
+        method: 'GET',
+        url: '/index',
+        payload: { data: 'input' },
+      }, res => {
+        expect(res.headers).to.have.property('content-type').which.contains('application/json');
+        expect(res.statusCode).to.eq(200);
+        done();
+      });
+    });
+
   });
 
   context('with HEAD support', () => {


### PR DESCRIPTION
This should address the second part of #659 where cleanup wasn't getting called properly for callback based requests that deferred execution.

I'm not sure what the original intent of the cleanup method was and this feels a bit like whack-a-mole. That said, all tests pass (including two new ones) and the test application linked in the issue works correctly. Speaking of tests, I have one test around error handling and I'm not sure how to suppress logging of the error to the screen while running the tests. Not sure if that matters, but it doesn't look nice.