### PR TITLE
Jwt audience validation

### DIFF
--- a/src/events/http/createJWTAuthScheme.js
+++ b/src/events/http/createJWTAuthScheme.js
@@ -53,16 +53,17 @@ export default function createAuthScheme(jwtOptions) {
           return Boom.unauthorized('JWT Token not from correct issuer url')
         }
 
-        if (
-          jwtOptions.audience.filter((x) =>
-            Array.isArray(aud) ? aud.includes(x) : aud === x,
-          ).length === 0 &&
-          !jwtOptions.audience.includes(clientId)
-        ) {
-          serverlessLog(`JWT Token does not contain correct audience`)
-          return Boom.unauthorized(
-            'JWT Token does not contain correct audience',
-          )
+        const validAudiences = Array.isArray(jwtOptions.audience)
+          ? jwtOptions.audience
+          : [jwtOptions.audience]
+        const providedAudiences = Array.isArray(aud) ? aud : [aud]
+        const validAudienceProvided = providedAudiences.some((a) =>
+          validAudiences.includes(a),
+        )
+
+        if (!validAudienceProvided && !jwtOptions.audience.includes(clientId)) {
+          serverlessLog(`JWT Token not from correct audience`)
+          return Boom.unauthorized('JWT Token not from correct audience')
         }
 
         let scopes = null

--- a/src/events/http/createJWTAuthScheme.js
+++ b/src/events/http/createJWTAuthScheme.js
@@ -62,8 +62,10 @@ export default function createAuthScheme(jwtOptions) {
         )
 
         if (!validAudienceProvided && !jwtOptions.audience.includes(clientId)) {
-          serverlessLog(`JWT Token not from correct audience`)
-          return Boom.unauthorized('JWT Token not from correct audience')
+          serverlessLog(`JWT Token does not contain correct audience`)
+          return Boom.unauthorized(
+            'JWT Token does not contain correct audience',
+          )
         }
 
         let scopes = null

--- a/tests/integration/jwt-authorizer/jwt-authorizer.test.js
+++ b/tests/integration/jwt-authorizer/jwt-authorizer.test.js
@@ -58,6 +58,11 @@ const correctAudience = {
 }
 delete correctAudience.client_id
 
+const correctAudienceInArray = {
+  ...correctAudience,
+  aud: [baseJWT.client_id],
+}
+
 const multipleCorrectAudience = {
   ...correctAudience,
   aud: [baseJWT.client_id, 'https://api.example.com/'],
@@ -108,7 +113,19 @@ describe('jwt authorizer tests', () => {
       path: '/dev/user1',
       status: 200,
     },
-
+    {
+      description: 'Valid JWT with audience in array',
+      expected: {
+        status: 'authorized',
+        requestContext: {
+          claims: correctAudienceInArray,
+          scopes: ['profile', 'email'],
+        },
+      },
+      jwt: correctAudienceInArray,
+      path: '/dev/user1',
+      status: 200,
+    },
     {
       description:
         'Valid JWT with multiple audience values (one matching single configured audience)',


### PR DESCRIPTION
## Description
Auth0, for example, can send aud: ["<audience1>", "<audience2>"] in it's token. It also looks like it's possible to configure multiple or single acceptable audiences in the serverless.yml. This PR lifts both sets of audiences into an array which are then checked for an overlap.

## Motivation and Context
I originally submitted this change as https://github.com/dherault/serverless-offline/pull/1060 which was closed in favour of the similar https://github.com/dherault/serverless-offline/pull/1070. Now that I've had chance to use the version that includes that change, I still see the same error that motivated my original PR.  I think my change is still needed.

## How Has This Been Tested?
Tests now exist for string-based audiences, array-based audiences containing a single element and array-based audiences of length > 1.
