### PR TITLE
feature: add support for nodejs14.x

### DIFF
--- a/src/config/supportedRuntimes.js
+++ b/src/config/supportedRuntimes.js
@@ -25,6 +25,7 @@ export const supportedNodejs = new Set([
   // supported
   'nodejs10.x',
   'nodejs12.x',
+  'nodejs14.x',
 ])
 
 // PROVIDED

--- a/src/lambda/handler-runner/HandlerRunner.js
+++ b/src/lambda/handler-runner/HandlerRunner.js
@@ -39,6 +39,14 @@ export default class HandlerRunner {
     debugLog(`Loading handler... (${handlerPath})`)
 
     if (useDocker) {
+      // https://github.com/lambci/docker-lambda/issues/329
+      if (runtime === 'nodejs14.x') {
+        logWarning(
+          '"nodejs14.x" runtime is not supported with docker. See https://github.com/lambci/docker-lambda/issues/329',
+        )
+        throw new Error('Unsupported runtime')
+      }
+
       const dockerOptions = {
         readOnly: this.#options.dockerReadOnly,
         layersDir: this.#options.layersDir,


### PR DESCRIPTION
## Description
AWS Lambda now supports nodejs14.x. Updated the package to support this version.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Without this support, an error is thrown when trying to run serverless offline on projects that use node 14.
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
I made changes to the config file in `serverless-offline`. Then used `yarn link` to link the local package and used it in one of my nodejs 14 serverless projects. It did not throw an error after the changes and ran the code as expected. 
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
