### PR TITLE
feat: Resolve Fn::Join in environment variables 

### DIFF
--- a/src/lambda/LambdaFunction.js
+++ b/src/lambda/LambdaFunction.js
@@ -6,6 +6,7 @@ import jszip from 'jszip'
 import HandlerRunner from './handler-runner/index.js'
 import LambdaContext from './LambdaContext.js'
 import serverlessLog from '../serverlessLog.js'
+import resolveJoins from '../utils/resolveJoins.js'
 import {
   DEFAULT_LAMBDA_MEMORY_SIZE,
   DEFAULT_LAMBDA_RUNTIME,
@@ -77,7 +78,7 @@ export default class LambdaFunction {
     this._verifySupportedRuntime()
 
     const env = this._getEnv(
-      provider.environment,
+      resolveJoins(provider.environment),
       functionDefinition.environment,
       handler,
     )

--- a/src/utils/resolveJoins.js
+++ b/src/utils/resolveJoins.js
@@ -1,5 +1,9 @@
 // Used to resolve Fn::Join in environment variables
 export default function resolveJoins(environment) {
+  if (!environment) {
+    return undefined
+  }
+
   const newEnv = {}
 
   Object.keys(environment).forEach((key) => {

--- a/src/utils/resolveJoins.js
+++ b/src/utils/resolveJoins.js
@@ -1,0 +1,20 @@
+// Used to resolve Fn::Join in environment variables
+export default function resolveJoins(environment) {
+  const newEnv = {}
+
+  Object.keys(environment).forEach((key) => {
+    const value = environment[key]
+    const joinArray = value['Fn::Join']
+    const isJoin = Boolean(joinArray)
+
+    if (isJoin) {
+      const separator = joinArray[0]
+      const joined = joinArray[1].join(separator)
+      newEnv[key] = joined
+    } else {
+      newEnv[key] = value
+    }
+  })
+
+  return newEnv
+}


### PR DESCRIPTION
## Purpose

Currently, `Fn::Join` is not being resolved correctly in environment variables. This PR uses javascript's `Array.join` to correctly resolve such values.