### PR TITLE
Add network and hostname options for DockerRunner

### DIFF
--- a/src/config/commandOptions.js
+++ b/src/config/commandOptions.js
@@ -32,6 +32,9 @@ export default {
     shortcut: 'o',
     usage: 'The host name to listen on. Default: localhost',
   },
+  hostname: {
+    usage: 'The hostname for the container when using Docker',
+  },
   httpPort: {
     usage: 'HTTP port to listen on. Default: 3000',
   },
@@ -42,6 +45,9 @@ export default {
   },
   lambdaPort: {
     usage: 'Lambda http port to listen on. Default: 3002',
+  },
+  network: {
+    usage: 'The name of the Docker network when using Docker',
   },
   noPrependStageInUrl: {
     usage: "Don't prepend http routes with the stage.",

--- a/src/lambda/handler-runner/HandlerRunner.js
+++ b/src/lambda/handler-runner/HandlerRunner.js
@@ -42,6 +42,8 @@ export default class HandlerRunner {
       const dockerOptions = {
         readOnly: this.#options.dockerReadOnly,
         layersDir: this.#options.layersDir,
+        network: this.#options.network,
+        hostname: this.#options.hostname,
       }
 
       const { default: DockerRunner } = await import('./docker-runner/index.js')

--- a/src/lambda/handler-runner/docker-runner/DockerContainer.js
+++ b/src/lambda/handler-runner/docker-runner/DockerContainer.js
@@ -131,6 +131,27 @@ export default class DockerContainer {
       dockerArgs.push('-e', `${key}=${value}`)
     })
 
+    if (this.#dockerOptions.network !== null && this.#dockerOptions.network !== '') {
+      let networkFound = true
+
+      try {
+        await execa('docker', ['inspect', this.#dockerOptions.network])
+      } catch (error) {
+        logWarning(
+          `docker network ${this.#dockerOptions.network} does not exist`,
+        )
+        networkFound = false
+      }
+
+      if (networkFound) {
+        dockerArgs.push('--network', this.#dockerOptions.network)
+      }
+    }
+
+    if (this.#dockerOptions.hostname !== null && this.#dockerOptions.hostname !== '') {
+      dockerArgs.push('--hostname', this.#dockerOptions.hostname)
+    }
+
     if (platform() === 'linux') {
       // Add `host.docker.internal` DNS name to access host from inside the container
       // https://github.com/docker/for-linux/issues/264


### PR DESCRIPTION
## Description 

Added --network and --hostname options for specifying a network and/or hostname for the Docker runner.

## Motivation and Context

Fixes #1144

## How Has This Been Tested?

- Created a Docker network using: `docker network create test`
- Created a simple `hello` Go lambda
- Added `network` and `hostname` options to `custom:` block in `serverless.yml`
- Run `SLS_DEBUG=* sls offline`
- Verify output
- Make request
- Verify started container network and hostname using `docker inspect <containerID>`
- Repeated same procedure using `--network` and `--hostname` flags to `sls offline` instead off `serverless.yml`
