### PR TITLE
linux only: fall back to host networking if gateway IP not found

### DIFF
--- a/src/lambda/handler-runner/docker-runner/DockerContainer.js
+++ b/src/lambda/handler-runner/docker-runner/DockerContainer.js
@@ -135,7 +135,12 @@ export default class DockerContainer {
       // Add `host.docker.internal` DNS name to access host from inside the container
       // https://github.com/docker/for-linux/issues/264
       const gatewayIp = await this._getBridgeGatewayIp()
-      dockerArgs.push('--add-host', `host.docker.internal:${gatewayIp}`)
+      if (!!gatewayIp) {
+        dockerArgs.push('--add-host', `host.docker.internal:${gatewayIp}`)
+      } else {
+        // fall back to host networking if gateway IP not found
+        dockerArgs.push('--network', 'host')
+      }
     }
 
     const { stdout: containerId } = await execa('docker', [


### PR DESCRIPTION
## Description

I am running into a situation on a linux server where the `docker network inspect bridge --format '{{(index .IPAM.Config 0).Gateway}}'` command is only returning the `Subnet` key in the config and not also the `Gateway` key as expected.    

I don't have control over this particular CI server so I don't know why that is the case.  However, this causes the `docker create` command to fail with an invalid argument for `--add-host`.  

Wondering how you feel about adding a fallback in this scenario to host networking.  This allows the `docker create` command to proceed.  

## Motivation and Context

This change adds a fallback for when the ``docker network inspect bridge --format '{{(index .IPAM.Config 0).Gateway}}'`` fails to return a `Gateway` key in the IPAM config.  This allows the `docker create` command to proceed with host networking in this case.

## How Has This Been Tested?

This has been tested by running a go lambda on a linux server via `serverless offline --useDocker`.  

## Screenshots (if appropriate):
