### PR TITLE
Reuse Python handler processes for performance.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "serverless-offline",
-  "version": "6.1.1",
+  "version": "6.1.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -4877,8 +4877,7 @@
     "extend": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
-      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
-      "dev": true
+      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="
     },
     "extend-shallow": {
       "version": "3.0.2",

--- a/package.json
+++ b/package.json
@@ -150,6 +150,7 @@
     "chalk": "^3.0.0",
     "cuid": "^2.1.8",
     "execa": "^4.0.0",
+    "extend": "^3.0.2",
     "fs-extra": "^8.1.0",
     "js-string-escape": "^1.0.1",
     "jsonpath-plus": "^3.0.0",

--- a/src/config/commandOptions.js
+++ b/src/config/commandOptions.js
@@ -72,4 +72,7 @@ export default {
   useDocker: {
     usage: 'Uses docker for node/python/ruby',
   },
+  functionCleanupIdleTimeSeconds: {
+    usage: 'Number of seconds until an idle function is eligible for cleanup',
+  },
 }

--- a/src/config/defaultOptions.js
+++ b/src/config/defaultOptions.js
@@ -22,4 +22,5 @@ export default {
   useWorkerThreads: false,
   websocketPort: 3001,
   useDocker: false,
+  functionCleanupIdleTimeSeconds: 60,
 }

--- a/src/lambda/LambdaFunctionPool.js
+++ b/src/lambda/LambdaFunctionPool.js
@@ -24,8 +24,11 @@ export default class LambdaFunctionPool {
           const { idleTimeInMinutes, status } = lambdaFunction
           // console.log(idleTimeInMinutes, status)
 
-          // 45 // TODO config, or maybe option?
-          if (status === 'IDLE' && idleTimeInMinutes >= 1) {
+          if (
+            status === 'IDLE' &&
+            idleTimeInMinutes >=
+              this.#options.functionCleanupIdleTimeSeconds / 60
+          ) {
             // console.log(`removed Lambda Function ${lambdaFunction.functionName}`)
             lambdaFunction.cleanup()
             lambdaFunctions.delete(lambdaFunction)
@@ -35,7 +38,7 @@ export default class LambdaFunctionPool {
 
       // schedule new timer
       this._startCleanTimer()
-    }, 10000) // TODO: config, or maybe option?
+    }, (this.#options.functionCleanupIdleTimeSeconds * 1000) / 2)
   }
 
   _cleanupPool() {

--- a/src/lambda/handler-runner/python-runner/PythonRunner.js
+++ b/src/lambda/handler-runner/python-runner/PythonRunner.js
@@ -42,12 +42,12 @@ export default class PythonRunner {
       ],
       {
         env: extend(process.env, this.#env),
-        shell: true
+        shell: true,
       },
     )
 
     process.on('exit', () => {
-      this.handlerProcess.kill();
+      this.handlerProcess.kill()
     })
   }
 
@@ -91,11 +91,15 @@ export default class PythonRunner {
   // https://github.com/serverless/serverless/blob/v1.50.0/lib/plugins/aws/invokeLocal/invoke.py
   async run(event, context) {
     return new Promise((accept, reject) => {
-
       const input = stringify({
         context,
         event,
       })
+
+      const onErr = (data) => {
+        // TODO
+        console.log(data.toString())
+      }
 
       const onData = (data) => {
         this.handlerProcess.stdout.removeListener('data', onData)
@@ -112,16 +116,11 @@ export default class PythonRunner {
         }
       }
 
-      const onErr = (data) => {
-        // TODO
-        console.log(data.toString())
-      }
-
       this.handlerProcess.stdout.on('data', onData)
       this.handlerProcess.stderr.on('data', onErr)
 
       process.nextTick(() => {
-        this.handlerProcess.stdin.write(input);
+        this.handlerProcess.stdin.write(input)
         this.handlerProcess.stdin.write('\n')
       })
     })

--- a/src/lambda/handler-runner/python-runner/PythonRunner.js
+++ b/src/lambda/handler-runner/python-runner/PythonRunner.js
@@ -1,6 +1,7 @@
 import { EOL, platform } from 'os'
 import { delimiter, join, relative, resolve } from 'path'
-import execa from 'execa'
+import { spawn } from 'child_process'
+import extend from 'extend'
 
 const { parse, stringify } = JSON
 const { cwd } = process
@@ -18,7 +19,36 @@ export default class PythonRunner {
     this.#env = env
     this.#handlerName = handlerName
     this.#handlerPath = handlerPath
-    this.#runtime = runtime
+    this.#runtime = platform() === 'win32' ? 'python.exe' : runtime
+
+    if (process.env.VIRTUAL_ENV) {
+      const runtimeDir = platform() === 'win32' ? 'Scripts' : 'bin'
+      process.env.PATH = [
+        join(process.env.VIRTUAL_ENV, runtimeDir),
+        delimiter,
+        process.env.PATH,
+      ].join('')
+    }
+
+    const [pythonExecutable] = this.#runtime.split('.')
+
+    this.handlerProcess = spawn(
+      pythonExecutable,
+      [
+        '-u',
+        resolve(__dirname, 'invoke.py'),
+        relative(cwd(), this.#handlerPath),
+        this.#handlerName,
+      ],
+      {
+        env: extend(process.env, this.#env),
+        shell: true
+      },
+    )
+
+    process.on('exit', () => {
+      this.handlerProcess.kill();
+    })
   }
 
   // no-op
@@ -57,68 +87,43 @@ export default class PythonRunner {
 
   // invokeLocalPython, loosely based on:
   // https://github.com/serverless/serverless/blob/v1.50.0/lib/plugins/aws/invokeLocal/index.js#L410
-  // invoke.py, copy/pasted entirely as is:
+  // invoke.py, based on:
   // https://github.com/serverless/serverless/blob/v1.50.0/lib/plugins/aws/invokeLocal/invoke.py
   async run(event, context) {
-    const runtime = platform() === 'win32' ? 'python.exe' : this.#runtime
+    return new Promise((accept, reject) => {
 
-    const input = stringify({
-      context,
-      event,
+      const input = stringify({
+        context,
+        event,
+      })
+
+      const onData = (data) => {
+        this.handlerProcess.stdout.removeListener('data', onData)
+        this.handlerProcess.stderr.removeListener('data', onErr)
+
+        try {
+          return accept(this._parsePayload(data.toString()))
+        } catch (err) {
+          // TODO
+          console.log('No JSON')
+
+          // TODO return or re-throw?
+          return reject(err)
+        }
+      }
+
+      const onErr = (data) => {
+        // TODO
+        console.log(data.toString())
+      }
+
+      this.handlerProcess.stdout.on('data', onData)
+      this.handlerProcess.stderr.on('data', onErr)
+
+      process.nextTick(() => {
+        this.handlerProcess.stdin.write(input);
+        this.handlerProcess.stdin.write('\n')
+      })
     })
-
-    if (process.env.VIRTUAL_ENV) {
-      const runtimeDir = platform() === 'win32' ? 'Scripts' : 'bin'
-      process.env.PATH = [
-        join(process.env.VIRTUAL_ENV, runtimeDir),
-        delimiter,
-        process.env.PATH,
-      ].join('')
-    }
-
-    const [pythonExecutable] = runtime.split('.')
-
-    const python = execa(
-      pythonExecutable,
-      [
-        '-u',
-        resolve(__dirname, 'invoke.py'),
-        relative(cwd(), this.#handlerPath),
-        this.#handlerName,
-      ],
-      {
-        env: this.#env,
-        input,
-        // shell: true,
-      },
-    )
-
-    let result
-
-    try {
-      result = await python
-    } catch (err) {
-      // TODO
-      console.log(err)
-
-      throw err
-    }
-
-    const { stderr, stdout } = result
-
-    if (stderr) {
-      // TODO
-      console.log(stderr)
-    }
-
-    try {
-      return this._parsePayload(stdout)
-    } catch (err) {
-      // TODO
-      console.log('No JSON')
-
-      // TODO return or re-throw?
-      return err
-    }
   }
 }

--- a/src/lambda/handler-runner/python-runner/PythonRunner.js
+++ b/src/lambda/handler-runner/python-runner/PythonRunner.js
@@ -50,15 +50,12 @@ export default class PythonRunner {
     this.handlerProcess.stdout.readline = readline.createInterface({
       input: this.handlerProcess.stdout,
     })
-
-    process.on('exit', () => {
-      this.handlerProcess.kill()
-    })
   }
 
-  // no-op
   // () => void
-  cleanup() {}
+  cleanup() {
+    this.handlerProcess.kill()
+  }
 
   _parsePayload(value) {
     let payload


### PR DESCRIPTION
The current implementation for Python handlers spawns a new child process on each endpoint invocation, which then has to re-do all of the Python imports/bootstrapping, which can be quite slow for large projects.

This PR keeps a process around for each handler function that it reuses on each new invocation, making it much more performant.