### PR TITLE
Protect against undefined env vars when resolving joins

### DIFF
--- a/src/utils/resolveJoins.js
+++ b/src/utils/resolveJoins.js
@@ -9,7 +9,7 @@ export default function resolveJoins(environment) {
   Object.keys(environment).forEach((key) => {
     const value = environment[key]
     if (!value) {
-      return; 
+      return
     }
     const joinArray = value['Fn::Join']
     const isJoin = Boolean(joinArray)

--- a/src/utils/resolveJoins.js
+++ b/src/utils/resolveJoins.js
@@ -8,6 +8,9 @@ export default function resolveJoins(environment) {
 
   Object.keys(environment).forEach((key) => {
     const value = environment[key]
+    if (!value) {
+      return; 
+    }
     const joinArray = value['Fn::Join']
     const isJoin = Boolean(joinArray)
 


### PR DESCRIPTION
While running sls offline on version 6.5, i came across a somewhat cryptic error:

```
Debug: internal, implementation, error 
    TypeError: Cannot read property 'Fn::Join' of undefined
    at my/path/node_modules/serverless-offline/dist/utils/resolveJoins.js:18:28
    at Array.forEach (<anonymous>)
    at resolveJoins (my/path/node_modules/serverless-offline/dist/utils/resolveJoins.js:15:28)
    at new LambdaFunction (my/path/node_modules/serverless-offline/dist/lambda/LambdaFunction.js:154:56)
    at LambdaFunctionPool.get (my/path/node_modules/serverless-offline/dist/lambda/LambdaFunctionPool.js:93:24)
    at Lambda.get (my/path/node_modules/serverless-offline/dist/lambda/Lambda.js:60:88)
    at hapiHandler (my/path/node_modules/serverless-offline/dist/events/http/HttpServer.js:511:82)
    at module.exports.internals.Manager.execute (my/path/node_modules/@hapi/hapi/lib/toolkit.js:41:33)
    at Object.internals.handler (my/path/node_modules/@hapi/hapi/lib/handler.js:46:48)
    at exports.execute (my/path/node_modules/@hapi/hapi/lib/handler.js:31:36)
    at Request._lifecycle (my/path/node_modules/@hapi/hapi/lib/request.js:312:68)
    at runMicrotasks (<anonymous>)
    at processTicksAndRejections (internal/process/task_queues.js:97:5)
    at Request._execute (my/path/node_modules/@hapi/hapi/lib/request.js:221:9)
```

Since my project doesn't use the join intrinsic function, the error wasn't particularly helpful in determining the problem.

After a bit of search, I found the cause in [this PR](https://github.com/dherault/serverless-offline/pull/1032).

The problem is that, if an environment variable is `undefined`, an exception is raised.

A better approach might be to either ignore undefined env vars or log them with a warning. I chose the former right now but am open to change the code as needed.