### PR TITLE
JSON stringify string responses

### DIFF
--- a/src/events/http/HttpServer.js
+++ b/src/events/http/HttpServer.js
@@ -770,7 +770,9 @@ export default class HttpServer {
           override: false,
         })
 
-        if (result && typeof result.body !== 'undefined') {
+        if (typeof result === 'string') {
+          response.source = JSON.stringify(result)
+        } else if (result && typeof result.body !== 'undefined') {
           if (result.isBase64Encoded) {
             response.encoding = 'binary'
             response.source = Buffer.from(result.body, 'base64')


### PR DESCRIPTION
With this change the `string` type lambda responses will be stringified using `JSON.stringify` function.
This should fix the following issue https://github.com/dherault/serverless-offline/issues/702