### PR TITLE
skip HEAD routes defined in resources

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1160,6 +1160,14 @@ class Offline {
       const routeMethod = method === 'ANY' ? '*' : method;
       const routeConfig = { cors: this.options.corsConfig };
 
+      // skip HEAD routes as hapi will fail with 'Method name not allowed: HEAD ...'
+      // for more details, check https://github.com/dherault/serverless-offline/issues/204
+      if (routeMethod === 'HEAD') {
+        this.serverlessLog('HEAD method event detected. Skipping HAPI server route mapping ...');
+
+        return;
+      }
+
       if (routeMethod !== 'HEAD' && routeMethod !== 'GET') {
         routeConfig.payload = { parse: false };
       }


### PR DESCRIPTION
Related to #204 and #409 

HEAD routes defined in resources block should also be skipped (until a better solution)