### PR TITLE
Handle array-based jwt audience data

### DIFF
--- a/src/events/http/createJWTAuthScheme.js
+++ b/src/events/http/createJWTAuthScheme.js
@@ -53,10 +53,15 @@ export default function createAuthScheme(jwtOptions) {
           return Boom.unauthorized('JWT Token not from correct issuer url')
         }
 
-        if (
-          !jwtOptions.audience.includes(aud) &&
-          !jwtOptions.audience.includes(clientId)
-        ) {
+        const validAudiences = Array.isArray(jwtOptions.audience)
+          ? jwtOptions.audience
+          : [jwtOptions.audience]
+        const providedAudiences = Array.isArray(aud) ? aud : [aud]
+        const validAudienceProvided = providedAudiences.some((a) =>
+          validAudiences.includes(a),
+        )
+
+        if (!validAudienceProvided && !jwtOptions.audience.includes(clientId)) {
           serverlessLog(`JWT Token not from correct audience`)
           return Boom.unauthorized('JWT Token not from correct audience')
         }


### PR DESCRIPTION
Auth0, for example, can send `aud: ["<audience1>", "<audience2>"]` in it's token. It also looks like it's possible to configure multiple or single acceptable audiences in the `serverless.yml`. This PR lifts both sets of audiences into an array which are then checked for an overlap.