### PR TITLE
Add custom authorizer request header option

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,64 @@
+# Contributing
+
+Welcome, and thanks in advance for your help!
+
+# How to contribute to Serverless-Offline
+
+To install all the locked versions of dependencies for serverless-offline
+```bash
+npm ci
+```
+
+# Development setup
+
+You can test your local changes to serverless-offline
+
+- Point your npm **package.json** to the local changes
+  - depends on an npm project
+
+
+## package.json
+
+1. Make sure you install the dependencies for your local serverless-offline
+    ```bash
+    # serverless-offline
+    npm ci
+    ```
+2. Install the local serverless-offline in your other npm project as a dev dependency
+    ```bash
+    # in your-npm-project
+    npm i -D serverless-offline@file:../serverless-offline
+    ```
+    After this, you should see a devDependencies like the following in your package.json
+    ```JSON
+    {
+      "devDependencies": {
+        "serverless-offline": "file:../serverless-offline"
+      }
+    }
+    ```
+    The local file-include in your-npm-project should have the linked changes in
+    it's respective node_modules
+
+---
+
+# Code Style
+
+
+## Verifying linting style
+
+```
+npm run lint
+```
+
+# Testing
+
+```
+npm test
+```
+
+# Test coverage
+
+```
+npm run test:cov
+```

--- a/README.md
+++ b/README.md
@@ -197,12 +197,36 @@ The plugin only supports retrieving Tokens from headers. You can configure the h
 }
 ```
 ## Remote authorizers
-You are able to mock the response from remote authorizers by setting the environmental variable `AUTHORIZER` before running `sls offline start`
+
+You are able to mock the response from remote authorizers by one of the following:
+1. Setting the **environmental variable** `AUTHORIZER` before running
+  `sls offline start`
+2. Passing a **request header** "Authorizer" (useful for integration
+  tests that need to test reactions to different authorizer responses)
+
+In both cases, the value must be a stringified JSON object.
+
+**Environment Variable**
 
 Example:
 > Unix: `export AUTHORIZER='{"principalId": "123"}'`
 
 > Windows: `SET AUTHORIZER='{"principalId": "123"}'`
+
+**Request Header**
+
+```js
+const supertest = require('supertest');
+const client = supertest(process.env.ENDPOINT);
+
+const authorizer = JSON.stringify({
+  principalId: '123',
+  customProp: 'my-custom-authorizer-prop',
+});
+const response = await client.post('/graphql')
+  .send({ query: 'query { user(userId: "testuser") { ... } }' })
+  .set('Authorizer', authorizer);
+```
 
 ## Custom headers
 You are able to use some custom headers in your request to gain more control over the requestContext object.

--- a/src/createLambdaProxyEvent.js
+++ b/src/createLambdaProxyEvent.js
@@ -75,6 +75,18 @@ module.exports = function createLambdaProxyEvent(
   const pathParams = { ...request.params };
 
   let token = headers.Authorization || headers.authorization;
+  const headerAuthorizerString = headers.Authorizer || headers.authorizer;
+
+  let headerAuthorizer;
+  if (headerAuthorizerString) {
+    try {
+      headerAuthorizer = JSON.parse(headerAuthorizerString);
+    } catch (error) {
+      console.error(
+        'Serverless-offline: Could not parse headers.Authorization, make sure it is correct JSON.',
+      );
+    }
+  }
 
   if (token && token.split(' ')[0] === 'Bearer') {
     [, token] = token.split(' ');
@@ -106,6 +118,7 @@ module.exports = function createLambdaProxyEvent(
       apiId: 'offlineContext_apiId',
       authorizer:
         authAuthorizer ||
+        headerAuthorizer ||
         Object.assign(authContext, {
           // 'principalId' should have higher priority
           principalId:


### PR DESCRIPTION
The existing environment variable for custom authorizer mocking, `process.env.AUTHORIZER` is nice, but limited to a single value per `sls offline start` session. For integration tests that need to mock different response values of custom authorizers, we need a way to set this per test, within the same session of `sls offline start`.

This pull request adds the option to pass an `Authorizer` or `authorizer` header in the request, and mapping that to the mocked authorizer response.

The environment variable takes precedence. Maybe the header value should be the default?