### PR TITLE
Reading headers defined on the proxy

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1233,7 +1233,7 @@ class Offline {
     this.serverlessLog('Routes defined in resources:');
 
     Object.entries(resourceRoutes).forEach(([methodId, resourceRoutesObj]) => {
-      const { isProxy, method, path, pathResource, proxyUri } = resourceRoutesObj;
+      const { isProxy, method, path, pathResource, proxyUri, proxyHeaders } = resourceRoutesObj;
 
       if (!isProxy) {
         return this.serverlessLog(`WARNING: Only HTTP_PROXY is supported. Path '${pathResource}' is ignored.`);
@@ -1259,9 +1259,7 @@ class Offline {
       // skip HEAD routes as hapi will fail with 'Method name not allowed: HEAD ...'
       // for more details, check https://github.com/dherault/serverless-offline/issues/204
       if (routeMethod === 'HEAD') {
-        this.serverlessLog('HEAD method event detected. Skipping HAPI server route mapping ...');
-
-        return;
+        return this.serverlessLog('HEAD method event detected. Skipping HAPI server route mapping ...');
       }
 
       if (routeMethod !== 'HEAD' && routeMethod !== 'GET') {
@@ -1276,6 +1274,9 @@ class Offline {
         handler: (request, h) => {
           const { params } = request;
           let resultUri = proxyUriInUse;
+          
+          // Merge the header defined in the serverless with the ones informed by the request
+          Object.assign(request.headers, proxyHeaders);
 
           Object.entries(params).forEach(([key, value]) => {
             resultUri = resultUri.replace(`{${key}}`, value);

--- a/src/parseResources.js
+++ b/src/parseResources.js
@@ -139,7 +139,7 @@ function constructHapiInterface(pathObjects, methodObjects, methodId) {
   const method = getHttpMethod(methodObj);
   // let integrationType;
   let proxyUri;
-  let proxyHeaders = {};
+  const proxyHeaders = {};
 
   if (!pathResource) return {};
 
@@ -149,10 +149,10 @@ function constructHapiInterface(pathObjects, methodObjects, methodId) {
     proxyUri = Integration.Uri;
     // Pulling the header defined in the serverless middleware
     // https://docs.aws.amazon.com/apigateway/latest/developerguide/request-response-data-mappings.html
-    if (Integration.RequestParameters){
-      Object.keys(Integration.RequestParameters).forEach((key)=>{
-        if (Integration.RequestParameters[key] && key.indexOf && key.indexOf('integration.request.header.')> -1){
-          proxyHeaders[key.replace('integration.request.header.','')] = Integration.RequestParameters[key];
+    if (Integration.RequestParameters) {
+      Object.keys(Integration.RequestParameters).forEach(key => {
+        if (Integration.RequestParameters[key] && key.indexOf && key.indexOf('integration.request.header.') > -1) {
+          proxyHeaders[key.replace('integration.request.header.', '')] = Integration.RequestParameters[key];
         }
       });
     }

--- a/src/parseResources.js
+++ b/src/parseResources.js
@@ -152,7 +152,9 @@ function constructHapiInterface(pathObjects, methodObjects, methodId) {
     if (Integration.RequestParameters) {
       Object.keys(Integration.RequestParameters).forEach(key => {
         if (Integration.RequestParameters[key] && key.indexOf && key.indexOf('integration.request.header.') > -1) {
-          proxyHeaders[key.replace('integration.request.header.', '')] = Integration.RequestParameters[key];
+          // slice due to
+          // https://docs.aws.amazon.com/apigateway/latest/developerguide/request-response-data-mappings.html
+          proxyHeaders[key.replace('integration.request.header.', '')] = Integration.RequestParameters[key].slice(1, -1);
         }
       });
     }

--- a/src/parseResources.js
+++ b/src/parseResources.js
@@ -139,6 +139,7 @@ function constructHapiInterface(pathObjects, methodObjects, methodId) {
   const method = getHttpMethod(methodObj);
   // let integrationType;
   let proxyUri;
+  let proxyHeaders = {};
 
   if (!pathResource) return {};
 
@@ -146,6 +147,15 @@ function constructHapiInterface(pathObjects, methodObjects, methodId) {
 
   if (Integration.Type === APIGATEWAY_INTEGRATION_TYPE_HTTP_PROXY) {
     proxyUri = Integration.Uri;
+    // Pulling the header defined in the serverless middleware
+    // https://docs.aws.amazon.com/apigateway/latest/developerguide/request-response-data-mappings.html
+    if (Integration.RequestParameters){
+      Object.keys(Integration.RequestParameters).forEach((key)=>{
+        if (Integration.RequestParameters[key] && key.indexOf && key.indexOf('integration.request.header.')> -1){
+          proxyHeaders[key.replace('integration.request.header.','')] = Integration.RequestParameters[key];
+        }
+      });
+    }
   }
 
   return {
@@ -154,6 +164,7 @@ function constructHapiInterface(pathObjects, methodObjects, methodId) {
     isProxy: !!proxyUri,
     proxyUri,
     pathResource,
+    proxyHeaders,
   };
 }
 


### PR DESCRIPTION
Since it is possible to define extra headers on the Serverless proxy configuration level, this function will format those headers into an object. One example, is a header used to call a third party API, but we want it to be defined in the Serverless API only, hence not exposed in the Front End request.