### PR TITLE
feat: add authorizer enhanced context

### DIFF
--- a/src/config/offline-default.req.vm
+++ b/src/config/offline-default.req.vm
@@ -11,14 +11,27 @@
   "body": $input.json("$"),
   "method": "$context.httpMethod",
   "principalId": "$context.authorizer.principalId",
+  #set( $map = $context.authorizer )
+  ## see https://github.com/serverless/serverless/issues/4374
+  "enhancedAuthContext": {
+    #foreach($key in $map.keySet())
+      ## The claims are not part of the enhancedAuthContext in serverless and should be excluded.
+      ## However it is more practical to set this property to null as defined in
+      ## https://docs.aws.amazon.com/apigateway/latest/developerguide/api-gateway-mapping-template-reference.html#context-variable-reference
+      #if($key == "claims")
+      "$key": null
+      #else
+      "$key": "$util.escapeJavaScript($map.get($key))"
+      #end
+      #if($foreach.hasNext),#end
+    #end
+  },
   #set( $map = $input.params().header )
   "headers": $loop,
   #set( $map = $input.params().querystring )
   "query": $loop,
   #set( $map = $input.params().path )
   "path": $loop,
-  #set( $map = $context.enhancedAuthContext )
-  "enhancedAuthContext": $loop,
   #set( $map = $context.identity )
   "identity": $loop,
   #set( $map = $stageVariables )

--- a/src/config/offline-default.req.vm
+++ b/src/config/offline-default.req.vm
@@ -17,6 +17,8 @@
   "query": $loop,
   #set( $map = $input.params().path )
   "path": $loop,
+  #set( $map = $context.enhancedAuthContext )
+  "enhancedAuthContext": $loop,
   #set( $map = $context.identity )
   "identity": $loop,
   #set( $map = $stageVariables )

--- a/src/config/offline-default.req.vm
+++ b/src/config/offline-default.req.vm
@@ -11,6 +11,10 @@
   "body": $input.json("$"),
   "method": "$context.httpMethod",
   "principalId": "$context.authorizer.principalId",
+  "stage": "$context.stage",
+  "cognitoPoolClaims" : {
+      "sub": "$context.authorizer.claims.sub"
+  },
   #set( $map = $context.authorizer )
   ## see https://github.com/serverless/serverless/issues/4374
   "enhancedAuthContext": {
@@ -35,5 +39,6 @@
   #set( $map = $context.identity )
   "identity": $loop,
   #set( $map = $stageVariables )
-  "stageVariables": $loop
+  "stageVariables": $loop,
+  "requestPath": "$context.resourcePath"
 }

--- a/src/createAuthScheme.js
+++ b/src/createAuthScheme.js
@@ -221,7 +221,7 @@ module.exports = function createAuthScheme(
                 `Authorization function returned a successful response: (λ: ${authFunName})`,
               );
 
-              const enhancedAuthContext = {
+              const authorizer = {
                 principalId: policy.principalId,
                 integrationLatency: '42',
                 ...policy.context,
@@ -233,8 +233,8 @@ module.exports = function createAuthScheme(
                   credentials: {
                     context: policy.context,
                     usageIdentifierKey: policy.usageIdentifierKey,
-                    enhancedAuthContext,
                     principalId: policy.principalId,
+                    authorizer,
                   },
                 }),
               );

--- a/src/createAuthScheme.js
+++ b/src/createAuthScheme.js
@@ -233,8 +233,8 @@ module.exports = function createAuthScheme(
                   credentials: {
                     context: policy.context,
                     usageIdentifierKey: policy.usageIdentifierKey,
-                    user: policy.principalId,
                     enhancedAuthContext,
+                    principalId: policy.principalId,
                   },
                 }),
               );

--- a/src/createAuthScheme.js
+++ b/src/createAuthScheme.js
@@ -217,8 +217,7 @@ module.exports = function createAuthScheme(
 
               serverlessLog(
                 `Authorization function returned a successful response: (λ: ${authFunName})`,
-                policy,
-              );
+              )
 
               // Set the credentials for the rest of the pipeline
               return resolve(
@@ -229,7 +228,7 @@ module.exports = function createAuthScheme(
                     user: policy.principalId,
                   },
                 }),
-              );
+              )
             };
 
             if (result && typeof result.then === 'function') {

--- a/src/createAuthScheme.js
+++ b/src/createAuthScheme.js
@@ -132,6 +132,8 @@ module.exports = function createAuthScheme(
 
       event.methodArn = `arn:aws:execute-api:${options.region}:${accountId}:${apiId}/${options.stage}/${httpMethod}${resourcePath}`;
 
+      event.enhancedAuthContext = {};
+
       event.requestContext = {
         accountId,
         apiId,
@@ -217,7 +219,13 @@ module.exports = function createAuthScheme(
 
               serverlessLog(
                 `Authorization function returned a successful response: (λ: ${authFunName})`,
-              )
+              );
+
+              const enhancedAuthContext = {
+                principalId: policy.principalId,
+                integrationLatency: '42',
+                ...policy.context,
+              };
 
               // Set the credentials for the rest of the pipeline
               return resolve(
@@ -226,9 +234,10 @@ module.exports = function createAuthScheme(
                     context: policy.context,
                     usageIdentifierKey: policy.usageIdentifierKey,
                     user: policy.principalId,
+                    enhancedAuthContext,
                   },
                 }),
-              )
+              );
             };
 
             if (result && typeof result.then === 'function') {

--- a/src/createLambdaProxyEvent.js
+++ b/src/createLambdaProxyEvent.js
@@ -18,7 +18,7 @@ module.exports = function createLambdaProxyEvent(
   stageVariables,
 ) {
   const authPrincipalId =
-    request.auth && request.auth.credentials && request.auth.credentials.user;
+    request.auth && request.auth.credentials && request.auth.credentials.principalId;
   const authContext =
     (request.auth &&
       request.auth.credentials &&

--- a/src/createVelocityContext.js
+++ b/src/createVelocityContext.js
@@ -26,12 +26,11 @@ function escapeJavaScript(x) {
 */
 module.exports = function createVelocityContext(request, options, payload) {
   const path = (x) => jsonPath(payload || {}, x);
-  const authPrincipalId =
-    request.auth && request.auth.credentials && request.auth.credentials.user;
   const enhancedAuthContext =
     request.auth &&
     request.auth.credentials &&
     request.auth.credentials.enhancedAuthContext;
+  const authPrincipalId = request.auth && request.auth.credentials && request.auth.credentials.principalId;
   const headers = request.unprocessedHeaders;
 
   let token = headers && (headers.Authorization || headers.authorization);

--- a/src/createVelocityContext.js
+++ b/src/createVelocityContext.js
@@ -28,6 +28,10 @@ module.exports = function createVelocityContext(request, options, payload) {
   const path = (x) => jsonPath(payload || {}, x);
   const authPrincipalId =
     request.auth && request.auth.credentials && request.auth.credentials.user;
+  const enhancedAuthContext =
+    request.auth &&
+    request.auth.credentials &&
+    request.auth.credentials.enhancedAuthContext;
   const headers = request.unprocessedHeaders;
 
   let token = headers && (headers.Authorization || headers.authorization);
@@ -56,6 +60,7 @@ module.exports = function createVelocityContext(request, options, payload) {
           'offlineContext_authorizer_principalId', // See #24
         claims,
       },
+      enhancedAuthContext: enhancedAuthContext || {},
       httpMethod: request.method.toUpperCase(),
       identity: {
         accountId: 'offlineContext_accountId',
@@ -82,10 +87,10 @@ module.exports = function createVelocityContext(request, options, payload) {
         typeof x === 'string'
           ? request.params[x] || request.query[x] || headers[x]
           : {
-              header: headers,
-              path: Object.assign({}, request.params),
-              querystring: Object.assign({}, request.query),
-            },
+            header: headers,
+            path: Object.assign({}, request.params),
+            querystring: Object.assign({}, request.query),
+          },
     },
     stageVariables: options.stageVariables,
     util: {


### PR DESCRIPTION
Serverless has this (not very-well documented) feature that passes lambda authorizer context data into the subsequent lambda execution event as `enhancedAuthContext`.

See https://github.com/serverless/serverless/issues/4374 for more info about this feature.

This is the type of event available in live environments, that serverless-offline currently does not support:

```
{
  "event": {
    "body": {},
    "method": "GET",
    "principalId": "150efb8b-5e2d-4cdd-88a5-5e1c74d06861",
    "stage": "dev",
    "cognitoPoolClaims": {
      "sub": ""
    },
    "enhancedAuthContext": {
      "principalId": "150efb8b-5e2d-4cdd-88a5-5e1c74d06861",
      "integrationLatency": "583",
      "somekey": "xxxxx"
    },
    "headers": { ... },
    "query": {},
    "path": {},
    "identity": { ... },
    "stageVariables": {},
    "requestPath": "/"
  }
}
```

This PR adds the enhancedAuthContext property to all calls (as with serverless by default), and populates it with the context built in custom authorizers.