### PR TITLE
Fix jwt authorizers payload v2

### DIFF
--- a/src/events/http/lambda-events/LambdaProxyIntegrationEventV2.js
+++ b/src/events/http/lambda-events/LambdaProxyIntegrationEventV2.js
@@ -147,8 +147,10 @@ export default class LambdaProxyIntegrationEventV2 {
         authorizer:
           authAuthorizer ||
           assign(authContext, {
-            claims,
-            scopes,
+            jwt: {
+              claims,
+              scopes,
+            },
             // 'principalId' should have higher priority
             principalId:
               authPrincipalId ||

--- a/src/events/http/lambda-events/LambdaProxyIntegrationEventV2.js
+++ b/src/events/http/lambda-events/LambdaProxyIntegrationEventV2.js
@@ -28,11 +28,6 @@ export default class LambdaProxyIntegrationEventV2 {
   }
 
   create() {
-    const authPrincipalId =
-      this.#request.auth &&
-      this.#request.auth.credentials &&
-      this.#request.auth.credentials.principalId
-
     const authContext =
       (this.#request.auth &&
         this.#request.auth.credentials &&
@@ -151,11 +146,6 @@ export default class LambdaProxyIntegrationEventV2 {
               claims,
               scopes,
             },
-            // 'principalId' should have higher priority
-            principalId:
-              authPrincipalId ||
-              process.env.PRINCIPAL_ID ||
-              'offlineContext_authorizer_principalId', // See #24
           }),
         domainName: 'offlineContext_domainName',
         domainPrefix: 'offlineContext_domainPrefix',


### PR DESCRIPTION
## Description
This PR fixes the JWT authorizer payload for the payload v2. It also removes the `principalId `field from the payload, since this doesn't seem to exist on the v2 payload. (_Please correct me if this is wrong._)

## Motivation and Context
Previously, the claims and scopes were nested according to the v1 format, which breaks functions that expect the v2 payload.

## How Has This Been Tested?
This was tested manually on my machine using a JWT authorizer with an AWS Cognito User Pool as the issuer and a TS function.