### PR TITLE
UpdateJSON response detection from stdout in local invocations

### DIFF
--- a/src/handler-runner/ServerlessInvokeLocalRunner.js
+++ b/src/handler-runner/ServerlessInvokeLocalRunner.js
@@ -39,36 +39,38 @@ module.exports = class ServerlessInvokeLocalRunner {
     subprocess.stdin.write(`${stringify(event)}\n`)
     subprocess.stdin.end()
 
+    const newlineRegex = /\r?\n|\r/g
+    const proxyResponseRegex = /{[\r\n]?\s*('|")isBase64Encoded('|")|{[\r\n]?\s*('|")statusCode('|")|{[\r\n]?\s*('|")headers('|")|{[\r\n]?\s*('|")body('|")|{[\r\n]?\s*('|")principalId('|")/
+
     let results = ''
     let hasDetectedJson = false
 
     subprocess.stdout.on('data', (data) => {
-      let str = data.toString('utf8')
-
+      let str = data.toString('utf-8')
+      // Search for the start of the JSON result
+      // https://docs.aws.amazon.com/apigateway/latest/developerguide/set-up-lambda-proxy-integrations.html#api-gateway-simple-proxy-for-lambda-output-format
+      const match = proxyResponseRegex.exec(str)
+      if (match && match.index > -1) {
+        // If we see a JSON result that looks like it could be a Lambda Proxy response,
+        // we want to start treating the console output like it is the actual response.
+        hasDetectedJson = true
+        // Here we overwrite the existing reults. The last JSON match is the only one we want
+        // to ensure that we don't accidentally start writing the results just because the
+        // lambda program itself printed something that matched the regex string. The last match is
+        // the correct one because it comes from sls invoke local after the lambda code fully executes.
+        results = trimNewlines(str.slice(match.index))
+        str = str.slice(0, match.index)
+      }
       if (hasDetectedJson) {
         // Assumes that all data after matching the start of the
         // JSON result is the rest of the context result.
         results += trimNewlines(str)
-      } else {
-        // Search for the start of the JSON result
-        // https://docs.aws.amazon.com/apigateway/latest/developerguide/set-up-lambda-proxy-integrations.html#api-gateway-simple-proxy-for-lambda-output-format
-        const match = /{[\r\n]?\s*"isBase64Encoded"|{[\r\n]?\s*"statusCode"|{[\r\n]?\s*"headers"|{[\r\n]?\s*"body"|{[\r\n]?\s*"principalId"/.exec(
-          str,
-        )
-
-        if (match && match.index > -1) {
-          // The JSON result was in this chunk so slice it out
-          hasDetectedJson = true
-          results += trimNewlines(str.slice(match.index))
-          str = str.slice(0, match.index)
-        }
-
-        if (str.length > 0) {
-          // The data does not look like JSON and we have not
-          // detected the start of JSON, so write the
-          // output to the console instead.
-          console.log('Proxy Handler could not detect JSON:', str)
-        }
+      }
+      if (str.length > 0) {
+        // The data does not look like JSON and we have not
+        // detected the start of JSON, so write the
+        // output to the console instead.
+        console.log('Proxy Handler could not detect JSON:', str)
       }
     })
 
@@ -79,7 +81,21 @@ module.exports = class ServerlessInvokeLocalRunner {
     subprocess.on('close', (code) => {
       if (code.toString() === '0') {
         try {
-          context.succeed(parse(results))
+          // This is a bit of an odd one. It looks like _process.stdout is chunking
+          // data to the max buffer size (in my case, 65536) and adding newlines
+          // between chunks.
+          //
+          // In my specific case, I was returning images encoded in the JSON response,
+          // and these newlines were occuring at regular intervals (every 65536 chars)
+          // and corrupting the response JSON. Not sure if this is the best way for
+          // a general solution, but it fixed it in my case.
+          //
+          // Upside is that it will handle large JSON payloads correctly,
+          // downside is that it will strip out any newlines that were supposed
+          // to be in the response data.
+          //
+          // Open to comments about better ways of doing this!
+          context.succeed(parse(results.replace(newlineRegex, '')))
         } catch (ex) {
           context.fail(results)
         }

--- a/src/handler-runner/ServerlessInvokeLocalRunner.js
+++ b/src/handler-runner/ServerlessInvokeLocalRunner.js
@@ -40,7 +40,7 @@ module.exports = class ServerlessInvokeLocalRunner {
     subprocess.stdin.end()
 
     const newlineRegex = /\r?\n|\r/g
-    const proxyResponseRegex = /{[\r\n]?\s*('|")isBase64Encoded('|")|{[\r\n]?\s*('|")statusCode('|")|{[\r\n]?\s*('|")headers('|")|{[\r\n]?\s*('|")body('|")|{[\r\n]?\s*('|")principalId('|")/
+    const proxyResponseRegex = /{[\r\n]?\s*(['"])isBase64Encoded(['"])|{[\r\n]?\s*(['"])statusCode(['"])|{[\r\n]?\s*(['"])headers(['"])|{[\r\n]?\s*(['"])body(['"])|{[\r\n]?\s*(['"])principalId(['"])/
 
     let results = ''
     let hasDetectedJson = false
@@ -60,8 +60,7 @@ module.exports = class ServerlessInvokeLocalRunner {
         // the correct one because it comes from sls invoke local after the lambda code fully executes.
         results = trimNewlines(str.slice(match.index))
         str = str.slice(0, match.index)
-      }
-      if (hasDetectedJson) {
+      } else if (hasDetectedJson) {
         // Assumes that all data after matching the start of the
         // JSON result is the rest of the context result.
         results += trimNewlines(str)
@@ -86,7 +85,7 @@ module.exports = class ServerlessInvokeLocalRunner {
           // between chunks.
           //
           // In my specific case, I was returning images encoded in the JSON response,
-          // and these newlines were occuring at regular intervals (every 65536 chars)
+          // and these newlines were occurring at regular intervals (every 65536 chars)
           // and corrupting the response JSON. Not sure if this is the best way for
           // a general solution, but it fixed it in my case.
           //


### PR DESCRIPTION
Two issues covered here:

**Incorrect treatment of prints as responses**
The previous JSON detection assumed that there would be one and only one valid JSON object printed to `stdout` from the process. If you printed something that looked like the response, it would often throw bad JSON exceptions and fail the invocation.

An example:
```python
def my_handler(event, context):
    my_response = { "statusCode": 200, "body": "hi" }
    print(my_response)
    print("hello!")
    return my_response
```
would end up failing while attempting to parse the following results string:
```
'{ "statusCode": 200, "body": "hi" }hello!{ "statusCode": 200, "body": "hi" }'
```

**Extra newlines in large responses**
Less clarity here... looks like it has something to do with buffer chunking? In any case, I was getting corrupted JSON when newlines were inserted into the buffer at regular intervals (which corresponded exactly with buffer chunk length). I fixed it by replacing all newlines at the very end. A little hacky, and would love some input of better ways to fix it (or if I'm the only one who's had it happen)