### PR TITLE
Remove body instance string checking on lambda integration

### DIFF
--- a/src/events/http/HttpServer.js
+++ b/src/events/http/HttpServer.js
@@ -785,12 +785,6 @@ export default class HttpServer {
           response.variety = 'buffer'
         } else if (typeof result === 'string') {
           response.source = JSON.stringify(result)
-        } else if (result && result.body && typeof result.body !== 'string') {
-          return this._reply502(
-            response,
-            'According to the API Gateway specs, the body content must be stringified. Check your Lambda response and make sure you are invoking JSON.stringify(YOUR_CONTENT) on your body object',
-            {},
-          )
         } else {
           response.source = result
         }


### PR DESCRIPTION
## Description
For `lambda-proxy` integration body need to be string, but not for `lambda` integration. So we don't need checking the body value as string on `lambda` integration

## Motivation and Context
On my project I use `lambda` integration, it work on aws, but not work when using serverless-offline.
By refer to this link for `lambda-proxy` https://docs.aws.amazon.com/apigateway/latest/developerguide/set-up-lambda-proxy-integrations.html#api-gateway-simple-proxy-for-lambda-input-format . It say it need to be string, and in this code, it already check it wether the body is string or not, and that's good.
But for `lambda` it's can be custom, can be string, can be object, based on defined custom-template.

## How Has This Been Tested?
I try to hit the api on aws it returns `200`.
And getting error `502` on local, then I test it by comment some lines that checking the body value.
Now it return the same result as aws api.

## Screenshots (if appropriate):
Before changes
<img width="1521" alt="Screen Shot 2021-01-09 at 09 50 16" src="https://user-images.githubusercontent.com/57900471/104081274-27066280-5260-11eb-8661-a7293cf8016b.png">

After changes
<img width="1521" alt="Screen Shot 2021-01-09 at 09 53 53" src="https://user-images.githubusercontent.com/57900471/104081360-ab58e580-5260-11eb-9d07-a0fd8bd90119.png">


