### PR TITLE
feat(disable-cache): Add an optional flag to disable the caching option

### DIFF
--- a/src/config/commandOptions.js
+++ b/src/config/commandOptions.js
@@ -75,4 +75,7 @@ export default {
   functionCleanupIdleTimeSeconds: {
     usage: 'Number of seconds until an idle function is eligible for cleanup',
   },
+  noCache: {
+    usage: 'Disable caching',
+  },
 }

--- a/src/config/defaultOptions.js
+++ b/src/config/defaultOptions.js
@@ -23,4 +23,5 @@ export default {
   websocketPort: 3001,
   useDocker: false,
   functionCleanupIdleTimeSeconds: 60,
+  noCache: false,
 }

--- a/src/lambda/handler-runner/HandlerRunner.js
+++ b/src/lambda/handler-runner/HandlerRunner.js
@@ -52,7 +52,11 @@ export default class HandlerRunner {
         const { default: WorkerThreadRunner } = await import(
           './worker-thread-runner/index.js'
         )
-        return new WorkerThreadRunner(this.#funOptions, this.#env)
+        return new WorkerThreadRunner(
+          this.#funOptions,
+          this.#env,
+          this.#options,
+        )
       }
 
       const { default: InProcessRunner } = await import(
@@ -64,6 +68,7 @@ export default class HandlerRunner {
         handlerName,
         this.#env,
         timeout,
+        this.#options,
       )
     }
 

--- a/src/lambda/handler-runner/child-process-runner/ChildProcessRunner.js
+++ b/src/lambda/handler-runner/child-process-runner/ChildProcessRunner.js
@@ -9,8 +9,9 @@ export default class ChildProcessRunner {
   #handlerName = null
   #handlerPath = null
   #timeout = null
+  #options = null
 
-  constructor(funOptions, env) {
+  constructor(funOptions, env, options) {
     const { functionKey, handlerName, handlerPath, timeout } = funOptions
 
     this.#env = env
@@ -18,6 +19,7 @@ export default class ChildProcessRunner {
     this.#handlerName = handlerName
     this.#handlerPath = handlerPath
     this.#timeout = timeout
+    this.#options = options
   }
 
   // no-op
@@ -27,7 +29,7 @@ export default class ChildProcessRunner {
   async run(event, context) {
     const childProcess = node(
       childProcessHelperPath,
-      [this.#functionKey, this.#handlerName, this.#handlerPath],
+      [this.#functionKey, this.#handlerName, this.#handlerPath, this.#options],
       {
         env: this.#env,
         stdio: 'inherit',

--- a/src/lambda/handler-runner/child-process-runner/childProcessHelper.js
+++ b/src/lambda/handler-runner/child-process-runner/childProcessHelper.js
@@ -20,7 +20,7 @@ process.on('uncaughtException', (err) => {
   })
 })
 
-const [, , functionKey, handlerName, handlerPath] = process.argv
+const [, , functionKey, handlerName, handlerPath, options] = process.argv
 
 process.on('message', async (messageData) => {
   const { context, event, timeout } = messageData
@@ -32,6 +32,7 @@ process.on('message', async (messageData) => {
     handlerName,
     process.env,
     timeout,
+    options,
   )
 
   let result

--- a/src/lambda/handler-runner/in-process-runner/InProcessRunner.js
+++ b/src/lambda/handler-runner/in-process-runner/InProcessRunner.js
@@ -8,13 +8,15 @@ export default class InProcessRunner {
   #handlerName = null
   #handlerPath = null
   #timeout = null
+  #options = null
 
-  constructor(functionKey, handlerPath, handlerName, env, timeout) {
+  constructor(functionKey, handlerPath, handlerName, env, timeout, options) {
     this.#env = env
     this.#functionKey = functionKey
     this.#handlerName = handlerName
     this.#handlerPath = handlerPath
     this.#timeout = timeout
+    this.#options = options
   }
 
   // no-op
@@ -36,6 +38,11 @@ export default class InProcessRunner {
     // otherwise the values of the attached props are not coerced to a string
     // e.g. process.env.foo = 1 should be coerced to '1' (string)
     assign(process.env, this.#env)
+
+    // Delete the cached handler
+    if (this.#options.noCache) {
+      delete require.cache[require.resolve(this.#handlerPath)]
+    }
 
     // lazy load handler with first usage
 

--- a/src/lambda/handler-runner/worker-thread-runner/WorkerThreadRunner.js
+++ b/src/lambda/handler-runner/worker-thread-runner/WorkerThreadRunner.js
@@ -6,7 +6,7 @@ const workerThreadHelperPath = resolve(__dirname, './workerThreadHelper.js')
 export default class WorkerThreadRunner {
   #workerThread = null
 
-  constructor(funOptions /* options */, env) {
+  constructor(funOptions /* options */, env, options) {
     // this._options = options
 
     const { functionKey, handlerName, handlerPath, timeout } = funOptions
@@ -19,6 +19,7 @@ export default class WorkerThreadRunner {
         handlerName,
         handlerPath,
         timeout,
+        options,
       },
     })
   }

--- a/src/lambda/handler-runner/worker-thread-runner/workerThreadHelper.js
+++ b/src/lambda/handler-runner/worker-thread-runner/workerThreadHelper.js
@@ -1,7 +1,7 @@
 import { parentPort, workerData } from 'worker_threads' // eslint-disable-line import/no-unresolved
 import InProcessRunner from '../in-process-runner/index.js'
 
-const { functionKey, handlerName, handlerPath } = workerData
+const { functionKey, handlerName, handlerPath, options } = workerData
 
 parentPort.on('message', async (messageData) => {
   const { context, event, port, timeout } = messageData
@@ -13,6 +13,7 @@ parentPort.on('message', async (messageData) => {
     handlerName,
     process.env,
     timeout,
+    options,
   )
 
   let result


### PR DESCRIPTION
Related to the following issue: https://github.com/dherault/serverless-offline/issues/864 
I added, behind an optional flag (`--noCache`) this line to invalidate the cache:
```js
delete require.cache[require.resolve(this.#handlerPath)]
```
Unfortunately, it causes memory leaks, this is why I put it behind a flag, as requested in the comments.



