### PR TITLE
Get event.resource by removing stage from route.path

### DIFF
--- a/src/events/http/lambda-events/LambdaProxyIntegrationEvent.js
+++ b/src/events/http/lambda-events/LambdaProxyIntegrationEvent.js
@@ -128,6 +128,7 @@ export default class LambdaProxyIntegrationEvent {
     const httpMethod = method.toUpperCase()
     const requestTime = formatToClfTime(received)
     const requestTimeEpoch = received
+    const resource = route.path.replace(`/${this.#stage}`, '')
 
     return {
       body,
@@ -196,7 +197,7 @@ export default class LambdaProxyIntegrationEvent {
         resourcePath: route.path,
         stage: this.#stage,
       },
-      resource: this.#path,
+      resource,
       stageVariables: this.#stageVariables,
     }
   }


### PR DESCRIPTION
See: 
https://github.com/dherault/serverless-offline/pull/1137
https://github.com/dherault/serverless-offline/pull/1137#issuecomment-742603299

That PR broke path parameters.
This PR fixes that issue and still sovles the need to remove stage from path for event.resource