### PR TITLE
close connection on error in $connect action handler

### DIFF
--- a/src/ApiGatewayWebSocket.js
+++ b/src/ApiGatewayWebSocket.js
@@ -94,6 +94,11 @@ module.exports = class ApiGatewayWebSocket {
           ws.send(JSON.stringify({ message:'Internal server error', connectionId, requestId:'1234567890' }));
         }
 
+        // mimic AWS behaviour (close connection) when the $connect action handler throws
+        if (name === '$connect') {
+          ws.close();
+        }
+
         debugLog(`Error in handler of action ${action}`, err);
       };
 


### PR DESCRIPTION
If an error occurs in the $connect action handler, AWS does not let the connection be established. In order to mimic that behaviour, let's close the connection if the $connect handler throws.

see https://github.com/dherault/serverless-offline/pull/711#issuecomment-506977431