### PR TITLE
fix: Allow explicitly setting headers within lambda

### DIFF
--- a/src/events/http/HttpServer.js
+++ b/src/events/http/HttpServer.js
@@ -83,6 +83,8 @@ export default class HttpServer {
           ? request.response.output
           : request.response
 
+        const explicitlySetHeaders = { ...response.headers }
+
         response.headers['access-control-allow-origin'] = request.headers.origin
         response.headers['access-control-allow-credentials'] = 'true'
 
@@ -102,6 +104,14 @@ export default class HttpServer {
               request.headers['access-control-request-method']
           }
         }
+
+        // Override default headers with headers that have been explicitly set
+        Object.keys(explicitlySetHeaders).forEach((key) => {
+          const value = explicitlySetHeaders[key]
+          if (value) {
+            response.headers[key] = value
+          }
+        })
       }
 
       return h.continue


### PR DESCRIPTION
## Purpose

This PR addresses [issue #984](https://github.com/dherault/serverless-offline/issues/984). Currently when an `origin` header is being set, a bunch of other default headers are being set too.

These default headers override any headers that may want to be set explicitly in the lambda. This PR fixes that.