### PR TITLE
fix: Handle star routes

### DIFF
--- a/src/utils/generateHapiPath.js
+++ b/src/utils/generateHapiPath.js
@@ -1,4 +1,4 @@
-export default function generateHapiPath(path, options, serverless) {
+export default function generateHapiPath(path = '', options, serverless) {
   // path must start with '/'
   let hapiPath = path.startsWith('/') ? path : `/${path}`
 


### PR DESCRIPTION
## Purpose

[Issue #999](https://github.com/dherault/serverless-offline/issues/999) discovered that star routes are not being handled correctly, since no path property is present. Defaulting the path to an empty string allows the pathing to be applied properly.