### PR TITLE
Fix: serverless-offline crashes if a function definition does not have a handler

### DIFF
--- a/src/ServerlessOffline.js
+++ b/src/ServerlessOffline.js
@@ -293,7 +293,7 @@ export default class ServerlessOffline {
         const { http, httpApi, schedule, websocket } = event
 
         if (http || httpApi) {
-          if (!!functionDefinition.handler) {
+          if (functionDefinition.handler) {
             httpEvents.push({
               functionKey,
               handler: functionDefinition.handler,

--- a/src/ServerlessOffline.js
+++ b/src/ServerlessOffline.js
@@ -293,11 +293,13 @@ export default class ServerlessOffline {
         const { http, httpApi, schedule, websocket } = event
 
         if (http || httpApi) {
-          httpEvents.push({
-            functionKey,
-            handler: functionDefinition.handler,
-            http: http || httpApi,
-          })
+          if (!!functionDefinition.handler) {
+            httpEvents.push({
+              functionKey,
+              handler: functionDefinition.handler,
+              http: http || httpApi,
+            })
+          }
         }
 
         if (schedule) {


### PR DESCRIPTION
Check for the existence of a handler property before trying to have serverless-offline set up an event handler. It's possible to have mock integrations configured in API Gateway via serverless framework that have no handler and always return a static response. My team has and is using these in production, but serverless-offline cannot handle them right now.

This fix prevents serverless-offline from crashing, but it still warns `WARNING: Entry for my-function-without-handler@undefined could not be retrieved.`

I can provide a full example serverless.yml that triggers this bug if requested.

https://serverless.com/framework/docs/providers/aws/events/apigateway/#mock-integration