### PR TITLE
Fix server start handling (callback -> promise)

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1070,17 +1070,21 @@ class Offline {
   }
 
   // All done, we can listen to incomming requests
-  _listen() {
-    return new Promise((resolve, reject) => {
-      this.server.start(err => {
-        if (err) return reject(err);
+  async _listen() {
+    try {
+      await this.server.start();
+    }
+    catch (e) {
+      // TODO FIXME
+      // should we just write the error to console and exit?
+      console.error('Unexpected error in serverless-offline.', e);
+      process.exit(1);
+    }
 
-        this.printBlankLine();
-        this.serverlessLog(`Offline listening on http${this.options.httpsProtocol ? 's' : ''}://${this.options.host}:${this.options.port}`);
+    this.printBlankLine();
+    this.serverlessLog(`Offline listening on http${this.options.httpsProtocol ? 's' : ''}://${this.options.host}:${this.options.port}`);
 
-        resolve(this.server);
-      });
-    });
+    return this.server;
   }
 
   end() {

--- a/src/index.js
+++ b/src/index.js
@@ -1075,9 +1075,7 @@ class Offline {
       await this.server.start();
     }
     catch (e) {
-      // TODO FIXME
-      // should we just write the error to console and exit?
-      console.error('Unexpected error in serverless-offline.', e);
+      console.error('Unexpected error while starting serverless-offline server:', e);
       process.exit(1);
     }
 


### PR DESCRIPTION
closes: https://github.com/dherault/serverless-offline/issues/683

hapi server callback is now a promise. not quite sure about the error handling recommendation. (console.error, process.exit) previously the callback error being wrapped in a promise was not being handled down the chain as far as I could tell (might have missed it).