### PR TITLE
POC for externally triggering cleanup of lambda functions

### DIFF
--- a/src/ServerlessOffline.js
+++ b/src/ServerlessOffline.js
@@ -35,6 +35,10 @@ export default class ServerlessOffline {
             usage:
               'Simulates API Gateway to call your lambda functions offline using backward compatible initialization.',
           },
+          functionsUpdated: {
+            type: 'entrypoint',
+            lifecycleEvents: ['cleanup'],
+          },
         },
         lifecycleEvents: ['start'],
         options: commandOptions,
@@ -45,6 +49,7 @@ export default class ServerlessOffline {
     this.hooks = {
       'offline:start:init': this.start.bind(this),
       'offline:start:ready': this.ready.bind(this),
+      'offline:functionsUpdated:cleanup': this.cleanupFunctions.bind(this),
       'offline:start': this._startWithExplicitEnd.bind(this),
       'offline:start:end': this.end.bind(this),
     }
@@ -133,6 +138,13 @@ export default class ServerlessOffline {
 
     if (!skipExit) {
       process.exit(0)
+    }
+  }
+
+  async cleanupFunctions() {
+    if (this.#lambda) {
+      serverlessLog('Forcing cleanup of Lambda functions')
+      await this.#lambda.cleanup()
     }
   }
 


### PR DESCRIPTION
Based on previous discussions with @dl748 around #1090, I've implemented this proof of concept for how `serverless-offline` might allow other plugins to trigger a lambda cleanup for hot reloading.

Even without integration directly within something like `serverless-webpack`, this enables a custom plugin to hook the relevant event and then invoke the `offline:functionsUpdated` command that this PR adds ([example](https://gist.github.com/kelchm/dab3b255fe44ed8cbb89088a963c0e19)).

Like with #1090, this still relies on `useWorkerThreads: true` and `allowCache: true` for this to actually work as expected. I'm also not really happy with the naming conventions here, please feel free to share any ideas if you have them.