### PR TITLE
JWT token contains multiple audience values (eg, Auth0)

### DIFF
--- a/src/events/http/createJWTAuthScheme.js
+++ b/src/events/http/createJWTAuthScheme.js
@@ -54,11 +54,15 @@ export default function createAuthScheme(jwtOptions) {
         }
 
         if (
-          !jwtOptions.audience.includes(aud) &&
+          jwtOptions.audience.filter((x) =>
+            Array.isArray(aud) ? aud.includes(x) : aud === x,
+          ).length === 0 &&
           !jwtOptions.audience.includes(clientId)
         ) {
-          serverlessLog(`JWT Token not from correct audience`)
-          return Boom.unauthorized('JWT Token not from correct audience')
+          serverlessLog(`JWT Token does not contain correct audience`)
+          return Boom.unauthorized(
+            'JWT Token does not contain correct audience',
+          )
         }
 
         let scopes = null

--- a/tests/integration/jwt-authorizer/jwt-authorizer.test.js
+++ b/tests/integration/jwt-authorizer/jwt-authorizer.test.js
@@ -58,6 +58,11 @@ const correctAudience = {
 }
 delete correctAudience.client_id
 
+const multipleCorrectAudience = {
+  ...correctAudience,
+  aud: [baseJWT.client_id, 'https://api.example.com/'],
+}
+
 const noScopes = {
   ...baseJWT,
 }
@@ -105,6 +110,21 @@ describe('jwt authorizer tests', () => {
     },
 
     {
+      description:
+        'Valid JWT with multiple audience values (one matching single configured audience)',
+      expected: {
+        status: 'authorized',
+        requestContext: {
+          claims: multipleCorrectAudience,
+          scopes: ['profile', 'email'],
+        },
+      },
+      jwt: multipleCorrectAudience,
+      path: '/dev/user1',
+      status: 200,
+    },
+
+    {
       description: 'Valid JWT with scopes',
       expected: {
         status: 'authorized',
@@ -144,7 +164,7 @@ describe('jwt authorizer tests', () => {
       expected: {
         statusCode: 401,
         error: 'Unauthorized',
-        message: 'JWT Token not from correct audience',
+        message: 'JWT Token does not contain correct audience',
       },
       jwt: wrongClientId,
       path: '/dev/user1',
@@ -155,7 +175,7 @@ describe('jwt authorizer tests', () => {
       expected: {
         statusCode: 401,
         error: 'Unauthorized',
-        message: 'JWT Token not from correct audience',
+        message: 'JWT Token does not contain correct audience',
       },
       jwt: wrongAudience,
       path: '/dev/user1',


### PR DESCRIPTION
[The `aud` claim in a JWT token can be an list](https://stackoverflow.com/a/41237822), in which case, validation should pass if one of the values matches one of the values configured for the authoriser. 

For example, see [Auth0 access tokens](https://auth0.com/docs/tokens#access-tokens).