### PR TITLE
Lambda-Event-Path-and-Resource-Sync

### DIFF
--- a/src/events/http/lambda-events/LambdaProxyIntegrationEvent.js
+++ b/src/events/http/lambda-events/LambdaProxyIntegrationEvent.js
@@ -196,7 +196,7 @@ export default class LambdaProxyIntegrationEvent {
         resourcePath: route.path,
         stage: this.#stage,
       },
-      resource: route.path,
+      resource: this.#path,
       stageVariables: this.#stageVariables,
     }
   }


### PR DESCRIPTION
## Description
Change LambdaProxyIntegrationEvent returned resource to use non-stagePrepended URL from instance #path intead of route.path.

## Motivation and Context
When running serverless-offline locally, the LambdaProxyIntegrationEvent uses the route.path to define the event.resource instead of this.#path. When using stages prepended to URLs to keep in step with a multi-environment local development setup (i.e. multiple environments tested with Postman), it is desirable to have the stage prepend the endpoint URL, but not desirable for the stage to mutate the event.resource where router / controller logic is determined.

Fixes: https://github.com/dherault/serverless-offline/issues/1029

## How Has This Been Tested?
Ran AWS Lambdas locally with URLs prepended by Stage with Postman.