### PR TITLE
1ms billing granularity

### DIFF
--- a/src/lambda/LambdaFunction.js
+++ b/src/lambda/LambdaFunction.js
@@ -209,10 +209,10 @@ export default class LambdaFunction {
     return this.#executionTimeEnded - this.#executionTimeStarted
   }
 
-  // rounds up to the nearest 100 ms
+  // rounds up to the nearest ms
   _billedExecutionTimeInMillis() {
     return (
-      ceil((this.#executionTimeEnded - this.#executionTimeStarted) / 100) * 100
+      ceil(this.#executionTimeEnded - this.#executionTimeStarted)
     )
   }
 


### PR DESCRIPTION
## Description
Don't round to nearest 100ms anymore but only to nearest full millisecond.

## Motivation and Context
https://aws.amazon.com/about-aws/whats-new/2020/12/aws-lambda-changes-duration-billing-granularity-from-100ms-to-1ms/#:~:text=AWS%20Lambda%20reduced%20the%20billing,100%20ms%20increment%20per%20invoke.