### PR TITLE
Do not remove unhandledRejection listeners as it breaks Serverless

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,7 +1,3 @@
 'use strict';
 
 module.exports = require('./ServerlessOffline.js');
-
-// Serverless exits with code 1 when a promise rejection is unhandled. Not AWS.
-// Users can still use their own unhandledRejection event though.
-process.removeAllListeners('unhandledRejection');


### PR DESCRIPTION
Removing `unhandledRejection` listener currently breaks exit code handling in Serverless 1.48.1+ -> https://github.com/serverless/serverless/issues/6441, it technically turns off some important part of Serverless logic.

Serverless no longer forces process exit on `unhandledRejection`, so merging this in won't introduce a regression to #255 (which also should rather have been processed in context of `serverless` repo, not here)

--- 

In future Serverless may force process exit on `unhandledRejection` but only if there were no listeners registered for it, which is on pair with Node.js deprecation warning:

```
[DEP0018] DeprecationWarning: Unhandled promise rejections are deprecated. In the future, promise rejections that are not handled will terminate the Node.js process with a non-zero exit code.
```


