### PR TITLE
Add support for lambda.invoke

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ This plugin is updated by its users, I just do maintenance and ensure that PRs a
 
 * [Installation](#installation)
 * [Usage and command line options](#usage-and-command-line-options)
+* [Usage with invoke](#usage-with-invoke)
 * [Token authorizers](#token-authorizers)
 * [Custom authorizers](#custom-authorizers)
 * [Remote authorizers](#remote-authorizers)
@@ -118,6 +119,31 @@ By default you can send your requests to `http://localhost:3000/`. Please note t
 * When no Content-Type header is set on a request, API Gateway defaults to `application/json`, and so does the plugin.
   But if you send an `application/x-www-form-urlencoded` or a `multipart/form-data` body with an `application/json` (or no) Content-Type, API Gateway won't parse your data (you'll get the ugly raw as input), whereas the plugin will answer 400 (malformed JSON).
   Please consider explicitly setting your requests' Content-Type and using separate templates.
+
+## Usage with `invoke`
+
+To use `AWS.invoke` you need to set the lambda `endpoint` to the serverless endpoint:
+
+```js
+const lambda = new AWS.Lambda({
+  apiVersion: '2015-03-31',
+  region: 'us-east-1',
+  endpoint: process.env.IS_OFFLINE ? 'http://localhost:3000' : null,
+})
+```
+
+All your lambdas can then be invoked in a handler using
+
+```js
+const builderLambdaParameters = {
+  FunctionName: 'my-service-stage-function',
+  InvocationType: 'Event',
+  LogType: 'None',
+  Payload: JSON.stringify({ data: 'foo' }),
+}
+
+lambda.invoke(builderLambdaParameters).send()
+```
 
 ## Token authorizers
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "serverless-offline",
-  "version": "5.1.0",
+  "version": "5.2.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/index.js
+++ b/src/index.js
@@ -460,6 +460,7 @@ class Offline {
       });
       // Adds a route for each http endpoint
       fun.events.forEach(event => {
+        if (!event.http) return;
 
         // Handle Simple http setup, ex. - http: GET users/index
         if (typeof event.http === 'string') {

--- a/src/index.js
+++ b/src/index.js
@@ -436,10 +436,30 @@ class Offline {
       debugLog(funName, 'runtime', serviceRuntime);
       this.serverlessLog(`Routes for ${funName}:`);
 
+      // Add proxy for lamda invoke
+      fun.events.push({
+        http: {
+          method: 'POST',
+          path: `{apiVersion}/functions/${fun.name}/invocations`,
+          integration: 'lambda',
+          request: {
+            template: {
+              // AWS SDK for NodeJS specifies as 'binary/octet-stream' not 'application/json'
+              'binary/octet-stream': JSON.stringify({
+                body: '$input.body',
+                targetHandler: fun.handler,
+              }),
+            },
+          },
+          response: {
+            headers: {
+              'Content-Type': 'application/json',
+            },
+          },
+        },
+      });
       // Adds a route for each http endpoint
-      // eslint-disable-next-line
-      (fun.events && fun.events.length || this.serverlessLog('(none)')) && fun.events.forEach(event => {
-        if (!event.http) return this.serverlessLog('(none)');
+      fun.events.forEach(event => {
 
         // Handle Simple http setup, ex. - http: GET users/index
         if (typeof event.http === 'string') {


### PR DESCRIPTION
## 🐭 Problem
Their was no way to invoke lambdas locally.
```
const builderLambdaParameters = {
      FunctionName: 'vidiff-services-dev-builder',
      InvocationType: 'Event',
      LogType: 'None',
      Payload: JSON.stringify({ buildId: build._id }),
}

await lambda.invoke(builderLambdaParameters).promise()
```

## 🐱 Solution
Add a new route for each handler to support `lambda.invoke`:
```
Serverless: Starting Offline: dev/eu-west-3.

Serverless: Routes for graphql:
Serverless: POST /graphql
Serverless: POST /{apiVersion}/functions/vidiff-services-dev-graphql/invocations

Serverless: Routes for builder: (NOTE: this route has no event)
Serverless: POST /{apiVersion}/functions/vidiff-services-dev-builder/invocations

Serverless: Offline listening on http://localhost:3111
```
And use `aws-sdk` like this:
```js
const lambda = new AWS.Lambda({
  apiVersion: '2015-03-31',
  region: 'eu-west-3',
  endpoint: process.env.IS_OFFLINE ? 'http://localhost:3111' : null,
})
```

## Remarks

Inspired by:
https://github.com/civicteam/serverless-offline-direct-lambda
https://github.com/ned-kelly/serverless-offline-direct-lambda
https://github.com/tylerzey/serverless-offline-direct-lambda
