### PR TITLE
Use .includes within a safe array variable "validAudiences"

### DIFF
--- a/src/events/http/createJWTAuthScheme.js
+++ b/src/events/http/createJWTAuthScheme.js
@@ -61,7 +61,7 @@ export default function createAuthScheme(jwtOptions) {
           validAudiences.includes(a),
         )
 
-        if (!validAudienceProvided && !jwtOptions.audience.includes(clientId)) {
+        if (!validAudienceProvided && !validAudiences.includes(clientId)) {
           serverlessLog(`JWT Token does not contain correct audience`)
           return Boom.unauthorized(
             'JWT Token does not contain correct audience',


### PR DESCRIPTION
Using .includes within a safe array variable `validAudiences` rather than unsafe includes call on `jwtOptions.audience`

## Description
I replaced the call of includes to an existing safe variable array `validAudiences`, because the old code `jwtOptions.audience.includes` throws errors when the type of `jwtOptions.audience` is not an array.

## Motivation and Context
It fixes an open issue #1078

## How Has This Been Tested?
It's a very very very small change in the code, also I ran `npm run test:unit` and it passes.  

## Screenshots (if appropriate):
