### PR TITLE
Fix: Handle undefined values when resolving Fn::Join in environment variables

### DIFF
--- a/src/utils/resolveJoins.js
+++ b/src/utils/resolveJoins.js
@@ -8,6 +8,10 @@ export default function resolveJoins(environment) {
 
   Object.keys(environment).forEach((key) => {
     const value = environment[key]
+    if (!value) {
+      return
+    }
+
     const joinArray = value['Fn::Join']
     const isJoin = Boolean(joinArray)
 


### PR DESCRIPTION
Fixes an edge case for #1032 which would cause a crash when environment variables have a value of `undefined`.

![image](https://user-images.githubusercontent.com/10026538/88601655-1aeb6780-d069-11ea-96f8-60812695954b.png)

I can just set the environment variable value and then everything is fine but this error should probably still be fixed because it causes `serverless-offline` to crash where it need not.

> But why would you have `undefined` environment variable value anyway?

Good question! Normally you shouldn't, because if you don't need an environment variable set you should probably remove it right?

I was developing locally and I didn't need certain environment variables set for local development with `sls offline`, but I did need them at deploy time. And it was working before I upgraded `serverless-offline` to v6.5.0 (for another feature).

**Example:** In my app, I only need the Slack Client ID when I deploy. But I still want to use `sls offline` to test parts of my app locally.

`SLACK_CLIENT_ID: ${env:SLACK_CLIENT_ID}`

![image](https://user-images.githubusercontent.com/10026538/88601922-98af7300-d069-11ea-8b4e-d22e389b96be.png)