### PR TITLE
refactor: Extract util for generating hapiPath

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "serverless-offline",
-  "version": "6.1.5",
+  "version": "6.2.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/events/http/HttpServer.js
+++ b/src/events/http/HttpServer.js
@@ -19,6 +19,7 @@ import {
   detectEncoding,
   jsonPath,
   splitHandlerPathAndName,
+  generateHapiPath,
 } from '../../utils/index.js'
 
 const { parse, stringify } = JSON
@@ -245,29 +246,8 @@ export default class HttpServer {
     )
 
     const { path } = httpEvent
-    // path must start with '/'
-    let hapiPath = path.startsWith('/') ? path : `/${path}`
-
-    // prepend stage to path
+    const hapiPath = generateHapiPath(path, this.#options, this.#serverless)
     const stage = this.#options.stage || this.#serverless.service.provider.stage
-
-    if (!this.#options.noPrependStageInUrl) {
-      // prepend stage to path
-      hapiPath = `/${stage}${hapiPath}`
-    }
-
-    // add prefix to path
-    if (this.#options.prefix) {
-      hapiPath = `/${this.#options.prefix}${hapiPath}`
-    }
-
-    // but must not end with '/'
-    if (hapiPath !== '/' && hapiPath.endsWith('/')) {
-      hapiPath = hapiPath.slice(0, -1)
-    }
-
-    hapiPath = hapiPath.replace(/\+}/g, '*}')
-
     const protectedRoutes = []
 
     if (httpEvent.private) {
@@ -886,25 +866,7 @@ export default class HttpServer {
         return
       }
 
-      let hapiPath = path.startsWith('/') ? path : `/${path}`
-
-      if (!this.#options.noPrependStageInUrl) {
-        const stage =
-          this.#options.stage || this.#serverless.service.provider.stage
-        // prepend stage to path
-        hapiPath = `/${stage}${hapiPath}`
-      }
-
-      if (this.#options.prefix) {
-        hapiPath = `/${this.#options.prefix}${hapiPath}`
-      }
-
-      if (hapiPath !== '/' && hapiPath.endsWith('/')) {
-        hapiPath = hapiPath.slice(0, -1)
-      }
-
-      hapiPath = hapiPath.replace(/\+}/g, '*}')
-
+      const hapiPath = generateHapiPath(path, this.#options, this.#serverless)
       const proxyUriOverwrite = resourceRoutesOptions[methodId] || {}
       const proxyUriInUse = proxyUriOverwrite.Uri || proxyUri
 

--- a/src/utils/generateHapiPath.js
+++ b/src/utils/generateHapiPath.js
@@ -1,0 +1,22 @@
+export default function generateHapiPath(path, options, serverless) {
+  // path must start with '/'
+  let hapiPath = path.startsWith('/') ? path : `/${path}`
+
+  if (!options.noPrependStageInUrl) {
+    const stage = options.stage || serverless.service.provider.stage
+    // prepend stage to path
+    hapiPath = `/${stage}${hapiPath}`
+  }
+
+  if (options.prefix) {
+    hapiPath = `/${options.prefix}${hapiPath}`
+  }
+
+  if (hapiPath !== '/' && hapiPath.endsWith('/')) {
+    hapiPath = hapiPath.slice(0, -1)
+  }
+
+  hapiPath = hapiPath.replace(/\+}/g, '*}')
+
+  return hapiPath
+}

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -13,6 +13,7 @@ export { default as parseQueryStringParameters } from './parseQueryStringParamet
 export { default as satisfiesVersionRange } from './satisfiesVersionRange.js'
 export { default as splitHandlerPathAndName } from './splitHandlerPathAndName.js'
 export { default as checkDockerDaemon } from './checkDockerDaemon.js'
+export { default as generateHapiPath } from './generateHapiPath.js'
 // export { default as baseImage } from './baseImage.js'
 
 // Detect the toString encoding from the request headers content-type


### PR DESCRIPTION
## Purpose

In my previous [PR](https://github.com/dherault/serverless-offline/pull/988) I noticed there was some duplicate logic for generating paths in `createRoutes` and `createResourceRoutes`.

Have extracted this code to a utility so any future updates can happen in one place.