### PR TITLE
refactor: Script for running tests with --watch

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -7,7 +7,9 @@ module.exports = {
     RUN_TEST_AGAINST_AWS: AWS_ENDPOINT != null,
     TEST_BASE_URL: AWS_ENDPOINT || 'http://localhost:3000',
   },
-  globalSetup: './tests/_setupTeardown/npmInstall.js',
   modulePathIgnorePatterns: ['src/lambda/__tests__/fixtures/'],
   setupFiles: ['object.fromentries/auto.js'],
+  ...(!process.env.SKIP_SETUP && {
+    globalSetup: './tests/_setupTeardown/npmInstall.js',
+  }),
 }

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "test:unit": "jest --verbose --silent --runInBand --config jest.config.units.js",
     "test:cov": "npm run build && jest --coverage --silent --runInBand --collectCoverageFrom=src/**/*.js",
     "test:log": "npm run build && jest --verbose",
-    "test:noBuild": "jest --verbose --runInBand --bail"
+    "test:noBuild": "jest --verbose --runInBand --bail",
+    "test:watch": "SKIP_SETUP=true jest --verbose --watch"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Purpose

Added an `npm` script to run `jest` with `--watch` to speed up local testing. Skips the install script as this is usually unnecessary when just writing or updating tests.