### PR TITLE
[docs] Improve command to test installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ plugins:
 
 You can check wether you have successfully installed the plugin by running the serverless command line:
 
-`serverless`
+`serverless --verbose`
 
 the console should display _Offline_ as one of the plugins now available in your Serverless project.
 

--- a/package.json
+++ b/package.json
@@ -133,7 +133,8 @@
     "Trevor Leach (https://github.com/trevor-leach)",
     "Tuan Minh Huynh (https://github.com/tuanmh)",
     "Utku Turunc (https://github.com/utkuturunc)",
-    "Vasiliy Solovey (https://github.com/miltador)"
+    "Vasiliy Solovey (https://github.com/miltador)",
+    "Dima Krutolianov (https://github.com/dimadk24)"
   ],
   "engines": {
     "node": ">=8.10.0"


### PR DESCRIPTION
Just running `serverless` doesn't show plugins. You need to run it with `--verbose` to view plugins.