### PR TITLE
Also support `--disableCookieValidation` when we `_createResourceRoutes`.

### DIFF
--- a/src/ApiGateway.js
+++ b/src/ApiGateway.js
@@ -1063,8 +1063,21 @@ module.exports = class ApiGateway {
         );
       }
 
+      const state = this.options.disableCookieValidation
+        ? {
+          failAction: 'ignore',
+          parse: false,
+        }
+        : {
+          failAction: 'error',
+          parse: true,
+        };
+
       const routeMethod = method === 'ANY' ? '*' : method;
-      const routeConfig = { cors: this.options.corsConfig };
+      const routeConfig = {
+        cors: this.options.corsConfig,
+        state,
+      };
 
       // skip HEAD routes as hapi will fail with 'Method name not allowed: HEAD ...'
       // for more details, check https://github.com/dherault/serverless-offline/issues/204

--- a/src/__tests__/integration/offline.js
+++ b/src/__tests__/integration/offline.js
@@ -1130,5 +1130,60 @@ describe('Offline', () => {
 
       expect(result.queryString).toHaveProperty('bar', 'baz');
     });
+
+    describe('disable cookie validation', () => {
+      test('should return bad request by default if invalid cookies are passed by the request', async () => {
+        const offline = new OfflineBuilder(serviceBuilder, {
+          resourceRoutes: true,
+        })
+          .addFunctionHTTP(
+            'test',
+            {
+              method: 'GET',
+              path: 'fn1',
+            },
+            (event, context, cb) => cb(null, {}),
+          )
+          .toObject();
+
+        const res = await offline.inject({
+          headers: {
+            Cookie:
+              'a.strange.cookie.with.newline.at.the.end=yummie123utuiwi-32432fe3-f3e2e32\n',
+          },
+          method: 'GET',
+          url: '/fn1',
+        });
+
+        expect(res.statusCode).toEqual(400);
+      });
+
+      test('should return 200 if the "disableCookieValidation"-flag is set', async () => {
+        const offline = new OfflineBuilder(serviceBuilder, {
+          resourceRoutes: true,
+          disableCookieValidation: true,
+        })
+          .addFunctionHTTP(
+            'test',
+            {
+              method: 'GET',
+              path: 'fn1',
+            },
+            (event, context, cb) => cb(null, {}),
+          )
+          .toObject();
+
+        const res = await offline.inject({
+          headers: {
+            Cookie:
+              'a.strange.cookie.with.newline.at.the.end=yummie123utuiwi-32432fe3-f3e2e32\n',
+          },
+          method: 'GET',
+          url: '/fn1',
+        });
+
+        expect(res.statusCode).toEqual(200);
+      });
+    });
   });
 });


### PR DESCRIPTION
Requests to `resourceRoutes` created behind an API Gateway Proxy (i.e., running with `--resourceRoutes`) would fail due to hapi just exploding on the cookie validation.

This just rips off the strategy in #513 (specifically https://github.com/dherault/serverless-offline/commit/5d9a67a5c460e456e54e5be0967807fcfdee2064).

Much of the credit here goes to @cassiohub (@cassiohubner on GitLab).