### PR TITLE
Fix:#989 ModuleNotFoundError occur when running Python function on Windows OS

### DIFF
--- a/src/lambda/handler-runner/python-runner/invoke.py
+++ b/src/lambda/handler-runner/python-runner/invoke.py
@@ -6,6 +6,7 @@ import argparse
 import json
 import logging
 import sys
+import os
 from time import strftime, time
 from importlib import import_module
 
@@ -72,7 +73,7 @@ if __name__ == '__main__':
     # this is needed because you need to import from where you've executed sls
     sys.path.append('.')
 
-    module = import_module(args.handler_path.replace('/', '.'))
+    module = import_module(args.handler_path.replace(os.sep, '.'))
     handler = getattr(module, args.handler_name)
 
     # Keep a reference to the original stdin so that we can continue to receive


### PR DESCRIPTION
Fixes #989
When running Python function on Windows OS, invoke.py cannot import handler module because it doesn't convert path separator of Windows OS "\" to ".".
So, I fixed that using os.sep instead of literal "/".
