### PR TITLE
Add another style of policyResource

### DIFF
--- a/src/api-gateway/authMatchPolicyResource.js
+++ b/src/api-gateway/authMatchPolicyResource.js
@@ -20,6 +20,10 @@ export default function authMatchPolicyResource(policyResource, resource) {
     // better fix for #523
     return true
   }
+  
+  if (policyResource === 'arn:aws:execute-api:*:*:*') {
+    return true
+  }
 
   if (policyResource.includes('*') || policyResource.includes('?')) {
     // Policy contains a wildcard resource

--- a/src/api-gateway/authMatchPolicyResource.js
+++ b/src/api-gateway/authMatchPolicyResource.js
@@ -20,7 +20,7 @@ export default function authMatchPolicyResource(policyResource, resource) {
     // better fix for #523
     return true
   }
-  
+
   if (policyResource === 'arn:aws:execute-api:*:*:*') {
     return true
   }


### PR DESCRIPTION
We are using a resource policy("`arn:aws:execute-api:*:*:*`") that works fine on aws but not when using serverless, this took some time to figure out. Could we add it?

Image of aws documentation where this structure is used:
https://imgur.com/iQX17pt.png