### PR TITLE
Update billing to nearest ms

### DIFF
--- a/src/lambda/LambdaFunction.js
+++ b/src/lambda/LambdaFunction.js
@@ -209,11 +209,9 @@ export default class LambdaFunction {
     return this.#executionTimeEnded - this.#executionTimeStarted
   }
 
-  // rounds up to the nearest 100 ms
+  // round up to the nearest ms
   _billedExecutionTimeInMillis() {
-    return (
-      ceil((this.#executionTimeEnded - this.#executionTimeStarted) / 100) * 100
-    )
+    return ceil(this.#executionTimeEnded - this.#executionTimeStarted)
   }
 
   // extractArtifact, loosely based on:


### PR DESCRIPTION
## Description
AWS has updated billing to the nearest 1ms instead of 100ms as per https://aws.amazon.com/about-aws/whats-new/2020/12/aws-lambda-changes-duration-billing-granularity-from-100ms-to-1ms/ 


## Motivation and Context
AWS has updated billing to nearest ms, so the estimated billed duration should reflect the change

## How Has This Been Tested?
n/a

## Screenshots (if appropriate):
