### PR TITLE
feat: add go to supported runtimes

### DIFF
--- a/src/ServerlessOffline.js
+++ b/src/ServerlessOffline.js
@@ -380,7 +380,8 @@ module.exports = class ServerlessOffline {
       !(
         serviceRuntime.startsWith('nodejs') ||
         serviceRuntime.startsWith('python') ||
-        serviceRuntime.startsWith('ruby')
+        serviceRuntime.startsWith('ruby') ||
+        serviceRuntime.startsWith('go')
       )
     ) {
       this.printBlankLine();


### PR DESCRIPTION
Disclaimer: this is copy/pasted from [steve-winter/serverless-offline](https://github.com/steve-winter/serverless-offline/pull/1) which seems to be accidentally be created against his own master branch.

This PR adds golang to the supported runtimes.

I've tested it via 

```
npm i --save phux/serverless-offline#go_serviceruntime
```

And it seems to work fine.