### PR TITLE
[Docs] Fix #1084

### DIFF
--- a/README.md
+++ b/README.md
@@ -280,7 +280,6 @@ By default layers are downloaded on a per-project basis, however, if you want to
 
 #### dockerReadOnly
 For certain programming languages and frameworks, it's desirable to be able to write to the filesystem for things like testing with local SQLite databases, or other testing-only modifications. For this, you can set `dockerReadOnly: false`, and this will allow local filesystem modifications. This does not strictly mimic AWS Lambda, as Lambda has a Read-Only filesystem, so this should be used as a last resort.
-=======
 
 ## Token authorizers
 


### PR DESCRIPTION
Fix #1084 

Remove (possibly) unintended big font for a paragraph in docs