### PR TITLE
Add DELETE route to close a websocket connection

### DIFF
--- a/src/ApiGatewayWebSocket.js
+++ b/src/ApiGatewayWebSocket.js
@@ -248,6 +248,33 @@ module.exports = class ApiGatewayWebSocket {
         return '';
       },
     });
+
+    this.wsServer.route({
+      method: 'DELETE',
+      path: '/@connections/{connectionId}',
+      config: { payload: { parse: false } },
+      handler: (request, h) => {
+        debugLog(`got DELETE to ${request.url}`);
+
+        const getByConnectionId = (map, searchValue) => {
+          for (const [key, connection] of map.entries()) {
+            if (connection.connectionId === searchValue) return key;
+          }
+
+          return undefined;
+        };
+
+        const ws = getByConnectionId(this.clients, request.params.connectionId);
+
+        if (!ws) return h.response().code(410);
+
+        ws.close();
+
+        debugLog(`closed connection:${request.params.connectionId}`);
+
+        return '';
+      },
+    });
   }
 
   _createWsAction(fun, funName, servicePath, funOptions, event) {

--- a/src/ApiGatewayWebSocket.js
+++ b/src/ApiGatewayWebSocket.js
@@ -24,6 +24,10 @@ module.exports = class ApiGatewayWebSocket {
     this.websocketsApiRouteSelectionExpression = serverless.service.provider.websocketsApiRouteSelectionExpression || '$request.body.action';
   }
 
+  printBlankLine() {
+    console.log();
+  }
+
   _createWebSocket() {
     // start COPY PASTE FROM HTTP SERVER CODE
     const serverOptions = {


### PR DESCRIPTION
As mentioned [here](https://github.com/dherault/serverless-offline/pull/711#issuecomment-507386379), the websocket implementation is missing a way to close the websocket from the server using the @connections URLs. This merge requests adds that feature.

To close a websocket, as per AWS (very scarce) documentation, call `DELETE http://<websocket_host>/@connections/<connectionId>`