### PR TITLE
Add `host.docker.internal` DNS name to container on linux

### DIFF
--- a/tests/integration/docker/access-host/accessHost.test.js
+++ b/tests/integration/docker/access-host/accessHost.test.js
@@ -1,4 +1,3 @@
-import { platform } from 'os'
 import { resolve } from 'path'
 import { Server } from '@hapi/hapi'
 import fetch from 'node-fetch'
@@ -27,7 +26,6 @@ _describe('Access host with Docker tests', () => {
 
     return setup({
       servicePath: resolve(__dirname),
-      args: ['--host-os', platform()],
     })
   })
 

--- a/tests/integration/docker/access-host/serverless.yml
+++ b/tests/integration/docker/access-host/serverless.yml
@@ -10,8 +10,6 @@ provider:
   runtime: nodejs12.x
   stage: dev
   versionFunctions: false
-  environment:
-    HOST_OS: ${opt:host-os}
 
 custom:
   serverless-offline:

--- a/tests/integration/docker/access-host/src/handler.js
+++ b/tests/integration/docker/access-host/src/handler.js
@@ -5,12 +5,7 @@ const fetch = require('node-fetch')
 const { stringify } = JSON
 
 module.exports.hello = async () => {
-  let host
-  if (process.env.HOST_OS === 'linux') {
-    host = 'localhost'
-  } else {
-    host = 'host.docker.internal'
-  }
+  const host = 'host.docker.internal'
 
   const response = await fetch(`http://${host}:8080/hello`)
   const text = await response.text()


### PR DESCRIPTION
fixes #858

- stop using host networking mode on linux
- add `host.docker.internal` DNS name  on linux to access host service from inside the container