### PR TITLE
Alternative approach to fixing serverless-webpack hot reload integration

### DIFF
--- a/src/ServerlessOffline.js
+++ b/src/ServerlessOffline.js
@@ -47,6 +47,7 @@ export default class ServerlessOffline {
       'offline:start:ready': this.ready.bind(this),
       'offline:start': this._startWithExplicitEnd.bind(this),
       'offline:start:end': this.end.bind(this),
+      'after:webpack:compile:watch:compile': this.cleanup.bind(this),
     }
   }
 
@@ -134,6 +135,17 @@ export default class ServerlessOffline {
     if (!skipExit) {
       process.exit(0)
     }
+  }
+
+  // Force cleanup lambda functions
+  async cleanup() {
+    const eventModules = []
+
+    if (this.#lambda) {
+      serverlessLog('Forcing cleanup of Lambda functions')
+      eventModules.push(this.#lambda.cleanup())
+    }
+    await Promise.all(eventModules)
   }
 
   /**

--- a/src/config/defaultOptions.js
+++ b/src/config/defaultOptions.js
@@ -28,5 +28,11 @@ export default {
   layersDir: null,
   dockerReadOnly: true,
   functionCleanupIdleTimeSeconds: 60,
-  allowCache: false,
+  allowCache: true,
+  // Overrides for node versions >= v11.7.0
+  ...(process.version >= 'v11.7.0'
+    ? {
+        useWorkerThreads: true,
+      }
+    : {}),
 }

--- a/src/config/defaultOptions.js
+++ b/src/config/defaultOptions.js
@@ -29,10 +29,4 @@ export default {
   dockerReadOnly: true,
   functionCleanupIdleTimeSeconds: 60,
   allowCache: true,
-  // Overrides for node versions >= v11.7.0
-  ...(process.version >= 'v11.7.0'
-    ? {
-        useWorkerThreads: true,
-      }
-    : {}),
 }


### PR DESCRIPTION
This pull request implements an alternative approach to #1050 for fixing #931. The concept here is fairly simple in that we hook the `after:webpack:compile:watch:compile` event from `serverless-weback` in order to trigger a forced cleanup of the Lambda functions. 

I've also made a change to the default configuration by setting `allowCache: true`. This should address a wide range of issues that have been reported recently against the `v6.7.0` release, albeit at the expense of hot reload working with the default options.

The overall  upside here is that we get all the benefits of the caching behavior (including maintaining out of box compatibility with things like the `aws-sdk`) while still being able to support hot reloading. In my testing this has been very performant and reliable so far.

### Limitations
- This doesn't solve the problem for anyone who isn't also using `serverless-webpack`
- This approach only works with worker threads (`useWorkerThreads: true`)
- The tight coupling with events from `serverless-webpack` isn't very elegant

### Additional Issues Addressed
- #1075
- #1080 
- #1081
- #1083

### TODO
- [x] Investigate test failures
- [ ] Update Documentation
- [ ] Unit Tests
