### PR TITLE
Delete the cached handler

### DIFF
--- a/src/lambda/handler-runner/in-process-runner/InProcessRunner.js
+++ b/src/lambda/handler-runner/in-process-runner/InProcessRunner.js
@@ -37,8 +37,10 @@ export default class InProcessRunner {
     // e.g. process.env.foo = 1 should be coerced to '1' (string)
     assign(process.env, this.#env)
 
-    // lazy load handler with first usage
+    // Delete the cached handler
+    delete require.cache[require.resolve(this.#handlerPath)]
 
+    // lazy load handler with first usage
     const { [this.#handlerName]: handler } = await import(this.#handlerPath)
 
     if (typeof handler !== 'function') {


### PR DESCRIPTION
I do not know the lib enough to understand the side effects this could cause. But it solves the problem of the handler caching.