### PR TITLE
Support WebSocket timeouts limits & fix connectedAt context attribute

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ All CLI options are optional:
 --useWorkerThreads          Uses worker threads for handlers. Requires node.js v11.7.0 or higher
 --websocketPort             WebSocket port to listen on. Default: 3001
 --webSocketHardTimeout      Set WebSocket hard timeout in seconds to reproduce AWS limits (https://docs.aws.amazon.com/apigateway/latest/developerguide/limits.html#apigateway-execution-service-websocket-limits-table). Default: 7200 (2 hours)
+--webSocketIdleTimeout      Set WebSocket idle timeout in seconds to reproduce AWS limits (https://docs.aws.amazon.com/apigateway/latest/developerguide/limits.html#apigateway-execution-service-websocket-limits-table). Default: 600 (10 minutes)
 --useDocker                 Run handlers in a docker container.
 ```
 

--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@ All CLI options are optional:
 --useChildProcesses         Run handlers in a child process
 --useWorkerThreads          Uses worker threads for handlers. Requires node.js v11.7.0 or higher
 --websocketPort             WebSocket port to listen on. Default: 3001
+--webSocketHardTimeout      Set WebSocket hard timeout in seconds to reproduce AWS limits (https://docs.aws.amazon.com/apigateway/latest/developerguide/limits.html#apigateway-execution-service-websocket-limits-table). Default: 7200 (2 hours)
 --useDocker                 Run handlers in a docker container.
 ```
 

--- a/src/config/commandOptions.js
+++ b/src/config/commandOptions.js
@@ -78,6 +78,10 @@ export default {
   websocketPort: {
     usage: 'Websocket port to listen on. Default: 3001',
   },
+  webSocketHardTimeout: {
+    usage:
+      'Set WebSocket hard timeout in seconds to reproduce AWS limits (https://docs.aws.amazon.com/apigateway/latest/developerguide/limits.html#apigateway-execution-service-websocket-limits-table). Default: 7200 (2 hours)',
+  },
   useDocker: {
     usage: 'Uses docker for node/python/ruby',
   },

--- a/src/config/commandOptions.js
+++ b/src/config/commandOptions.js
@@ -82,6 +82,10 @@ export default {
     usage:
       'Set WebSocket hard timeout in seconds to reproduce AWS limits (https://docs.aws.amazon.com/apigateway/latest/developerguide/limits.html#apigateway-execution-service-websocket-limits-table). Default: 7200 (2 hours)',
   },
+  webSocketIdleTimeout: {
+    usage:
+      'Set WebSocket idle timeout in seconds to reproduce AWS limits (https://docs.aws.amazon.com/apigateway/latest/developerguide/limits.html#apigateway-execution-service-websocket-limits-table). Default: 600 (10 minutes)',
+  },
   useDocker: {
     usage: 'Uses docker for node/python/ruby',
   },

--- a/src/config/defaultOptions.js
+++ b/src/config/defaultOptions.js
@@ -22,6 +22,7 @@ export default {
   useChildProcesses: false,
   useWorkerThreads: false,
   websocketPort: 3001,
+  webSocketHardTimeout: 7200,
   useDocker: false,
   functionCleanupIdleTimeSeconds: 60,
 }

--- a/src/config/defaultOptions.js
+++ b/src/config/defaultOptions.js
@@ -23,6 +23,7 @@ export default {
   useWorkerThreads: false,
   websocketPort: 3001,
   webSocketHardTimeout: 7200,
+  webSocketIdleTimeout: 600,
   useDocker: false,
   functionCleanupIdleTimeSeconds: 60,
 }

--- a/src/events/websocket/WebSocketClients.js
+++ b/src/events/websocket/WebSocketClients.js
@@ -127,6 +127,11 @@ export default class WebSocketClients {
 
     this._processEvent(webSocketClient, connectionId, '$connect', connectEvent)
 
+    const hardTimeout = setTimeout(() => {
+      debugLog(`timeout:hard:${connectionId}`)
+      webSocketClient.close()
+    }, 2 * 3600 * 1000)
+
     webSocketClient.on('close', () => {
       debugLog(`disconnect:${connectionId}`)
 
@@ -135,6 +140,8 @@ export default class WebSocketClients {
       const disconnectEvent = new WebSocketDisconnectEvent(
         connectionId,
       ).create()
+
+      clearTimeout(hardTimeout)
 
       this._processEvent(
         webSocketClient,

--- a/src/events/websocket/WebSocketClients.js
+++ b/src/events/websocket/WebSocketClients.js
@@ -41,7 +41,6 @@ export default class WebSocketClients {
 
     this.#clients.delete(client)
     this.#clients.delete(connectionId)
-    this.#idleTimeouts.delete(connectionId, client)
 
     return connectionId
   }
@@ -57,7 +56,7 @@ export default class WebSocketClients {
     const timeoutId = setTimeout(() => {
       debugLog(`timeout:idle:${connectionId}`)
       client.close(1001, 'Going away')
-    }, 10 * 1000)
+    }, this.#options.webSocketIdleTimeout * 1000)
     this.#idleTimeouts.set(client, timeoutId)
   }
 
@@ -161,7 +160,7 @@ export default class WebSocketClients {
       ).create()
 
       clearTimeout(hardTimeout)
-      this._clearIdleTimeout(connectionId)
+      this._clearIdleTimeout(webSocketClient)
 
       this._processEvent(
         webSocketClient,

--- a/src/events/websocket/WebSocketClients.js
+++ b/src/events/websocket/WebSocketClients.js
@@ -130,7 +130,7 @@ export default class WebSocketClients {
     const hardTimeout = setTimeout(() => {
       debugLog(`timeout:hard:${connectionId}`)
       webSocketClient.close()
-    }, 2 * 3600 * 1000)
+    }, this.#options.webSocketHardTimeout * 1000)
 
     webSocketClient.on('close', () => {
       debugLog(`disconnect:${connectionId}`)

--- a/src/events/websocket/lambda-events/WebSocketRequestContext.js
+++ b/src/events/websocket/lambda-events/WebSocketRequestContext.js
@@ -2,15 +2,28 @@ import { createUniqueId, formatToClfTime } from '../../../utils/index.js'
 
 const { now } = Date
 
+const connectedAt = new Map()
+
 export default class WebSocketRequestContext {
   #connectionId = null
   #eventType = null
   #route = null
+  #connectedAt = null
 
   constructor(eventType, route, connectionId) {
     this.#connectionId = connectionId
     this.#eventType = eventType
     this.#route = route
+
+    if (eventType === 'CONNECT') {
+      connectedAt.set(connectionId, now())
+    }
+
+    this.#connectedAt = connectedAt.get(connectionId)
+
+    if (eventType === 'DISCONNECT') {
+      connectedAt.delete(connectionId)
+    }
   }
 
   create() {
@@ -18,7 +31,7 @@ export default class WebSocketRequestContext {
 
     const requestContext = {
       apiId: 'private',
-      connectedAt: now(), // TODO this is probably not correct, and should be the initial connection time?
+      connectedAt: this.#connectedAt,
       connectionId: this.#connectionId,
       domainName: 'localhost',
       eventType: this.#eventType,


### PR DESCRIPTION
This PR add WebSocket idle & hard timeouts support. This is configurable, in order to be able to test timeout behaviour without having to wait for 2 hours 😄 

Also fixing connectedAt request context attribute.


I didn't add test because there is no tests currently so it's a lot of work to add test for this.(I found https://github.com/dherault/serverless-offline/pull/814 but looks like it won't be merged)