### PR TITLE
feat(prefixes): Bring back prefix option

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ All CLI options are optional:
 --noPrependStageInUrl       Don't prepend http routes with the stage.
 --noAuth                    Turns off all authorizers
 --noTimeout             -t  Disables the timeout feature.
---prefix                -p  Adds a prefix to every path, to send your requests to http://localhost:3000/[prefix]/[your_path] instead. Default: '/'
+--prefix                -p  Adds a prefix to every path, to send your requests to http://localhost:3000/[prefix]/[your_path] instead. Default: ''
 --printOutput               Turns on logging of your lambda outputs in the terminal.
 --resourceRoutes            Turns on loading of your HTTP proxy settings from serverless.yml
 --useChildProcesses         Run handlers in a child process

--- a/README.md
+++ b/README.md
@@ -105,6 +105,7 @@ All CLI options are optional:
 --noPrependStageInUrl       Don't prepend http routes with the stage.
 --noAuth                    Turns off all authorizers
 --noTimeout             -t  Disables the timeout feature.
+--prefix                -p  Adds a prefix to every path, to send your requests to http://localhost:3000/[prefix]/[your_path] instead. Default: '/'
 --printOutput               Turns on logging of your lambda outputs in the terminal.
 --resourceRoutes            Turns on loading of your HTTP proxy settings from serverless.yml
 --useChildProcesses         Run handlers in a child process

--- a/src/config/commandOptions.js
+++ b/src/config/commandOptions.js
@@ -53,6 +53,11 @@ export default {
     shortcut: 't',
     usage: 'Disables the timeout feature.',
   },
+  prefix: {
+    shortcut: 'p',
+    usage:
+      'Adds a prefix to every path, to send your requests to http://localhost:3000/prefix/[your_path] instead.',
+  },
   printOutput: {
     usage: 'Outputs your lambda response to the terminal.',
   },

--- a/src/config/defaultOptions.js
+++ b/src/config/defaultOptions.js
@@ -16,6 +16,7 @@ export default {
   noPrependStageInUrl: false,
   noAuth: false,
   noTimeout: false,
+  prefix: '',
   printOutput: false,
   resourceRoutes: false,
   useChildProcesses: false,

--- a/src/events/http/HttpServer.js
+++ b/src/events/http/HttpServer.js
@@ -256,6 +256,11 @@ export default class HttpServer {
       hapiPath = `/${stage}${hapiPath}`
     }
 
+    // add prefix to path
+    if (this.#options.prefix) {
+      hapiPath = `/${this.#options.prefix}${hapiPath}`
+    }
+
     // but must not end with '/'
     if (hapiPath !== '/' && hapiPath.endsWith('/')) {
       hapiPath = hapiPath.slice(0, -1)
@@ -888,6 +893,10 @@ export default class HttpServer {
           this.#options.stage || this.#serverless.service.provider.stage
         // prepend stage to path
         hapiPath = `/${stage}${hapiPath}`
+      }
+
+      if (this.#options.prefix) {
+        hapiPath = `/${this.#options.prefix}${hapiPath}`
       }
 
       if (hapiPath !== '/' && hapiPath.endsWith('/')) {


### PR DESCRIPTION
## Purpose

In v6 of `serverless-offline`, the `prefix` option got removed. I'm not aware of the context behind this, but it seems like a few people would love to have this functionality back, and @dherault seems open to this idea.

## Original issue

https://github.com/dherault/serverless-offline/issues/929