### PR TITLE
Provide default event payload for scheduled when "input" not specified in serverless.yml

### DIFF
--- a/src/ServerlessOffline.js
+++ b/src/ServerlessOffline.js
@@ -191,8 +191,9 @@ export default class ServerlessOffline {
 
   async _createSchedule(events) {
     const { default: Schedule } = await import('./events/schedule/index.js')
+    const { service } = this.#serverless
 
-    this.#schedule = new Schedule(this.#lambda)
+    this.#schedule = new Schedule(this.#lambda, service.provider.region)
 
     this.#schedule.create(events)
   }


### PR DESCRIPTION
Fixes #878 by emulating the behavior of AWS Lambda as explained in the issue.
When serverless.yml has no input defined for the scheduled event payload, one is generated emulating the one you get from AWS.

The generated object looks like this:
```js
{
      version: '0',
      id: 'random-event-id',
      account: 'random-account-id',
      region: 'xxx' // actual region from serverless.yml
      time: 'xxxx' // generated on every call via new Date().toISOString()
      'detail-type': 'Scheduled Event',
      detail: {},
      source: 'aws.events'
}
```