### PR TITLE
Handle undefined environment variables in resolveJoins

### DIFF
--- a/src/utils/resolveJoins.js
+++ b/src/utils/resolveJoins.js
@@ -9,7 +9,6 @@ export default function resolveJoins(environment) {
   Object.keys(environment).forEach((key) => {
     const value = environment[key]
     if (!value) {
-      newEnv[key] = value
       return
     }
 

--- a/src/utils/resolveJoins.js
+++ b/src/utils/resolveJoins.js
@@ -12,7 +12,7 @@ export default function resolveJoins(environment) {
       newEnv[key] = value
       return
     }
-    
+
     const joinArray = value['Fn::Join']
     const isJoin = Boolean(joinArray)
 

--- a/src/utils/resolveJoins.js
+++ b/src/utils/resolveJoins.js
@@ -8,6 +8,11 @@ export default function resolveJoins(environment) {
 
   Object.keys(environment).forEach((key) => {
     const value = environment[key]
+    if (!value) {
+      newEnv[key] = value
+      return
+    }
+    
     const joinArray = value['Fn::Join']
     const isJoin = Boolean(joinArray)
 

--- a/tests/endToEnd/environmentVariables/environmentVariables.test.js
+++ b/tests/endToEnd/environmentVariables/environmentVariables.test.js
@@ -1,0 +1,67 @@
+import { resolve } from 'path'
+import fetch from 'node-fetch'
+import {
+  joinUrl,
+  setup,
+  teardown,
+} from '../../integration/_testHelpers/index.js'
+
+jest.setTimeout(30000)
+
+describe('environment variables', () => {
+  const ENV_VAR_QUOTED = 'I am ENV_VAR_1'
+  const ENV_VAR_UNQUOTED = 'I am ENV_VAR_2'
+  const ENV_VAR_MAPPED = 'I am ENV_VAR_3'
+
+  // init
+  let json
+  beforeAll(async () => {
+    process.env.ENV_VAR_QUOTED = ENV_VAR_QUOTED
+    process.env.ENV_VAR_UNQUOTED = ENV_VAR_UNQUOTED
+    process.env.ENV_VAR_MAPPED_FROM_ANOTHER = ENV_VAR_MAPPED
+    await setup({
+      servicePath: resolve(__dirname),
+    })
+    const url = joinUrl(TEST_BASE_URL, '/dev/hello')
+    const response = await fetch(url)
+    json = await response.json()
+  })
+
+  // cleanup
+  afterAll(async () => {
+    process.env.ENV_VAR_QUOTED = undefined
+    process.env.ENV_VAR_UNQUOTED = undefined
+    process.env.ENV_VAR_MAPPED_FROM_ANOTHER = undefined
+    await teardown()
+  })
+
+  test('it should handle a quoted environment variable', async () => {
+    expect(json).toMatchObject({
+      ENV_VAR_QUOTED,
+    })
+  })
+
+  test('it should handle an unquoted environment variable', async () => {
+    expect(json).toMatchObject({
+      ENV_VAR_UNQUOTED,
+    })
+  })
+
+  test('it should handle a mapped environment variable', async () => {
+    expect(json).toMatchObject({
+      ENV_VAR_MAPPED,
+    })
+  })
+
+  test('it should handle an undefined quoted environment variable', async () => {
+    expect(json).toMatchObject({
+      ENV_VAR_EMPTY_STRING: 'undefined',
+    })
+  })
+
+  test('it should handle an undefined unquoted environment variable', async () => {
+    expect(json).toMatchObject({
+      ENV_VAR_UNDEFINED: 'undefined',
+    })
+  })
+})

--- a/tests/endToEnd/environmentVariables/environmentVariables.test.js
+++ b/tests/endToEnd/environmentVariables/environmentVariables.test.js
@@ -54,14 +54,10 @@ describe('environment variables', () => {
   })
 
   test('it should handle an undefined quoted environment variable', async () => {
-    expect(json).toMatchObject({
-      ENV_VAR_EMPTY_STRING: 'undefined',
-    })
+    expect(json).toHaveProperty('ENV_VAR_EMPTY_STRING', undefined)
   })
 
   test('it should handle an undefined unquoted environment variable', async () => {
-    expect(json).toMatchObject({
-      ENV_VAR_UNDEFINED: 'undefined',
-    })
+    expect(json).toHaveProperty('ENV_VAR_UNDEFINED', undefined)
   })
 })

--- a/tests/endToEnd/environmentVariables/handler.js
+++ b/tests/endToEnd/environmentVariables/handler.js
@@ -1,0 +1,24 @@
+'use strict'
+
+exports.hello = async () => {
+  const {
+    ENV_VAR_QUOTED,
+    ENV_VAR_UNQUOTED,
+    ENV_VAR_MAPPED,
+    ENV_VAR_EMPTY_STRING,
+    ENV_VAR_UNDEFINED,
+  } = process.env
+
+  const body = JSON.stringify({
+    ENV_VAR_QUOTED,
+    ENV_VAR_UNQUOTED,
+    ENV_VAR_MAPPED,
+    ENV_VAR_EMPTY_STRING,
+    ENV_VAR_UNDEFINED,
+  })
+
+  return {
+    statusCode: 200,
+    body,
+  }
+}

--- a/tests/endToEnd/environmentVariables/handler.js
+++ b/tests/endToEnd/environmentVariables/handler.js
@@ -13,8 +13,8 @@ exports.hello = async () => {
     ENV_VAR_QUOTED,
     ENV_VAR_UNQUOTED,
     ENV_VAR_MAPPED,
-    ENV_VAR_EMPTY_STRING,
-    ENV_VAR_UNDEFINED,
+    ENV_VAR_EMPTY_STRING, // This should be undefined
+    ENV_VAR_UNDEFINED, // This should be undefined
   })
 
   return {

--- a/tests/endToEnd/environmentVariables/serverless.yml
+++ b/tests/endToEnd/environmentVariables/serverless.yml
@@ -1,0 +1,26 @@
+service: uncategorized-tests
+
+plugins:
+  - ../../../
+
+provider:
+  memorySize: 128
+  name: aws
+  region: us-east-1 # default
+  runtime: nodejs12.x
+  stage: dev
+  versionFunctions: false
+  environment:
+    ENV_VAR_QUOTED: "${env:ENV_VAR_QUOTED}"
+    ENV_VAR_UNQUOTED: ${env:ENV_VAR_UNQUOTED}
+    ENV_VAR_MAPPED: "${env:ENV_VAR_MAPPED_FROM_ANOTHER}"
+    ENV_VAR_EMPTY_STRING: "${env:ENV_VAR_EMPTY_STRING}"
+    ENV_VAR_UNDEFINED: ${env:ENV_VAR_UNDEFINED}
+
+functions:
+  hello:
+    handler: handler.hello
+    events:
+      - http:
+          method: get
+          path: /hello


### PR DESCRIPTION
Suggested fix for https://github.com/dherault/serverless-offline/issues/1048 - tested locally and it works for me.
I also added a test suite for env var handling

Fixes the following exception:
```
Debug: internal, implementation, error
    TypeError: Cannot read property 'Fn::Join' of undefined
    at /Users/alexhayton/personal/stablemaster/lambda/node_modules/serverless-offline/dist/utils/resolveJoins.js:17:28
    at Array.forEach (<anonymous>)
    at resolveJoins (/Users/alexhayton/personal/stablemaster/lambda/node_modules/serverless-offline/dist/utils/resolveJoins.js:15:28)
    at new LambdaFunction (/Users/alexhayton/personal/stablemaster/lambda/node_modules/serverless-offline/dist/lambda/LambdaFunction.js:154:56)
    at LambdaFunctionPool.get (/Users/alexhayton/personal/stablemaster/lambda/node_modules/serverless-offline/dist/lambda/LambdaFunctionPool.js:93:24)
    at Lambda.get (/Users/alexhayton/personal/stablemaster/lambda/node_modules/serverless-offline/dist/lambda/Lambda.js:60:88)
    at hapiHandler (/Users/alexhayton/personal/stablemaster/lambda/node_modules/serverless-offline/dist/events/http/HttpServer.js:511:82)
    at module.exports.internals.Manager.execute (/Users/alexhayton/personal/stablemaster/lambda/node_modules/@hapi/hapi/lib/toolkit.js:41:33)
    at Object.internals.handler (/Users/alexhayton/personal/stablemaster/lambda/node_modules/@hapi/hapi/lib/handler.js:46:48)
    at exports.execute (/Users/alexhayton/personal/stablemaster/lambda/node_modules/@hapi/hapi/lib/handler.js:31:36)
    at Request._lifecycle (/Users/alexhayton/personal/stablemaster/lambda/node_modules/@hapi/hapi/lib/request.js:312:68)
    at processTicksAndRejections (internal/process/task_queues.js:97:5)
    at Request._execute (/Users/alexhayton/personal/stablemaster/lambda/node_modules/@hapi/hapi/lib/request.js:221:9)
```

To reproduce, simply define something in `provider.environment` which isn't set in your local shell:
```yaml
provider:
  environment:
    MY_ENV_VAR: ${env:MY_ENV_VAR}
```