### PR TITLE
fix for httpApi jwt auth

### DIFF
--- a/src/events/http/authJWTSettingsExtractor.js
+++ b/src/events/http/authJWTSettingsExtractor.js
@@ -54,7 +54,15 @@ export default function authJWTSettingsExtractor(
     )
   }
 
-  if (!httpApiAuthorizer.audience || httpApiAuthorizer.audience.length === 0) {
+  if (!httpApiAuthorizer.audience) {
+    return buildFailureResult(
+      `WARNING: JWT authorizer ${authorizer.name} missing audience`,
+    )
+  }
+  if (typeof httpApiAuthorizer.audience === 'string') {
+    httpApiAuthorizer.audience = [httpApiAuthorizer.audience]
+  }
+  if (httpApiAuthorizer.audience.length === 0) {
     return buildFailureResult(
       `WARNING: JWT authorizer ${authorizer.name} missing audience`,
     )


### PR DESCRIPTION
## Description

Fix for `httpApi.authorizers` where `.audience` is a string not an array.

## Motivation and Context

This is a minor bug fix: if you have an `httpApi` function with an `authorizer` then sls-offline breaks during JWT verification with a TypeError: `offline: TypeError: jwtOptions.audience.filter is not a function`.

Offline is assuming that `.audience` is an array at initialization time, when in the case of `httpApi.authorizers` it is a string (regardless of whether serverless.yaml has a string or array).

## How Has This Been Tested?

I have only tested this fix within the codebase that I am working on - i.e. I manually edited `./node_modules/serverless-offline/dist/events/http/authJWTSettingsExtractor.js` and re-ran my test with the fix applied. It worked without problems.

I also built and ran unit test as per the contibuting guidelines - no errors.

The fix is also simple enough to eyeball - it will work whether `jwtOptions.audience` is an array or string.

I appreciate that this is not very extensive testing - I'm pressed for time. I'm happy for you to fix however you see fit and just use my code to pinpoint the error.

## Screenshots (if appropriate):

N/A