### PR TITLE
Regression: randomly generated API key is not displayed if no API key is defined

### DIFF
--- a/src/ServerlessOffline.js
+++ b/src/ServerlessOffline.js
@@ -265,25 +265,14 @@ export default class ServerlessOffline {
   _getEvents() {
     const { service } = this.#serverless
 
-    // for simple API Key authentication model
-    if (service.provider.apiKeys) {
-      serverlessLog(`Key with token: ${this.#options.apiKey}`)
-
-      if (this.#options.noAuth) {
-        serverlessLog(
-          'Authorizers are turned off. You do not need to use x-api-key header.',
-        )
-      } else {
-        serverlessLog('Remember to use x-api-key on the request headers')
-      }
-    }
-
     const httpEvents = []
     const lambdas = []
     const scheduleEvents = []
     const webSocketEvents = []
 
     const functionKeys = service.getAllFunctions()
+
+    let hasPrivateHttpEvent = false
 
     functionKeys.forEach((functionKey) => {
       const functionDefinition = service.getFunction(functionKey)
@@ -310,6 +299,10 @@ export default class ServerlessOffline {
             httpEvent.http = { ...httpApi, isHttpApi: true }
           }
 
+          if (http && http.private) {
+            hasPrivateHttpEvent = true
+          }
+
           httpEvents.push(httpEvent)
         }
 
@@ -322,6 +315,19 @@ export default class ServerlessOffline {
         }
       })
     })
+
+    // for simple API Key authentication model
+    if (hasPrivateHttpEvent) {
+      serverlessLog(`Key with token: ${this.#options.apiKey}`)
+
+      if (this.#options.noAuth) {
+        serverlessLog(
+          'Authorizers are turned off. You do not need to use x-api-key header.',
+        )
+      } else {
+        serverlessLog('Remember to use x-api-key on the request headers')
+      }
+    }
 
     return {
       httpEvents,


### PR DESCRIPTION
Fixing a regression of a fix for bug raised in a #832 issue.