### PR TITLE
Fix #1035 - Add apiKeyId to identity information

### DIFF
--- a/README.md
+++ b/README.md
@@ -352,6 +352,7 @@ You are able to use environment variables to customize identity params in event 
 | SLS_COGNITO_IDENTITY_ID             | event.requestContext.identity.cognitoIdentityId             |
 | SLS_CALLER                          | event.requestContext.identity.caller                        |
 | SLS_API_KEY                         | event.requestContext.identity.apiKey                        |
+| SLS_API_KEY_ID                      | event.requestContext.identity.apiKeyId                      |
 | SLS_COGNITO_AUTHENTICATION_TYPE     | event.requestContext.identity.cognitoAuthenticationType     |
 | SLS_COGNITO_AUTHENTICATION_PROVIDER | event.requestContext.identity.cognitoAuthenticationProvider |
 

--- a/src/events/http/lambda-events/LambdaProxyIntegrationEvent.js
+++ b/src/events/http/lambda-events/LambdaProxyIntegrationEvent.js
@@ -167,6 +167,7 @@ export default class LambdaProxyIntegrationEvent {
           accessKey: null,
           accountId: process.env.SLS_ACCOUNT_ID || 'offlineContext_accountId',
           apiKey: process.env.SLS_API_KEY || 'offlineContext_apiKey',
+          apiKeyId: process.env.SLS_API_KEY_ID || 'offlineContext_apiKeyId',
           caller: process.env.SLS_CALLER || 'offlineContext_caller',
           cognitoAuthenticationProvider:
             _headers['cognito-authentication-provider'] ||


### PR DESCRIPTION
## Description
Adds the ApiKeyId to the identity object in the requestContext of the LambdaProxyIntegrationEvent

## Motivation and Context
When testing locally it sometimes is needed to read out the apiKeyId instead of the apiKey
#1035 

## How Has This Been Tested?
I npm link'ed this branch in my local environment and verified the apiKeyId was available in the event.

There seems to be no unit test that covers the contents the identity object, except for a file in the folder called "old-unit". Please let me know if adding an additional expect there is appreciated.

## Screenshots (if appropriate):
![Screenshot](https://user-images.githubusercontent.com/4551130/106633243-e6f48000-657e-11eb-811e-65c7e61e4f84.PNG)
