### PR TITLE
Default httpApi payload to 2.0

### DIFF
--- a/src/ServerlessOffline.js
+++ b/src/ServerlessOffline.js
@@ -304,7 +304,7 @@ export default class ServerlessOffline {
             if (!httpEvent.http.payload) {
               if (service.provider.httpApi) {
                 httpEvent.http.payload =
-                  service.provider.httpApi.payload || '1.0'
+                  service.provider.httpApi.payload || '2.0'
               }
             }
           }


### PR DESCRIPTION
## Description
Change the default httpApi payload to 2.0
If payload is not provided it is now assumed to be 2.0 (serverless 2.0 default)


## Motivation and Context
Version 2.0 of serverless changed the default httpApi payload to 2.0: [Changelog: https://github.com/serverless/serverless/compare/v1.83.0...v2.0.0]
This change adjusts the default to match the serverless default.

## How Has This Been Tested?
Tested with serverless 2.11.0 and serverless-offline 6.8.0
