### PR TITLE
fix greedy path for proxy

### DIFF
--- a/src/events/http/HttpServer.js
+++ b/src/events/http/HttpServer.js
@@ -857,13 +857,7 @@ export default class HttpServer {
     serverlessLog('Routes defined in resources:')
 
     Object.entries(resourceRoutes).forEach(([methodId, resourceRoutesObj]) => {
-      const {
-        isProxy,
-        method,
-        path,
-        pathResource,
-        proxyUri,
-      } = resourceRoutesObj
+      const { isProxy, method, pathResource, proxyUri } = resourceRoutesObj
 
       if (!isProxy) {
         serverlessLog(
@@ -871,12 +865,16 @@ export default class HttpServer {
         )
         return
       }
-      if (!path) {
+      if (!pathResource) {
         serverlessLog(`WARNING: Could not resolve path for '${methodId}'.`)
         return
       }
 
-      const hapiPath = generateHapiPath(path, this.#options, this.#serverless)
+      const hapiPath = generateHapiPath(
+        pathResource,
+        this.#options,
+        this.#serverless,
+      )
       const proxyUriOverwrite = resourceRoutesOptions[methodId] || {}
       const proxyUriInUse = proxyUriOverwrite.Uri || proxyUri
 

--- a/src/events/http/parseResources.js
+++ b/src/events/http/parseResources.js
@@ -145,10 +145,6 @@ function getIntegrationObj(methodObj) {
   return methodObj.Properties.Integration
 }
 
-function templatePathToHapiPath(path) {
-  return path.replace('+', '')
-}
-
 function constructHapiInterface(pathObjects, methodObjects, methodId) {
   // returns all info necessary so that routes can be added in index.js
   const methodObj = methodObjects[methodId]
@@ -163,8 +159,6 @@ function constructHapiInterface(pathObjects, methodObjects, methodId) {
     return {}
   }
 
-  const path = templatePathToHapiPath(pathResource)
-
   if (Integration.Type === APIGATEWAY_INTEGRATION_TYPE_HTTP_PROXY) {
     proxyUri = Integration.Uri
   }
@@ -172,7 +166,6 @@ function constructHapiInterface(pathObjects, methodObjects, methodId) {
   return {
     isProxy: !!proxyUri,
     method,
-    path,
     pathResource,
     proxyUri,
   }

--- a/src/utils/generateHapiPath.js
+++ b/src/utils/generateHapiPath.js
@@ -4,7 +4,7 @@ export default function generateHapiPath(path = '', options, serverless) {
 
   if (!options.noPrependStageInUrl) {
     const stage = options.stage || serverless.service.provider.stage
-    // prepend stage to path
+    // prepend the stage to path
     hapiPath = `/${stage}${hapiPath}`
   }
 


### PR DESCRIPTION
Fixes: #1016 

I don't think we still need this path.replace, i could not find any case for it(hopefully someone more familiar with the code can shine some light on it). Especially since in generateHapiPath.js, where the resulting path is used, we expect this '+' to still be there.