### PR TITLE
Forward config overrides file to serverless when invoking proxy handler

### DIFF
--- a/src/functionHelper.js
+++ b/src/functionHelper.js
@@ -15,6 +15,7 @@ function runProxyHandler(funOptions, options) {
     const stage = options.s || options.stage;
 
     if (stage) args.push('-s', stage);
+    if (options.config) args.push('--config', options.config);
 
     // Use path to binary if provided, otherwise assume globally-installed
     const binPath = options.b || options.binPath;


### PR DESCRIPTION
I discovered while working on [serverless-offline-sqs](https://github.com/CoorpAcademy/serverless-plugins/tree/master/packages/serverless-offline-sqs) environment handling,
that I had some issue when using a non js handler and overriding the config file.
`sls invoke` being called without forwarding the config file, and so in my case, the lambda not being found/configured.

Here is what would fix it IM. :)
(I had experiment it locally and that I solves my issue)

I had a look around the tests, and did found an obvious place to put it.
If you give me some it, I'll be happy to add them there.

Precision: I purposefully made this PR on the v5.x branch in the hope to have a patch release. =)