### PR TITLE
Fix invalid call to createUniqueId in ScheduleEvent.js

### DIFF
--- a/src/events/schedule/ScheduleEvent.js
+++ b/src/events/schedule/ScheduleEvent.js
@@ -5,7 +5,7 @@ export default class ScheduleEvent {
     // format of aws displaying the time, e.g.: 2020-02-09T14:13:57Z
     const time = new Date().toISOString().replace(/\.(.*)(?=Z)/g, '')
 
-    this.account = createUniqueId()()
+    this.account = createUniqueId()
     this.detail = {}
     this['detail-type'] = 'Scheduled Event'
     this.id = createUniqueId()


### PR DESCRIPTION
Fix "TypeError (0 , _index.createUniqueId)(...) is not a function" when invoking scheduled events, see #886.