### PR TITLE
fix: missing base in URL() constructor

### DIFF
--- a/src/ApiGatewayWebSocket.js
+++ b/src/ApiGatewayWebSocket.js
@@ -171,7 +171,7 @@ module.exports = class ApiGatewayWebSocket {
             only: true,
             initially: false,
             connect: ({ ws, req }) => {
-              const { searchParams } = new URL(req.url);
+              const { searchParams } = new URL(req.url, `ws://${req.headers.host}`);
               const queryStringParameters = parseQueryStringParameters(
                 searchParams,
               );


### PR DESCRIPTION
As `req.url` only contains the relative URL, the [base URL parameter](https://nodejs.org/api/url.html#url_constructor_new_url_input_base) (or absolute input URL, either of those must be given) was missing from the `new URL(req.url)` call, which causes a crash on $connect action as it is unable to parse the query string parameters and throws with ERR_INVALID_URL.