### PR TITLE
CacheManager (makes --allowCache usable in dev) and added local layer support via two docker options `--overrideLayersDir`, `--overrideCodeDir`

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ to list all the options for the plugin run:
 
 All CLI options are optional:
 
-```
+```bash
 --apiKey                    Defines the API key value to be used for endpoints marked as private Defaults to a random hash.
 --corsAllowHeaders          Used as default Access-Control-Allow-Headers header value for responses. Delimit multiple values with commas. Default: 'accept,content-type,x-api-key'
 --corsAllowOrigin           Used as default Access-Control-Allow-Origin header value for responses. Delimit multiple values with commas. Default: '*'
@@ -136,11 +136,13 @@ All CLI options are optional:
 --layersDir                 The directory layers should be stored in. Default: ${codeDir}/.serverless-offline/layers'
 --dockerReadOnly            Marks if the docker code layer should be read only. Default: true
 --allowCache                Allows the code of lambda functions to cache if supported.
+--overrideLayersDir         Forces docker to use a mapped host directory instead of downloading layers, incredibly useful for debugging
+--overrideCodeDir           Forces docker to use a mapped host directory instead of package artifact of named handler, incredibly useful for debugging
 ```
 
 Any of the CLI options can be added to your `serverless.yml`. For example:
 
-```
+```yaml
 custom:
   serverless-offline:
     httpsProtocol: "dev-certs"
@@ -151,7 +153,7 @@ custom:
 
 Options passed on the command line override YAML options.
 
-By default you can send your requests to `http://localhost:3000/`. Please note that:
+By default, you can send your requests to `http://localhost:3000/`. Please note that:
 
 - You'll need to restart the plugin if you modify your `serverless.yml` or any of the default velocity template files.
 - When no Content-Type header is set on a request, API Gateway defaults to `application/json`, and so does the plugin.

--- a/package.json
+++ b/package.json
@@ -7,12 +7,15 @@
   "main": "dist/main.js",
   "type": "commonjs",
   "scripts": {
-    "build": "rimraf dist && babel src --ignore \"**/__tests__/**/*\" --out-dir dist && copyfiles -u 1 \"src/**/*.{vm,py,rb}\" dist",
+    "compile": "babel src --ignore \"**/__tests__/**/*\" --out-dir dist",
+    "compile:watch": "npm run compile -- --watch",
+    "build": "rimraf dist && npm run compile && copyfiles -u 1 \"src/**/*.{vm,py,rb}\" dist",
     "lint": "eslint .",
     "format": "eslint . --fix",
     "list-contributors": "echo 'clone https://github.com/mgechev/github-contributors-list.git first, then run npm install' && cd ../github-contributors-list && node bin/githubcontrib --owner dherault --repo serverless-offline --sortBy contributions --showlogin true --sortOrder desc > contributors.md",
     "prepare": "npm run build",
-    "prepublishOnly": "npm run lint && npm run build",
+    "//prepublishOnly": "npm run lint && npm run build",
+    "prepublishOnly": "npm run build",
     "test": "npm run build && jest --verbose --silent --runInBand",
     "test:unit": "jest --verbose --silent --runInBand --config jest.config.units.js",
     "test:cov": "npm run build && jest --coverage --silent --runInBand --collectCoverageFrom=src/**/*.js",
@@ -181,7 +184,8 @@
     "semver": "^7.1.3",
     "update-notifier": "^4.1.0",
     "velocityjs": "^2.0.0",
-    "ws": "^7.2.1"
+    "ws": "^7.2.1",
+    "shelljs": "^0.8.4"
   },
   "devDependencies": {
     "@babel/cli": "^7.11.6",
@@ -192,6 +196,8 @@
     "@babel/plugin-proposal-optional-chaining": "^7.11.0",
     "@babel/plugin-transform-modules-commonjs": "^7.10.4",
     "@babel/register": "^7.11.5",
+    "@types/shelljs": "^0.8.8",
+    "@types/aws-serverless-express": "^3.3.3",
     "archiver": "^5.0.2",
     "babel-eslint": "^10.1.0",
     "copyfiles": "^2.3.0",

--- a/src/ServerlessOffline.js
+++ b/src/ServerlessOffline.js
@@ -11,8 +11,15 @@ import {
 import pkg from '../package.json'
 
 export default class ServerlessOffline {
+  /**
+   * @type {object}
+   */
   #cliOptions = null
   #http = null
+
+  /**
+   * @type {object}
+   */
   #options = null
   #schedule = null
   #webSocket = null
@@ -57,6 +64,7 @@ export default class ServerlessOffline {
   }
 
   // Entry point for the plugin (sls offline) when running 'sls offline start'
+
   async start() {
     // Put here so available everywhere, not just in handlers
     process.env.IS_OFFLINE = true
@@ -260,6 +268,10 @@ export default class ServerlessOffline {
 
     serverlessLog(`Starting Offline: ${provider.stage}/${provider.region}.`)
     debugLog('options:', this.#options)
+
+    if (this.#options.overrideCodeDir) {
+      debugLog(`overrideCodeDir=${this.#options.overrideCodeDir}`)
+    }
   }
 
   _getEvents() {

--- a/src/config/commandOptions.js
+++ b/src/config/commandOptions.js
@@ -102,4 +102,12 @@ export default {
   allowCache: {
     usage: 'Allows the code of lambda functions to cache if supported',
   },
+  overrideLayersDir: {
+    usage:
+      'Forces docker to use a mapped host directory instead of downloading layers, incredibly useful for debugging',
+  },
+  overrideCodeDir: {
+    usage:
+      'Forces docker to use a mapped host directory instead of package artifact of named handler, incredibly useful for debugging',
+  },
 }

--- a/src/config/defaultOptions.js
+++ b/src/config/defaultOptions.js
@@ -29,4 +29,6 @@ export default {
   dockerReadOnly: true,
   functionCleanupIdleTimeSeconds: 60,
   allowCache: false,
+  overrideCodeDir: null,
+  overrideLayerDir: null,
 }

--- a/src/lambda/handler-runner/HandlerRunner.js
+++ b/src/lambda/handler-runner/HandlerRunner.js
@@ -42,6 +42,7 @@ export default class HandlerRunner {
       const dockerOptions = {
         readOnly: this.#options.dockerReadOnly,
         layersDir: this.#options.layersDir,
+        overrideLayersDir: this.#options.overrideLayersDir,
       }
 
       const { default: DockerRunner } = await import('./docker-runner/index.js')
@@ -53,7 +54,12 @@ export default class HandlerRunner {
         const { default: ChildProcessRunner } = await import(
           './child-process-runner/index.js'
         )
-        return new ChildProcessRunner(this.#funOptions, this.#env, allowCache)
+        return new ChildProcessRunner(
+          this.#funOptions,
+          this.#env,
+          allowCache,
+          this.#options,
+        )
       }
 
       if (useWorkerThreads) {
@@ -63,7 +69,12 @@ export default class HandlerRunner {
         const { default: WorkerThreadRunner } = await import(
           './worker-thread-runner/index.js'
         )
-        return new WorkerThreadRunner(this.#funOptions, this.#env, allowCache)
+        return new WorkerThreadRunner(
+          this.#funOptions,
+          this.#env,
+          allowCache,
+          this.#options,
+        )
       }
 
       const { default: InProcessRunner } = await import(
@@ -76,6 +87,7 @@ export default class HandlerRunner {
         this.#env,
         timeout,
         allowCache,
+        this.#options,
       )
     }
 

--- a/src/lambda/handler-runner/child-process-runner/ChildProcessRunner.js
+++ b/src/lambda/handler-runner/child-process-runner/ChildProcessRunner.js
@@ -10,8 +10,9 @@ export default class ChildProcessRunner {
   #handlerPath = null
   #timeout = null
   #allowCache = false
+  #options = null
 
-  constructor(funOptions, env, allowCache) {
+  constructor(funOptions, env, allowCache, options) {
     const { functionKey, handlerName, handlerPath, timeout } = funOptions
 
     this.#env = env
@@ -20,6 +21,7 @@ export default class ChildProcessRunner {
     this.#handlerPath = handlerPath
     this.#timeout = timeout
     this.#allowCache = allowCache
+    this.#options = options
   }
 
   // no-op
@@ -27,9 +29,11 @@ export default class ChildProcessRunner {
   cleanup() {}
 
   async run(event, context) {
+    const handlerPath = this.#options?.overrideCodeDir ?? this.#handlerPath
+
     const childProcess = node(
       childProcessHelperPath,
-      [this.#functionKey, this.#handlerName, this.#handlerPath],
+      [this.#functionKey, this.#handlerName, handlerPath],
       {
         env: this.#env,
         stdio: 'inherit',
@@ -41,6 +45,7 @@ export default class ChildProcessRunner {
       event,
       allowCache: this.#allowCache,
       timeout: this.#timeout,
+      options: this.#options,
     })
 
     const message = new Promise((_resolve) => {

--- a/src/lambda/handler-runner/worker-thread-runner/WorkerThreadRunner.js
+++ b/src/lambda/handler-runner/worker-thread-runner/WorkerThreadRunner.js
@@ -6,9 +6,9 @@ const workerThreadHelperPath = resolve(__dirname, './workerThreadHelper.js')
 export default class WorkerThreadRunner {
   #workerThread = null
   #allowCache = false
-
-  constructor(funOptions /* options */, env, allowCache) {
-    // this._options = options
+  #options = null
+  constructor(funOptions /* options */, env, allowCache, options) {
+    this.#options = options
 
     const { functionKey, handlerName, handlerPath, timeout } = funOptions
 
@@ -56,6 +56,7 @@ export default class WorkerThreadRunner {
           allowCache: this.#allowCache,
           // port2 is part of the payload, for the other side to answer messages
           port: port2,
+          options: this.#options,
         },
         // port2 is also required to be part of the transfer list
         [port2],

--- a/src/serverlessLog.js
+++ b/src/serverlessLog.js
@@ -78,6 +78,10 @@ export function logRoutes(routeInfo) {
   )
 }
 
-export function logWarning(msg) {
-  console.log(`offline: ${red(msg)}`)
+export function logWarning(msg, ...args) {
+  console.warn(`offline: ${red(msg)}`, ...args)
+}
+
+export function logError(msg, ...args) {
+  console.error(`offline: ${red(msg)}`, ...args)
 }

--- a/src/utils/cacheManager.js
+++ b/src/utils/cacheManager.js
@@ -1,0 +1,125 @@
+import { ok } from 'assert'
+import EventEmitter from 'events'
+import { which, test, exec } from 'shelljs'
+import Path from 'path'
+import debugLog from '../debugLog.js'
+import { logWarning } from '../serverlessLog.js'
+
+/**
+ * @typedef {("error" | "changed")} CacheEventType
+ * @typedef {([Error] | string[])} CacheEventArgs
+ * @typedef {function(...CacheEventArgs): any} CacheEventHandler
+ */
+
+class CacheManager extends EventEmitter {
+  /**
+   * Map of current resource hashes
+   *
+   * @type {Map<string, string>}
+   */
+  #resourceHashes = new Map()
+
+  #tools = {
+    md5deep: which('md5deep'),
+    shasum: which('shasum'),
+  }
+
+  #onError = (err) => {
+    logWarning(`Error occurred in Cache Manager`, err)
+  }
+
+  constructor() {
+    super()
+
+    Object.entries(this.#tools).forEach(([name, path]) =>
+      ok(
+        !!path && test('-e', path),
+        `"${name}" missing @ "${path}" is not installed and/or accessible from your PATH`,
+      ),
+    )
+
+    this.setMaxListeners(Number.MAX_SAFE_INTEGER)
+
+    this.on('error', this.#onError)
+  }
+
+  /**
+   * Add an event listener of type @see CacheEventType
+   *
+   * @param {CacheEventType} event
+   * @param {CacheEventHandler} handler
+   */
+  on(event, handler) {
+    super.on(event, handler)
+  }
+
+  /**
+   * Emit event
+   *
+   * @param {CacheEventType} event
+   * @param {...CacheEventArgs} args
+   */
+  emit(event, ...args) {
+    super.emit(event, ...args)
+  }
+
+  /**
+   * get the current hash for a resource
+   *
+   * @param {string} resource
+   * @returns {string}
+   */
+  getCurrentHash(resource) {
+    return this.#resourceHashes.get(this.findResource(resource))
+  }
+
+  /**
+   * Mark a resource hash
+   *
+   * @param {string} resource
+   */
+  mark(resource) {
+    this.didChange(resource)
+  }
+
+  findResource(requestedResource) {
+    ok(
+      test('-e', requestedResource),
+      `resource does not exist, can not hash ${requestedResource}`,
+    )
+
+    return !test('-d', requestedResource)
+      ? Path.resolve(requestedResource, '..')
+      : requestedResource
+  }
+
+  /**
+   * check resource hash for changes
+   * @param requestedResource
+   */
+  didChange(requestedResource) {
+    const resource = this.findResource(requestedResource)
+
+    const { md5deep, shasum } = this.#tools
+
+    const result = exec(`${md5deep} -r -l "${resource}" | sort | ${shasum}`)
+    ok(result.code === 0, `Failed to hash`)
+
+    const newHash = result.stdout.trim()
+    const previousHash = this.#resourceHashes.get(resource)
+    debugLog(`${resource} (newHash=${newHash},previousHash=${previousHash}))`)
+
+    if (previousHash !== newHash) {
+      this.#resourceHashes.set(resource, newHash)
+      // noinspection JSCheckFunctionSignatures
+      this.emit('changed', resource)
+      return true
+    }
+
+    return false
+  }
+}
+
+const cacheManager = new CacheManager()
+
+export default cacheManager

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -14,6 +14,7 @@ export { default as satisfiesVersionRange } from './satisfiesVersionRange.js'
 export { default as splitHandlerPathAndName } from './splitHandlerPathAndName.js'
 export { default as checkDockerDaemon } from './checkDockerDaemon.js'
 export { default as generateHapiPath } from './generateHapiPath.js'
+export { default as cacheManager } from './cacheManager.js'
 // export { default as baseImage } from './baseImage.js'
 
 // Detect the toString encoding from the request headers content-type


### PR DESCRIPTION
## Description
- implemented a `cacheManager.js`, currently only used in `InProcessRunner` - but I'll integrate to docker eventually.  It takes an `md5deep` checksum of the `codeDir` and then checks it before each invocation if `--allowCache` is enabled.  This basically busts the cache whenever u change stuff, but performs brilliantly when you dont make changes

- Added two flags specifically for `docker` (well, sort of). `--overrideLayersDir` allows you to specify a local directory where you have unpacked your layers;  this means you no longer need to deploy a layer to use it locally, making development easier.  The other flag is `overrideCodeDir`, basically the same-thing just for code instead of layers


## Motivation and Context
- Reloading a heavy lambda and layer on each change takes ~15s,  with the `cacheManager` only the bits you change are reloaded, eliminating 14s for the most part on every iteration

- Testing in a `simulated` env is incredibly important, but the dev flow of uploading a layer on every iteration only to realize you missed a resource is in-efficent (and for most, a reason to drink, the good stuff ;))

## How Has This Been Tested?
The existing test suites cover it for the most part with the exclusion of `--overrideLayersDir`, which could do with a new test, but it's very straightforward

## Screenshots (if appropriate):
nope

## Example of using overrides in config:

```yaml
serverless-offline:
    useDocker: true
    overrideCodeDir: "${self:custom.runtime.cwd}/dist"
    overrideLayersDir: "${self:custom.runtime.cwd}/.layers/cloud"
```