### PR TITLE
Allow for empty corsExposedHeaders

### DIFF
--- a/src/ServerlessOffline.js
+++ b/src/ServerlessOffline.js
@@ -320,7 +320,8 @@ module.exports = class ServerlessOffline {
       .split(',');
     this.options.corsExposedHeaders = this.options.corsExposedHeaders
       .replace(/\s/g, '')
-      .split(',');
+      .split(',')
+      .filter(header => header !== '');
 
     if (this.options.corsDisallowCredentials)
       this.options.corsAllowCredentials = false;


### PR DESCRIPTION
Upgrading from `v4` to `v5` broke a lot of my tests regarding `cors` due to the upgrade to `hapi@18`. For some reason now, there are `corsExposedHeaders` set by default. Maybe an empty string, or empty array should be the default? I don't see why `serverless-offline` should have a an opinion on which headers should be exposed by default.
Another problem that I didn't address here is that now, returning `access-control-allow-origin` headers from a lambda gets ignored, and overwritten by `hapi` into `access-control-allow-origin: event.headers.Origin`, while before the headers returned by the lambda would get respected.