### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ All CLI options are optional:
 --enforceSecureCookies      Enforce secure cookies
 --hideStackTraces           Hide the stack trace on lambda failure. Default: false
 --host                  -o  Host name to listen on. Default: localhost
---httpPort                  Http port to listen on. Default: 3000
+--port / -P                 Http port to listen on. Default: 3000
 --httpsProtocol         -H  To enable HTTPS, specify directory (relative to your cwd, typically your project dir) for both cert.pem and key.pem files
 --lambdaPort                Lambda http port to listen on. Default: 3002
 --noPrependStageInUrl       Don't prepend http routes with the stage.


### PR DESCRIPTION
Change `--port` to follow the cmd help.

```
✗ ./node_modules/.bin/serverless offline --help
Plugin: ServerlessOffline
offline ....................... Simulates API Gateway to call your lambda functions offline.
offline start ................. Simulates API Gateway to call your lambda functions offline using backward compatible initialization.
    --apiKey ........................... Defines the API key value to be used for endpoints marked as private. Defaults to a random hash.
    --binPath / -b ..................... Path to the Serverless binary.
    --cacheInvalidationRegex ........... Provide the plugin with a regexp to use for cache invalidation. Default: node_modules
    --corsAllowHeaders ................. Used to build the Access-Control-Allow-Headers header for CORS support.
    --corsAllowOrigin .................. Used to build the Access-Control-Allow-Origin header for CORS support.
    --corsDisallowCredentials .......... Used to override the Access-Control-Allow-Credentials default (which is true) to false.
    --corsExposedHeaders ............... USed to build the Access-Control-Exposed-Headers response header for CORS support
    --disableCookieValidation .......... Used to disable cookie-validation on hapi.js-server
    --enforceSecureCookies ............. Enforce secure cookies
    --exec ............................. When provided, a shell script is executed when the server starts up, and the server will shut down after handling this command.
    --hideStackTraces .................. Hide the stack trace on lambda failure. Default: false
    --host / -o ........................ The host name to listen on. Default: localhost
    --httpsProtocol / -H ............... To enable HTTPS, specify directory (relative to your cwd, typically your project dir) for both cert.pem and key.pem files.
    --location / -l .................... The root location of the handlers' files.
    --noAuth ........................... Turns off all authorizers
    --noEnvironment .................... Turns off loading of your environment variables from serverless.yml. Allows the usage of tools such as PM2 or docker-compose.
    --port / -P ........................ Port to listen on. Default: 3000
    --prefix / -p ...................... Adds a prefix to every path, to send your requests to http://localhost:3000/prefix/[your_path] instead.
    --preserveTrailingSlash ............ Used to keep trailing slashes on the request path
    --printOutput ...................... Outputs your lambda response to the terminal.
    --providedRuntime .................. Sets the provided runtime for lambdas
    --region / -r ...................... The region used to populate your templates.
    --resourceRoutes ................... Turns on loading of your HTTP proxy settings from serverless.yml.
    --showDuration ..................... Show the execution time duration of the lambda function.
    --skipCacheInvalidation / -c ....... Tells the plugin to skip require cache invalidation. A script reloading tool like Nodemon might then be needed
    --stage / -s ....................... The stage used to populate your templates.
    --useSeparateProcesses ............. Uses separate node processes for handlers
    --websocketPort .................... Websocket port to listen on. Default: 3001
```