### PR TITLE
Improved lambda invoke

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,6 +198,38 @@ aws lambda invoke /dev/null \
   --function-name myServiceName-dev-invokedHandler
 ```
 
+List of available function names and their corresponding serverless.yml function keys
+are listed after the server starts. This is important if you use a custom naming
+scheme for your functions as the serverless-offline will use your custom name:
+
+```
+serverless offline
+...
+offline: Starting Offline: local/us-east-1.
+offline: Offline [http for lambda] listening on http://localhost:3002
+offline: Function names exposed for local invocation by aws-sdk:
+           * invokedHandler: myServiceName-dev-invokedHandler
+```
+
+To list the available manual invocation paths exposed to for targeting 
+by the aws-sdk and aws-cli use `SLS_DEBUG=*` with `serverless offline`. After the invoke server starts up, full list of endpoints will be displayed:
+```
+SLS_DEBUG=* serverless offline
+...
+offline: Starting Offline: local/us-east-1.
+...
+offline: Offline [http for lambda] listening on http://localhost:3002
+offline: Function names exposed for local invocation by aws-sdk:
+           * invokedHandler: myServiceName-dev-invokedHandler
+[offline] Lambda Invocation Routes (for AWS SDK or AWS CLI):
+           * POST http://localhost:3002/2015-03-31/functions/myServiceName-dev-invokedHandler/invocations
+[offline] Lambda Async Invocation Routes (for AWS SDK or AWS CLI):
+           * POST http://localhost:3002/2014-11-13/functions/myServiceName-dev-invokedHandler/invoke-async/
+```
+
+You can manually target these endpoints with a REST client to debug your lambda
+function.
+
 ## The `process.env.IS_OFFLINE` variable
 
 Will be `"true"` in your handlers and thorough the plugin.

--- a/README.md
+++ b/README.md
@@ -200,7 +200,11 @@ aws lambda invoke /dev/null \
 
 List of available function names and their corresponding serverless.yml function keys
 are listed after the server starts. This is important if you use a custom naming
-scheme for your functions as the serverless-offline will use your custom name:
+scheme for your functions as `serverless-offline` will use your custom name.
+The left side is the function's key in your `serverless.yml`
+(`invokedHandler` in the example below) and the right side is the function name
+that is used to call the function externally such as `aws-sdk`
+(`myServiceName-dev-invokedHandler` in the example below):
 
 ```
 serverless offline
@@ -211,8 +215,8 @@ offline: Function names exposed for local invocation by aws-sdk:
            * invokedHandler: myServiceName-dev-invokedHandler
 ```
 
-To list the available manual invocation paths exposed to for targeting 
-by the aws-sdk and aws-cli use `SLS_DEBUG=*` with `serverless offline`. After the invoke server starts up, full list of endpoints will be displayed:
+To list the available manual invocation paths exposed for targeting 
+by `aws-sdk` and `aws-cli`, use `SLS_DEBUG=*` with `serverless offline`. After the invoke server starts up, full list of endpoints will be displayed:
 ```
 SLS_DEBUG=* serverless offline
 ...
@@ -228,7 +232,8 @@ offline: Function names exposed for local invocation by aws-sdk:
 ```
 
 You can manually target these endpoints with a REST client to debug your lambda
-function.
+function if you want to. Your `POST` JSON body will be the `Payload` passed to your function if you were
+to calling it via `aws-sdk`.
 
 ## The `process.env.IS_OFFLINE` variable
 

--- a/README.md
+++ b/README.md
@@ -706,7 +706,6 @@ We try to follow [Airbnb's JavaScript Style Guide](https://github.com/airbnb/jav
 :---: |:---: |:---: |:---: |:---: |
 [lteacher](https://github.com/lteacher) |[martinmicunda](https://github.com/martinmicunda) |[nori3tsu](https://github.com/nori3tsu) |[ppasmanik](https://github.com/ppasmanik) |[ryanzyy](https://github.com/ryanzyy) |
 
-[<img alt="m0ppers" src="https://avatars3.githubusercontent.com/u/819421?v=4&s=117" width="117">](https://github.com/m0ppers) |[<img alt="footballencarta" src="https://avatars0.githubusercontent.com/u/1312258?v=4&s=117" width="117">](https://github.com/footballencarta) |
-:---: |:---: |
-[m0ppers](https://github.com/m0ppers) |[footballencarta](https://github.com/footballencarta) |
-
+[<img alt="m0ppers" src="https://avatars3.githubusercontent.com/u/819421?v=4&s=117" width="117">](https://github.com/m0ppers) |[<img alt="footballencarta" src="https://avatars0.githubusercontent.com/u/1312258?v=4&s=117" width="117">](https://github.com/footballencarta) |[<img alt="bryanvaz" src="https://avatars0.githubusercontent.com/u/9157498?v=4&s=117" width="117">](https://github.com/bryanvaz) |
+:---: |:---: |:---: |
+[m0ppers](https://github.com/m0ppers) |[footballencarta](https://github.com/footballencarta) |[bryanvaz](https://github.com/bryanvaz) |

--- a/package.json
+++ b/package.json
@@ -146,7 +146,8 @@
     "Tuan Minh Huynh (https://github.com/tuanmh)",
     "Utku Turunc (https://github.com/utkuturunc)",
     "Vasiliy Solovey (https://github.com/miltador)",
-    "Dima Krutolianov (https://github.com/dimadk24)"
+    "Dima Krutolianov (https://github.com/dimadk24)",
+    "Bryan Vaz (https://github.com/bryanvaz)"
   ],
   "engines": {
     "node": ">=10.13.0"

--- a/src/lambda/HttpServer.js
+++ b/src/lambda/HttpServer.js
@@ -49,9 +49,9 @@ export default class HttpServer {
     // Print all the invocation routes to debug
     const basePath = `http${httpsProtocol ? 's' : ''}://${host}:${lambdaPort}`
     const funcNamePairs = this.#lambda.listFunctionNamePairs()
-    debugLog(
+    serverlessLog(
       [
-        `Lambda Function Names (For local lambda invocation):`,
+        `Function names exposed for local invocation by aws-sdk:`,
         ...this.#lambda
           .listFunctionNames()
           .map(
@@ -62,7 +62,7 @@ export default class HttpServer {
     )
     debugLog(
       [
-        `Lambda Invocation Routes:`,
+        `Lambda Invocation Routes (for AWS SDK or AWS CLI):`,
         ...this.#lambda
           .listFunctionNames()
           .map(
@@ -78,7 +78,7 @@ export default class HttpServer {
     )
     debugLog(
       [
-        `Lambda Async Invocation Routes:`,
+        `Lambda Async Invocation Routes (for AWS SDK or AWS CLI):`,
         ...this.#lambda
           .listFunctionNames()
           .map(

--- a/src/lambda/HttpServer.js
+++ b/src/lambda/HttpServer.js
@@ -1,6 +1,7 @@
 import { Server } from '@hapi/hapi'
 import { invocationsRoute, invokeAsyncRoute } from './routes/index.js'
 import serverlessLog from '../serverlessLog.js'
+import debugLog from '../debugLog.js'
 
 export default class HttpServer {
   #lambda = null
@@ -44,6 +45,52 @@ export default class HttpServer {
       `Offline [http for lambda] listening on http${
         httpsProtocol ? 's' : ''
       }://${host}:${lambdaPort}`,
+    )
+    // Print all the invocation routes to debug
+    const basePath = `http${httpsProtocol ? 's' : ''}://${host}:${lambdaPort}`
+    const funcNamePairs = this.#lambda.listFunctionNamePairs()
+    debugLog(
+      [
+        `Lambda Function Names (For local lambda invocation):`,
+        ...this.#lambda
+          .listFunctionNames()
+          .map(
+            (functionName) =>
+              `           * ${funcNamePairs[functionName]}: ${functionName}`,
+          ),
+      ].join('\n'),
+    )
+    debugLog(
+      [
+        `Lambda Invocation Routes:`,
+        ...this.#lambda
+          .listFunctionNames()
+          .map(
+            (functionName) =>
+              `           * ${
+                _invocationsRoute.method
+              } ${basePath}${_invocationsRoute.path.replace(
+                '{functionName}',
+                functionName,
+              )}`,
+          ),
+      ].join('\n'),
+    )
+    debugLog(
+      [
+        `Lambda Async Invocation Routes:`,
+        ...this.#lambda
+          .listFunctionNames()
+          .map(
+            (functionName) =>
+              `           * ${
+                _invokeAsyncRoute.method
+              } ${basePath}${_invokeAsyncRoute.path.replace(
+                '{functionName}',
+                functionName,
+              )}`,
+          ),
+      ].join('\n'),
     )
   }
 

--- a/src/lambda/Lambda.js
+++ b/src/lambda/Lambda.js
@@ -33,6 +33,19 @@ export default class Lambda {
     return this.get(functionKey)
   }
 
+  listFunctionNames() {
+    const functionNames = Array.from(this.#lambdaFunctionNamesKeys.keys())
+    return functionNames
+  }
+
+  listFunctionNamePairs() {
+    const funcNamePairs = Array.from(this.#lambdaFunctionNamesKeys).reduce(
+      (obj, [key, value]) => Object.assign(obj, { [key]: value }), // Be careful! Maps can have non-String keys; object literals can't.
+      {},
+    )
+    return funcNamePairs
+  }
+
   start() {
     return this.#httpServer.start()
   }

--- a/src/lambda/routes/invocations/InvocationsController.js
+++ b/src/lambda/routes/invocations/InvocationsController.js
@@ -14,8 +14,14 @@ export default class InvocationsController {
       serverlessLog(
         `Attempt to invoke function '${functionName}' failed. Function does not exists.`,
       )
+      // Conforms to the actual response from AWS Lambda when invoking a non-existent
+      // function
       return {
-        Payload: '',
+        FunctionError: 'ResourceNotFoundException',
+        Payload: {
+          Message: `Function not found: ${functionName}`,
+          Type: 'User',
+        },
         StatusCode: 404,
       }
     }
@@ -49,15 +55,26 @@ export default class InvocationsController {
         console.log(err)
         throw err
       }
-
-      return result
+      // result is actually the Payload.
+      // So return in a standard structure so Hapi can
+      // respond with the correct status codes
+      return {
+        Payload: result,
+        StatusCode: 200,
+      }
     }
 
     // TODO FIXME
-    console.log(
-      `invocationType: '${invocationType}' not supported by serverless-offline`,
-    )
+    const errMsg = `invocationType: '${invocationType}' not supported by serverless-offline`
+    console.log(errMsg)
 
-    return undefined
+    return {
+      FunctionError: 'InvalidParameterValueException',
+      Payload: {
+        Message: errMsg,
+        Type: 'User',
+      },
+      StatusCode: 400,
+    }
   }
 }

--- a/src/lambda/routes/invocations/InvocationsController.js
+++ b/src/lambda/routes/invocations/InvocationsController.js
@@ -1,3 +1,5 @@
+import serverlessLog from '../../../serverlessLog.js'
+
 export default class InvocationsController {
   #lambda = null
 
@@ -6,6 +8,18 @@ export default class InvocationsController {
   }
 
   async invoke(functionName, invocationType, event, clientContext) {
+    // Reject gracefully if functionName does not exist
+    const functionNames = this.#lambda.listFunctionNames()
+    if (functionNames.length === 0 || !functionNames.includes(functionName)) {
+      serverlessLog(
+        `Attempt to invoke function '${functionName}' failed. Function does not exists.`,
+      )
+      return {
+        Payload: '',
+        StatusCode: 404,
+      }
+    }
+
     const lambdaFunction = this.#lambda.getByFunctionName(functionName)
 
     lambdaFunction.setClientContext(clientContext)

--- a/src/lambda/routes/invocations/invocationsRoute.js
+++ b/src/lambda/routes/invocations/invocationsRoute.js
@@ -9,7 +9,7 @@ export default function invocationsRoute(lambda, options) {
   const invocationsController = new InvocationsController(lambda)
 
   return {
-    handler(request) {
+    handler(request /* , h */) {
       const {
         headers,
         params: { functionName },

--- a/src/lambda/routes/invocations/invocationsRoute.js
+++ b/src/lambda/routes/invocations/invocationsRoute.js
@@ -51,6 +51,8 @@ export default function invocationsRoute(lambda, options) {
       }
       const response = h.response(resultPayload).code(statusCode)
       if (functionError) {
+        // AWS Invoke documentation is wrong. The header for error type is
+        // 'x-amzn-ErrorType' in production, not 'X-Amz-Function-Error'
         response.header('x-amzn-ErrorType', functionError)
       }
       return response

--- a/src/lambda/routes/invocations/invocationsRoute.js
+++ b/src/lambda/routes/invocations/invocationsRoute.js
@@ -55,6 +55,9 @@ export default function invocationsRoute(lambda, options) {
         // 'x-amzn-ErrorType' in production, not 'X-Amz-Function-Error'
         response.header('x-amzn-ErrorType', functionError)
       }
+      if (invokeResults && invokeResults.UnhandledError) {
+        response.header('X-Amz-Function-Error', 'Unhandled')
+      }
       return response
     },
     method: 'POST',

--- a/src/main.js
+++ b/src/main.js
@@ -1,9 +1,9 @@
 'use strict'
 
 // UNCOMMENT FOR DEVELOPMENT:
-
+//
 // const { resolve } = require('path')
-
+//
 // // eslint-disable-next-line import/no-extraneous-dependencies
 // require('@babel/register')({
 //   configFile: resolve(__dirname, '../babel.config.js'),

--- a/src/main.js
+++ b/src/main.js
@@ -1,9 +1,9 @@
 'use strict'
 
 // UNCOMMENT FOR DEVELOPMENT:
-//
+
 // const { resolve } = require('path')
-//
+
 // // eslint-disable-next-line import/no-extraneous-dependencies
 // require('@babel/register')({
 //   configFile: resolve(__dirname, '../babel.config.js'),

--- a/tests/integration/lambda-invoke/lambdaInvoke.test.js
+++ b/tests/integration/lambda-invoke/lambdaInvoke.test.js
@@ -22,8 +22,8 @@ describe('Lambda.invoke tests', () => {
     {
       description: "should work asynchronous with invocation type 'Event'",
       expected: {
-        Payload: stringify({ Payload: '', StatusCode: 202 }),
-        StatusCode: 200,
+        Payload: '',
+        StatusCode: 202,
       },
       path: '/dev/invocation-type-event',
       status: 200,
@@ -52,6 +52,20 @@ describe('Lambda.invoke tests', () => {
       path: '/dev/test-handler',
       status: 200,
     },
+
+    {
+      description:
+        'should return an AWS error type ResourceNotFoundException for non-existent function name',
+      expected: {
+        error: {
+          code: 'ResourceNotFoundException',
+          message: `Function not found: function-does-not-exist`,
+          statusCode: 404,
+        },
+      },
+      path: '/dev/function-does-not-exist',
+      status: 404,
+    },
   ].forEach(({ description, expected, path, status }) => {
     test(description, async () => {
       const url = joinUrl(TEST_BASE_URL, path)
@@ -62,5 +76,31 @@ describe('Lambda.invoke tests', () => {
       const json = await response.json()
       expect(json).toEqual(expected)
     })
+  })
+  test('should return a successful invocation but with error details for function that throws an error', async () => {
+    const expected = {
+      Payload: {
+        errorType: 'Error',
+        errorMessage: 'Unhandled Error message body',
+      },
+      FunctionError: 'Unhandled',
+      StatusCode: 200,
+    }
+    const path = '/dev/function-with-error'
+    const status = 200
+
+    const url = joinUrl(TEST_BASE_URL, path)
+
+    const response = await fetch(url)
+    expect(response.status).toEqual(status)
+
+    const json = await response.json()
+    expect(json.StatusCode).toEqual(expected.StatusCode)
+    expect(json.FunctionError).toEqual(expected.FunctionError)
+
+    const responsePayload = JSON.parse(json.Payload)
+    expect(responsePayload.errorType).toEqual(expected.Payload.errorType)
+    expect(responsePayload.errorMessage).toEqual(expected.Payload.errorMessage)
+    expect(Array.isArray(responsePayload.trace)).toBeTruthy()
   })
 })

--- a/tests/integration/lambda-invoke/lambdaInvokeHandler.js
+++ b/tests/integration/lambda-invoke/lambdaInvokeHandler.js
@@ -47,6 +47,56 @@ exports.invokeInvocationTypeRequestResponse = async function invokeInvocationTyp
   }
 }
 
+exports.invokeFunctionDoesNotExist = async function invokeFunctionDoesNotExist() {
+  const params = {
+    // ClientContext: undefined,
+    FunctionName: 'function-does-not-exist',
+    InvocationType: 'RequestResponse',
+    // Payload: undefined,
+  }
+  let response = {}
+  try {
+    response = await lambda.invoke(params).promise()
+  } catch (error) {
+    response = {
+      error: {
+        code: error.code,
+        message: error.message,
+        statusCode: error.statusCode,
+      },
+    }
+    return {
+      body: stringify(response),
+      statusCode: error.statusCode,
+    }
+  }
+
+  throw new Error('Lambda should have thrown an error')
+}
+
+exports.invokeFunctionWithError = async function invokeFunctionWithError() {
+  const params = {
+    // ClientContext: undefined,
+    FunctionName: 'lambda-invoke-tests-dev-invokedHandlerWithError',
+    InvocationType: 'RequestResponse',
+    // Payload: undefined,
+  }
+  let response = {}
+  try {
+    response = await lambda.invoke(params).promise()
+  } catch (error) {
+    response = { error }
+    return {
+      body: stringify(response),
+      statusCode: 200,
+    }
+  }
+  return {
+    body: stringify(response),
+    statusCode: 200,
+  }
+}
+
 exports.testHandler = async function testHandler() {
   const clientContextData = stringify({ foo: 'foo' })
 
@@ -70,4 +120,8 @@ exports.invokedHandler = async function invokedHandler(event, context) {
     clientContext: context.clientContext,
     event,
   }
+}
+
+exports.invokedHandlerWithError = async function invokedHandlerWithError() {
+  throw new Error('Unhandled Error message body')
 }

--- a/tests/integration/lambda-invoke/serverless.yml
+++ b/tests/integration/lambda-invoke/serverless.yml
@@ -39,8 +39,25 @@ functions:
           path: invocation-type-request-response
     handler: lambdaInvokeHandler.invokeInvocationTypeRequestResponse
 
+  invokeFunctionDoesNotExist:
+    events:
+      - http:
+          method: get
+          path: function-does-not-exist
+    handler: lambdaInvokeHandler.invokeFunctionDoesNotExist
+
+  invokeFunctionWithError:
+    events:
+      - http:
+          method: get
+          path: function-with-error
+    handler: lambdaInvokeHandler.invokeFunctionWithError
+
   invokedHandler:
     handler: lambdaInvokeHandler.invokedHandler
+
+  invokedHandlerWithError:
+    handler: lambdaInvokeHandler.invokedHandlerWithError
 
   invokeAsync:
     events:


### PR DESCRIPTION
## Summary of changes
* Improves the understanding of the offline direct lambda invocations and how to use them
* Handles two common error scenarios gracefully and with responses matching AWS production Lambda endpoints:
  1. Function does not exist
  2. Function throws an unhandled error

Should help solve:  #1015, #987, #982, #969, #843, #761

_All issues stem from not knowing what routes are active and can be triggered by either `aws-sdk`, `aws-cli`, or manually via a REST client_

## Details

Previously if there was a function name mis-match (usually because a custom naming scheme is being used), the error message was not helpful because the error would only be triggered when `serverless-offline` would try to invoke the non-existent function, rather than when it tries to find the function.

Additionally, there was a 'TODO' on unhandled errors. This updates the response signature to match the AWS Lambda production apis, as well as support for additional validation and error types as and when people contribute them (such as request and response size limitations). This will allow users to get realistic errors back via `aws-sdk` and `aws-cli`.

## Additional Tests:
* Test for correct response when invoking function that does not exist
* Test for correct response when invoking function that returns an unhandled error
