### PR TITLE
fix 'forEach' rejection

### DIFF
--- a/src/ServerlessOffline.js
+++ b/src/ServerlessOffline.js
@@ -288,7 +288,7 @@ export default class ServerlessOffline {
 
       lambdas.push({ functionKey, functionDefinition })
 
-      const events = service.getAllEventsInFunction(functionKey)
+      const events = service.getAllEventsInFunction(functionKey) || []
 
       events.forEach((event) => {
         const { http, schedule, websocket } = event


### PR DESCRIPTION
Was getting a weird error when trying to start serverless-offline. This change fixed the issue for me
```
UnhandledPromiseRejectionWarning: TypeError: Cannot read property 'forEach' of undefined
    at functionKeys.forEach (/workspace/boosterbox/node_modules/serverless-offline/src/ServerlessOffline.ts:319:14)
    at Array.forEach (<anonymous>)
    at ServerlessOffline._getEvents (/workspace/boosterbox/node_modules/serverless-offline/src/ServerlessOffline.ts:310:18)    at ServerlessOffline.start (/workspace/boosterbox/node_modules/serverless-offline/src/ServerlessOffline.ts:86:14)
    at Promise.all.services.map (/workspace/boosterbox/node_modules/environment/index.js:111:29)
```