### PR TITLE
Also support `--disableCookieValidation` when we `createResourceRoutes`.

### DIFF
--- a/src/events/http/HttpServer.js
+++ b/src/events/http/HttpServer.js
@@ -901,8 +901,20 @@ export default class HttpServer {
       }
 
       const hapiMethod = method === 'ANY' ? '*' : method
+
+      const state = this.#options.disableCookieValidation
+        ? {
+            failAction: 'ignore',
+            parse: false,
+          }
+        : {
+            failAction: 'error',
+            parse: true,
+          }
+
       const hapiOptions = {
         cors: this.#options.corsConfig,
+        state,
       }
 
       // skip HEAD routes as hapi will fail with 'Method name not allowed: HEAD ...'

--- a/tests/old-unit/offline.test.js
+++ b/tests/old-unit/offline.test.js
@@ -1012,5 +1012,66 @@ describe('Offline', () => {
 
       expect(result.queryString).toHaveProperty('bar', 'baz')
     })
+
+    describe('disable cookie validation', () => {
+      test('should return bad request by default if invalid cookies are passed by the request', async () => {
+        const offline = await new OfflineBuilder(serviceBuilder, {
+          resourceRoutes: true,
+        })
+          .addFunctionConfig('cookie', {
+            events: [
+              {
+                http: {
+                  method: 'GET',
+                  path: 'cookie',
+                },
+              },
+            ],
+            handler: 'tests/old-unit/fixtures/handler.cookie',
+          })
+          .toObject()
+
+        const res = await offline.inject({
+          headers: {
+            Cookie:
+              'a.strange.cookie.with.newline.at.the.end=yummie123utuiwi-32432fe3-f3e2e32\n',
+          },
+          method: 'GET',
+          url: '/dev/cookie',
+        })
+
+        expect(res.statusCode).toEqual(400)
+      })
+
+      test('should return 200 if the "disableCookieValidation"-flag is set', async () => {
+        const offline = await new OfflineBuilder(serviceBuilder, {
+          resourceRoutes: true,
+          disableCookieValidation: true,
+        })
+          .addFunctionConfig('cookie', {
+            events: [
+              {
+                http: {
+                  method: 'GET',
+                  path: 'cookie',
+                },
+              },
+            ],
+            handler: 'tests/old-unit/fixtures/handler.cookie',
+          })
+          .toObject()
+
+        const res = await offline.inject({
+          headers: {
+            Cookie:
+              'a.strange.cookie.with.newline.at.the.end=yummie123utuiwi-32432fe3-f3e2e32\n',
+          },
+          method: 'GET',
+          url: '/dev/cookie',
+        })
+
+        expect(res.statusCode).toEqual(200)
+      })
+    })
   })
 })


### PR DESCRIPTION
__This should close https://github.com/dherault/serverless-offline/issues/974 by forward porting my v5 solution from https://github.com/dherault/serverless-offline/pull/863__.

Requests to `resourceRoutes` created behind an API Gateway Proxy (i.e., running with `--resourceRoutes`) would fail due to hapi just exploding on the cookie validation.

This just rips off the strategy in https://github.com/dherault/serverless-offline/pull/513 (specifically https://github.com/dherault/serverless-offline/commit/5d9a67a5c460e456e54e5be0967807fcfdee2064) and https://github.com/dherault/serverless-offline/pull/863

Much of the credit here goes to @cassiohub (@cassiohubner on GitLab).