### PR TITLE
Fixing AWS env vars

### DIFF
--- a/src/lambda/LambdaFunction.js
+++ b/src/lambda/LambdaFunction.js
@@ -173,7 +173,7 @@ export default class LambdaFunction {
       LAMBDA_TASK_ROOT: '/var/task',
       LANG: 'en_US.UTF-8',
       LD_LIBRARY_PATH:
-        '/usr/local/lib64/node-v4.3.x/lib:/lib64:/usr/lib64:/var/runtime:/var/runtime/lib:/var/task:/var/task/lib',
+        '/usr/local/lib64/node-v4.3.x/lib:/lib64:/usr/lib64:/var/runtime:/var/runtime/lib:/var/task:/var/task/lib:/opt/lib',
       NODE_PATH: '/var/runtime:/var/task:/var/runtime/node_modules',
     }
   }


### PR DESCRIPTION
## Description
Fixing AWS env vars to make work with Layers

## Motivation and Context
Without `LD_LIBRARY_PATH` correct value, layers bin doesn't work correctly. More details about this variables can read [here](https://docs.aws.amazon.com/lambda/latest/dg/configuration-envvars.html#configuration-envvars-runtime)

## How Has This Been Tested?
I found this bug running this [layer](https://github.com/rpidanny/gm-lambda-layer). 
To simulate the problem, create a lambda function with this layer and set this [code](https://github.com/rpidanny/gm-lambda-layer/blob/master/test/index.js), when the code is called an error is raised. Entering in docker container, is possible to see that 
`LD_LIBRARY_PATH` doesn't have `/opt/lib` value.

After fixing the env value, this layer work as expected.
## Screenshots (if appropriate):
