### PR TITLE
Fix Api Gateway Proxy logs

### DIFF
--- a/src/events/http/HttpServer.js
+++ b/src/events/http/HttpServer.js
@@ -984,7 +984,7 @@ export default class HttpServer {
           }
 
           serverlessLog(
-            `PROXY ${request.method} ${request.url.path} -> ${resultUri}`,
+            `PROXY ${request.method} ${request.url.pathname} -> ${resultUri}`,
           )
 
           return h.proxy({


### PR DESCRIPTION
When we send a request to a proxy we have this kind of output 
<img width="472" alt="Screenshot 2020-07-07 at 3 49 03 PM" src="https://user-images.githubusercontent.com/18052624/86740643-62ce2e80-c069-11ea-9777-5259a057c294.png">