### PR TITLE
fix: fixup no prepend stage changes

### DIFF
--- a/src/events/http/HttpServer.js
+++ b/src/events/http/HttpServer.js
@@ -278,6 +278,7 @@ export default class HttpServer {
       method,
       path: hapiPath,
       server,
+      stage: this.#options.noPrependStageInUrl ? null : stage,
     })
 
     // If the endpoint has an authorization function, create an authStrategy for the route
@@ -346,7 +347,9 @@ export default class HttpServer {
         url: request.url.href,
       }
 
-      const requestPath = request.path.substr(`/${stage}`.length)
+      const requestPath = request.path.substr(
+        this.#options.noPrependStageInUrl ? 1 : `/${stage}`.length,
+      )
 
       if (request.auth.credentials && request.auth.strategy) {
         this.#lastRequestOptions.auth = request.auth
@@ -877,9 +880,12 @@ export default class HttpServer {
 
       let hapiPath = path.startsWith('/') ? path : `/${path}`
 
-      // prepend stage to path
-      hapiPath = `/${this.#options.stage ||
-        this.#serverless.service.provider.stage}${hapiPath}`
+      if (!this.#options.noPrependStageInUrl) {
+        const stage =
+          this.#options.stage || this.#serverless.service.provider.stage
+        // prepend stage to path
+        hapiPath = `/${stage}${hapiPath}`
+      }
 
       if (hapiPath !== '/' && hapiPath.endsWith('/')) {
         hapiPath = hapiPath.slice(0, -1)

--- a/src/serverlessLog.js
+++ b/src/serverlessLog.js
@@ -36,12 +36,13 @@ export function setLog(serverlessLogRef) {
 // logs based on:
 // https://github.com/serverless/serverless/blob/master/lib/classes/CLI.js
 
-function logRoute(method, server, path, maxLength) {
+function logRoute(method, server, path, maxLength, stage) {
   const methodColor = colorMethodMapping.get(method) ?? peachpuff
   const methodFormatted = method.padEnd(maxLength, ' ')
 
   return `${methodColor(methodFormatted)} ${yellow.dim('|')} ${grey.dim(
     server,
+    stage ? `${stage}/` : '',
   )}${lime(path)}`
 }
 
@@ -61,8 +62,8 @@ export function logRoutes(routeInfo) {
   console.log(
     boxen(
       routeInfo
-        .map(({ method, path, server }) =>
-          logRoute(method, server, path, maxLength),
+        .map(({ method, path, server, stage }) =>
+          logRoute(method, server, path, maxLength, stage),
         )
         .join('\n'),
       boxenOptions,


### PR DESCRIPTION
Fixes an issue where the `event.path` would get truncated if no stage prepend was enabled. Also renables logging the stage path in table output.

Closes https://github.com/dherault/serverless-offline/issues/938