### PR TITLE
Adds support for httpApi

### DIFF
--- a/src/ServerlessOffline.js
+++ b/src/ServerlessOffline.js
@@ -292,13 +292,13 @@ export default class ServerlessOffline {
       const events = service.getAllEventsInFunction(functionKey)
 
       events.forEach((event) => {
-        const { http, schedule, websocket } = event
+        const { http, httpApi, schedule, websocket } = event
 
-        if (http) {
+        if (http || httpApi) {
           httpEvents.push({
             functionKey,
             handler: functionDefinition.handler,
-            http,
+            http: http || httpApi,
           })
         }
 


### PR DESCRIPTION
This patch adds support for the new httpApi that aws offers
for reducing cost and latency in serverless applications. It
has been supported for a while in serverless, this just adds
support here to match.

The approach is pretty straightforward so far and may not include
all of the functionality that httpApi permits so far. Those will
come in later patches to this pull request.