### PR TITLE
Remove node.js v11.x (end-of-life) from travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,6 @@ os:
 node_js:
   - 8
   - 10
-  - 11 # node WG EOL 2019-06-01, AWS deprecation:
   - 12
 
 script:


### PR DESCRIPTION
https://github.com/nodejs/Release#nodejs-release-working-group