### PR TITLE
NPM script for running only unit tests

### DIFF
--- a/jest.config.units.js
+++ b/jest.config.units.js
@@ -1,0 +1,7 @@
+'use strict'
+
+module.exports = {
+  // Ignore 'tests' directory as it contains all the integration tests
+  modulePathIgnorePatterns: ['src/lambda/__tests__/fixtures/', 'tests/'],
+  setupFiles: ['object.fromentries/auto.js'],
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "serverless-offline",
-  "version": "6.2.0",
+  "version": "6.3.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "prepare": "npm run build",
     "prepublishOnly": "npm run lint && npm run build",
     "test": "npm run build && jest --verbose --silent --runInBand",
+    "test:unit": "jest --verbose --silent --runInBand --config jest.config.units.js",
     "test:cov": "npm run build && jest --coverage --silent --runInBand --collectCoverageFrom=src/**/*.js",
     "test:log": "npm run build && jest --verbose",
     "test:noBuild": "jest --verbose --runInBand --bail"


### PR DESCRIPTION
## Purpose

For the purposes of faster development, this PR adds an npm script (`npm run test:unit`) for running only unit tests, and without `npm install`.