### PR TITLE
fix: resourcePath in authorizers should contain wildcards

### DIFF
--- a/src/events/http/createAuthScheme.js
+++ b/src/events/http/createAuthScheme.js
@@ -44,7 +44,7 @@ export default function createAuthScheme(authorizerOptions, provider, lambda) {
       const accountId = 'random-account-id'
       const apiId = 'random-api-id'
       const httpMethod = request.method.toUpperCase()
-      const resourcePath = request.path.replace(
+      const resourcePath = request.route.path.replace(
         new RegExp(`^/${provider.stage}`),
         '',
       )

--- a/src/events/http/createAuthScheme.js
+++ b/src/events/http/createAuthScheme.js
@@ -59,8 +59,10 @@ export default function createAuthScheme(authorizerOptions, provider, lambda) {
           requestId: 'random-request-id',
           resourceId: 'random-resource-id',
           resourcePath,
+          path: request.path,
           stage: provider.stage,
         },
+        resource: resourcePath,
       }
 
       // Create event Object for authFunction

--- a/src/events/http/lambda-events/LambdaProxyIntegrationEvent.js
+++ b/src/events/http/lambda-events/LambdaProxyIntegrationEvent.js
@@ -186,7 +186,7 @@ export default class LambdaProxyIntegrationEvent {
         resourcePath: route.path,
         stage: this.#stage,
       },
-      resource: this.#path,
+      resource: route.path,
       stageVariables: this.#stageVariables,
     }
   }

--- a/tests/integration/handler/handler.js
+++ b/tests/integration/handler/handler.js
@@ -202,3 +202,10 @@ exports.TestPathVariable = (event, context, callback) => {
     body: stringify(event.path),
   })
 }
+
+exports.TestResourceVariable = (event, context, callback) => {
+  callback(null, {
+    statusCode: 200,
+    body: stringify(event.resource),
+  })
+}

--- a/tests/integration/handler/handlerPayload.test.js
+++ b/tests/integration/handler/handlerPayload.test.js
@@ -301,6 +301,13 @@ describe('handler payload tests with prepend off', () => {
       path: '/test-path-variable-handler',
       status: 200,
     },
+
+    {
+      description: 'event.resource should not contain wildcards',
+      expected: '/{id}/test-resource-variable-handler',
+      path: '/1/test-resource-variable-handler',
+      status: 200,
+    },
   ].forEach(({ description, expected, path, status }) => {
     test(description, async () => {
       const url = joinUrl(TEST_BASE_URL, path)

--- a/tests/integration/handler/serverless.yml
+++ b/tests/integration/handler/serverless.yml
@@ -155,3 +155,10 @@ functions:
           method: get
           path: test-path-variable-handler
     handler: handler.TestPathVariable
+
+  TestResourceVariable:
+    events:
+      - http:
+          method: get
+          path: /{id}/test-resource-variable-handler
+    handler: handler.TestResourceVariable


### PR DESCRIPTION
Fixes https://github.com/dherault/serverless-offline/issues/917

I still need to write tests for this fix.

I must say, the development experience to contribute to this project for the first time is quite poor. 
The main issue is I could not run tests reliably in my machine:
- every single time I want to run tests, npm installs every 'scenario' dependencies
- I cannot run unit tests separately, only the whole project with many integration tests
- I'm not sure where to add tests, considering unit tests are in a folder `old-unit`. I'm not confident in adding code to something with `old` in its name
- Some random tests break by timeout
- Husky runs tests on every push

In my opinion, tests should be easy to run locally, but not enforced to be ran on every push. Travis CI already does this tests for us, and is way more convenient. Running them locally on every push (which takes some minutes) will certainly make developers reconsider contributing ever again. For instance, [Next.js](https://github.com/zeit/next.js/blob/canary/contributing.md) is an immense project, and allows for flexible testing locally, and tests every PR on a CI.

If you would like, I can open an issue with my concerns so we can discuss it separately
