### PR TITLE
fix(http-server): change hapiHandler to use current request path

### DIFF
--- a/src/events/http/HttpServer.js
+++ b/src/events/http/HttpServer.js
@@ -347,6 +347,8 @@ export default class HttpServer {
         url: request.url.href,
       }
 
+      const requestPath = request.path.substr(`/${stage}`.length)
+
       if (request.auth.credentials && request.auth.strategy) {
         this.#lastRequestOptions.auth = request.auth
       }
@@ -456,7 +458,7 @@ export default class HttpServer {
               request,
               this.#serverless.service.provider.stage,
               requestTemplate,
-              _path,
+              requestPath,
             ).create()
           } catch (err) {
             return this._reply500(
@@ -472,7 +474,7 @@ export default class HttpServer {
         const lambdaProxyIntegrationEvent = new LambdaProxyIntegrationEvent(
           request,
           this.#serverless.service.provider.stage,
-          _path,
+          requestPath,
         )
 
         event = lambdaProxyIntegrationEvent.create()


### PR DESCRIPTION
The _path property is set initially during the `createRoutes` call and is passed into `LambdaIntegrationEvent` function for every request. This results in the initial path as defined in the `serverless.yml` being used for every request.

Prior to **6.0.0-alpha.54**, the `event.path` property would reflect the current request path. eg `/graphql`
**6.0.0-alpha.56** appended the stage to the path, e.g. `event.path: /dev/graphql`
**6.0.0-alpha.61** removed the stage but the path that is defined in the `serverless.yml` is used for for every request, e.g. `event.path: /{any+}`

I think related to:
#870
#896

This commit may have implications on other features that I am not aware of, I'm relatively new to Lambda's and Serverless.

Edit: typo