### PR TITLE
Cleanup lambda function before delete

### DIFF
--- a/src/lambda/LambdaFunctionPool.js
+++ b/src/lambda/LambdaFunctionPool.js
@@ -27,6 +27,7 @@ export default class LambdaFunctionPool {
           // 45 // TODO config, or maybe option?
           if (status === 'IDLE' && idleTimeInMinutes >= 1) {
             // console.log(`removed Lambda Function ${lambdaFunction.functionName}`)
+            lambdaFunction.cleanup()
             lambdaFunctions.delete(lambdaFunction)
           }
         })


### PR DESCRIPTION
I added calling `cleanup()` method of LambdaFunction to lambda function cleaner. It prevents zombie container of docker runner.