### PR TITLE
Support for HttpApi $default route, $default stage and 2.0 payloads

### DIFF
--- a/src/ServerlessOffline.js
+++ b/src/ServerlessOffline.js
@@ -290,22 +290,32 @@ export default class ServerlessOffline {
             handler: functionDefinition.handler,
             http: http || httpApi,
           }
-          // this is here to allow rawHttpEventDefinition to be a string
-          // the problem is that events defined as
-          // httpApi: '*'
-          // will not have the isHttpApi flag set. This will need to be addressed
-          // when adding support for HttpApi 2.0 payload types.
-          if (httpApi && typeof httpApi === 'object') {
-            httpEvent.http = {
-              ...httpApi,
-              isHttpApi: true,
+
+          if (httpApi) {
+            // Ensure definitions for 'httpApi' events are objects so that they can be marked
+            // with an 'isHttpApi' property (they are handled differently to 'http' events)
+            if (typeof httpEvent.http === 'string') {
+              httpEvent.http = { routeKey: httpEvent.http === '*' ? '$default' : httpEvent.http }
+            } else if (typeof httpEvent.http === 'object') {
+              if (!httpEvent.http.method) {
+                logWarning(`Event definition is missing a method for function "${functionKey}"`)
+                httpEvent.http.method = ''
+              }
+              const resolvedMethod = httpEvent.http.method === '*' ? 'ANY' : httpEvent.http.method.toUpperCase()
+              httpEvent.http.routeKey = `${resolvedMethod} ${httpEvent.http.path}`
+              // Clear these properties to avoid confusion (they will be derived from the routeKey
+              // when needed later)
+              delete httpEvent.http.method
+              delete httpEvent.http.path
+            } else {
+              logWarning(`Event definition must be a string or object but received ${typeof httpEvent.http} for function "${functionKey}"`)
+              httpEvent.http.routeKey = ''
             }
 
-            if (!httpEvent.http.payload) {
-              if (service.provider.httpApi) {
-                httpEvent.http.payload =
-                  service.provider.httpApi.payload || '1.0'
-              }
+            httpEvent.http.isHttpApi = true
+
+            if (!httpEvent.http.payload && service.provider.httpApi) {
+              httpEvent.http.payload = service.provider.httpApi.payload || '2.0'
             }
           }
 

--- a/src/ServerlessOffline.js
+++ b/src/ServerlessOffline.js
@@ -295,20 +295,29 @@ export default class ServerlessOffline {
             // Ensure definitions for 'httpApi' events are objects so that they can be marked
             // with an 'isHttpApi' property (they are handled differently to 'http' events)
             if (typeof httpEvent.http === 'string') {
-              httpEvent.http = { routeKey: httpEvent.http === '*' ? '$default' : httpEvent.http }
+              httpEvent.http = {
+                routeKey: httpEvent.http === '*' ? '$default' : httpEvent.http,
+              }
             } else if (typeof httpEvent.http === 'object') {
               if (!httpEvent.http.method) {
-                logWarning(`Event definition is missing a method for function "${functionKey}"`)
+                logWarning(
+                  `Event definition is missing a method for function "${functionKey}"`,
+                )
                 httpEvent.http.method = ''
               }
-              const resolvedMethod = httpEvent.http.method === '*' ? 'ANY' : httpEvent.http.method.toUpperCase()
+              const resolvedMethod =
+                httpEvent.http.method === '*'
+                  ? 'ANY'
+                  : httpEvent.http.method.toUpperCase()
               httpEvent.http.routeKey = `${resolvedMethod} ${httpEvent.http.path}`
               // Clear these properties to avoid confusion (they will be derived from the routeKey
               // when needed later)
               delete httpEvent.http.method
               delete httpEvent.http.path
             } else {
-              logWarning(`Event definition must be a string or object but received ${typeof httpEvent.http} for function "${functionKey}"`)
+              logWarning(
+                `Event definition must be a string or object but received ${typeof httpEvent.http} for function "${functionKey}"`,
+              )
               httpEvent.http.routeKey = ''
             }
 

--- a/src/ServerlessOffline.js
+++ b/src/ServerlessOffline.js
@@ -322,10 +322,10 @@ export default class ServerlessOffline {
             }
 
             httpEvent.http.isHttpApi = true
-
-            if (!httpEvent.http.payload && service.provider.httpApi) {
-              httpEvent.http.payload = service.provider.httpApi.payload || '2.0'
-            }
+            httpEvent.http.payload =
+              service.provider.httpApi && service.provider.httpApi.payload
+                ? service.provider.httpApi.payload
+                : '2.0'
           }
 
           if (http && http.private) {

--- a/src/events/http/HttpServer.js
+++ b/src/events/http/HttpServer.js
@@ -347,7 +347,8 @@ export default class HttpServer {
       method,
       path: hapiPath,
       server,
-      stage: endpoint.isHttpApi || this.#options.noPrependStageInUrl ? null : stage,
+      stage:
+        endpoint.isHttpApi || this.#options.noPrependStageInUrl ? null : stage,
       invokePath: `/2015-03-31/functions/${functionKey}/invocations`,
     })
 
@@ -359,7 +360,9 @@ export default class HttpServer {
 
     let cors = null
     if (endpoint.isHttpApi) {
-      const userCors = this.#serverless.service.provider.httpApi && this.#serverless.service.provider.httpApi.cors
+      const userCors =
+        this.#serverless.service.provider.httpApi &&
+        this.#serverless.service.provider.httpApi.cors
       if (userCors) {
         const defaultCors = {
           origin: ['*'],
@@ -386,7 +389,8 @@ export default class HttpServer {
       }
     } else if (endpoint.cors) {
       cors = {
-        credentials: endpoint.cors.credentials || this.#options.corsConfig.credentials,
+        credentials:
+          endpoint.cors.credentials || this.#options.corsConfig.credentials,
         exposedHeaders: this.#options.corsConfig.exposedHeaders,
         headers: endpoint.cors.headers || this.#options.corsConfig.headers,
         origin: endpoint.cors.origins || this.#options.corsConfig.origin,
@@ -443,9 +447,10 @@ export default class HttpServer {
         url: request.url.href,
       }
 
-      const requestPath = endpoint.isHttpApi || this.#options.noPrependStageInUrl
-        ? request.path
-        : request.path.substr(`/${stage}`.length)
+      const requestPath =
+        endpoint.isHttpApi || this.#options.noPrependStageInUrl
+          ? request.path
+          : request.path.substr(`/${stage}`.length)
 
       if (request.auth.credentials && request.auth.strategy) {
         this.#lastRequestOptions.auth = request.auth
@@ -588,20 +593,21 @@ export default class HttpServer {
           ? this.#serverless.service.custom.stageVariables
           : null
 
-        const lambdaProxyIntegrationEvent = endpoint.isHttpApi && endpoint.payload === '2.0'
-          ? new LambdaProxyIntegrationEventV2(
-            request,
-            '$default',
-            endpoint.routeKey,
-            stageVariables,
-          )
-          : new LambdaProxyIntegrationEvent(
-            request,
-            this.#serverless.service.provider.stage,
-            requestPath,
-            stageVariables,
-            endpoint.isHttpApi ? endpoint.routeKey : null,
-          )
+        const lambdaProxyIntegrationEvent =
+          endpoint.isHttpApi && endpoint.payload === '2.0'
+            ? new LambdaProxyIntegrationEventV2(
+                request,
+                '$default',
+                endpoint.routeKey,
+                stageVariables,
+              )
+            : new LambdaProxyIntegrationEvent(
+                request,
+                this.#serverless.service.provider.stage,
+                requestPath,
+                stageVariables,
+                endpoint.isHttpApi ? endpoint.routeKey : null,
+              )
 
         event = lambdaProxyIntegrationEvent.create()
       }

--- a/src/events/http/HttpServer.js
+++ b/src/events/http/HttpServer.js
@@ -361,35 +361,7 @@ export default class HttpServer {
         this._configureAuthorization(endpoint, functionKey, method, path)
 
     let cors = null
-    if (endpoint.isHttpApi) {
-      const userCors =
-        this.#serverless.service.provider.httpApi &&
-        this.#serverless.service.provider.httpApi.cors
-      if (userCors) {
-        const defaultCors = {
-          origin: ['*'],
-          headers: [
-            'Content-Type',
-            'X-Amz-Date',
-            'Authorization',
-            'X-Api-Key',
-            'X-Amz-Security-Token',
-            'X-Amz-User-Agent',
-          ],
-        }
-        if (userCors === true) {
-          cors = defaultCors
-        } else {
-          cors = {
-            credentials: userCors.allowCredentials,
-            exposedHeaders: userCors.exposedResponseHeaders || [],
-            headers: userCors.allowedHeaders || defaultCors.headers,
-            maxAge: userCors.maxAge,
-            origin: userCors.allowedOrigins || defaultCors.origin,
-          }
-        }
-      }
-    } else if (endpoint.cors) {
+    if (endpoint.cors) {
       cors = {
         credentials:
           endpoint.cors.credentials || this.#options.corsConfig.credentials,

--- a/src/events/http/HttpServer.js
+++ b/src/events/http/HttpServer.js
@@ -333,7 +333,9 @@ export default class HttpServer {
       httpEvent,
     )
 
-    const stage = this.#options.stage || this.#serverless.service.provider.stage
+    const stage = endpoint.isHttpApi
+      ? '$default'
+      : this.#options.stage || this.#serverless.service.provider.stage
     const protectedRoutes = []
 
     if (httpEvent.private) {
@@ -574,7 +576,7 @@ export default class HttpServer {
 
             event = new LambdaIntegrationEvent(
               request,
-              this.#serverless.service.provider.stage,
+              stage,
               requestTemplate,
               requestPath,
             ).create()
@@ -597,13 +599,13 @@ export default class HttpServer {
           endpoint.isHttpApi && endpoint.payload === '2.0'
             ? new LambdaProxyIntegrationEventV2(
                 request,
-                '$default',
+                stage,
                 endpoint.routeKey,
                 stageVariables,
               )
             : new LambdaProxyIntegrationEvent(
                 request,
-                this.#serverless.service.provider.stage,
+                stage,
                 requestPath,
                 stageVariables,
                 endpoint.isHttpApi ? endpoint.routeKey : null,
@@ -798,7 +800,7 @@ export default class HttpServer {
               try {
                 const reponseContext = new VelocityContext(
                   request,
-                  this.#serverless.service.provider.stage,
+                  stage,
                   result,
                 ).getContext()
 

--- a/src/events/http/lambda-events/LambdaProxyIntegrationEvent.js
+++ b/src/events/http/lambda-events/LambdaProxyIntegrationEvent.js
@@ -19,12 +19,14 @@ const { assign } = Object
 // http://docs.aws.amazon.com/apigateway/latest/developerguide/api-gateway-create-api-as-simple-proxy-for-lambda.html
 export default class LambdaProxyIntegrationEvent {
   #path = null
+  #routeKey = null
   #request = null
   #stage = null
   #stageVariables = null
 
-  constructor(request, stage, path, stageVariables) {
+  constructor(request, stage, path, stageVariables, routeKey = null) {
     this.#path = path
+    this.#routeKey = routeKey
     this.#request = request
     this.#stage = stage
     this.#stageVariables = stageVariables
@@ -128,7 +130,7 @@ export default class LambdaProxyIntegrationEvent {
     const httpMethod = method.toUpperCase()
     const requestTime = formatToClfTime(received)
     const requestTimeEpoch = received
-    const resource = route.path.replace(`/${this.#stage}`, '')
+    const resource = this.#routeKey || route.path.replace(`/${this.#stage}`, '')
 
     return {
       body,

--- a/src/events/http/lambda-events/LambdaProxyIntegrationEventV2.js
+++ b/src/events/http/lambda-events/LambdaProxyIntegrationEventV2.js
@@ -15,13 +15,13 @@ const { assign } = Object
 // https://www.serverless.com/framework/docs/providers/aws/events/http-api/
 // https://docs.aws.amazon.com/apigateway/latest/developerguide/http-api-develop-integrations-lambda.html
 export default class LambdaProxyIntegrationEventV2 {
-  #path = null
+  #routeKey = null
   #request = null
   #stage = null
   #stageVariables = null
 
-  constructor(request, stage, path, stageVariables) {
-    this.#path = path
+  constructor(request, stage, routeKey, stageVariables) {
+    this.#routeKey = routeKey
     this.#request = request
     this.#stage = stage
     this.#stageVariables = stageVariables
@@ -127,7 +127,7 @@ export default class LambdaProxyIntegrationEventV2 {
 
     return {
       version: '2.0',
-      routeKey: this.#path,
+      routeKey: this.#routeKey,
       rawPath: route.path,
       rawQueryString: new URL(
         url,
@@ -151,13 +151,13 @@ export default class LambdaProxyIntegrationEventV2 {
         domainPrefix: 'offlineContext_domainPrefix',
         http: {
           method: httpMethod,
-          path: this.#path,
+          path: route.path,
           protocol: 'HTTP/1.1',
           sourceIp: remoteAddress,
           userAgent: _headers['user-agent'] || '',
         },
         requestId: 'offlineContext_resourceId',
-        routeKey: this.#path,
+        routeKey: this.#routeKey,
         stage: this.#stage,
         time: requestTime,
         timeEpoch: requestTimeEpoch,

--- a/src/events/http/lambda-events/LambdaProxyIntegrationEventV2.js
+++ b/src/events/http/lambda-events/LambdaProxyIntegrationEventV2.js
@@ -4,7 +4,6 @@ import {
   formatToClfTime,
   nullIfEmpty,
   parseHeaders,
-  parseQueryStringParameters,
 } from '../../../utils/index.js'
 
 const { byteLength } = Buffer

--- a/tests/integration/jwt-authorizer/jwt-authorizer.test.js
+++ b/tests/integration/jwt-authorizer/jwt-authorizer.test.js
@@ -97,7 +97,7 @@ describe('jwt authorizer tests', () => {
         },
       },
       jwt: baseJWT,
-      path: '/dev/user1',
+      path: '/user1',
       status: 200,
     },
     {
@@ -110,7 +110,7 @@ describe('jwt authorizer tests', () => {
         },
       },
       jwt: correctAudience,
-      path: '/dev/user1',
+      path: '/user1',
       status: 200,
     },
     {
@@ -123,7 +123,7 @@ describe('jwt authorizer tests', () => {
         },
       },
       jwt: correctAudienceInArray,
-      path: '/dev/user1',
+      path: '/user1',
       status: 200,
     },
     {
@@ -137,7 +137,7 @@ describe('jwt authorizer tests', () => {
         },
       },
       jwt: multipleCorrectAudience,
-      path: '/dev/user1',
+      path: '/user1',
       status: 200,
     },
 
@@ -151,7 +151,7 @@ describe('jwt authorizer tests', () => {
         },
       },
       jwt: baseJWT,
-      path: '/dev/user2',
+      path: '/user2',
       status: 200,
     },
     {
@@ -162,7 +162,7 @@ describe('jwt authorizer tests', () => {
         message: 'JWT Token expired',
       },
       jwt: expiredJWT,
-      path: '/dev/user1',
+      path: '/user1',
       status: 401,
     },
     {
@@ -173,7 +173,7 @@ describe('jwt authorizer tests', () => {
         message: 'JWT Token not from correct issuer url',
       },
       jwt: wrongIssuerUrl,
-      path: '/dev/user1',
+      path: '/user1',
       status: 401,
     },
     {
@@ -184,7 +184,7 @@ describe('jwt authorizer tests', () => {
         message: 'JWT Token does not contain correct audience',
       },
       jwt: wrongClientId,
-      path: '/dev/user1',
+      path: '/user1',
       status: 401,
     },
     {
@@ -195,7 +195,7 @@ describe('jwt authorizer tests', () => {
         message: 'JWT Token does not contain correct audience',
       },
       jwt: wrongAudience,
-      path: '/dev/user1',
+      path: '/user1',
       status: 401,
     },
     {
@@ -206,7 +206,7 @@ describe('jwt authorizer tests', () => {
         message: 'JWT Token missing valid scope',
       },
       jwt: noScopes,
-      path: '/dev/user2',
+      path: '/user2',
       status: 403,
     },
   ].forEach(({ description, expected, jwt, path, status }) => {


### PR DESCRIPTION
## Description

Fixes #1118 but also addresses other issues found with `httpApi` events:

* Default payload format is now `2.0` (NB: also implemented by #1126 which does not include required fixes to 2.0 event payloads)
* Support for `$default` route
* Support for `$default` stage (Serverless always deploys to `$default` stage which should never be prepended to URL)
* ~Support for CORS configuration which is provided in `provider.httpApi`~ (reverted in favor of #1153)
* Fix `LambdaProxyIntegrationEvent.resource` which should be the route key (for `httpApi` events only)
* Fix `LambdaProxyIntegrationEventV2.routeKey` which should be the route key
* Fix `LambdaProxyIntegrationEventV2.rawPath` which should be obtained from the requested URL (not the route)
* Optimize `LambdaProxyIntegrationEventV2.rawQueryString` and `LambdaProxyIntegrationEventV2.queryStringParameters` to use existing `URL` instance provided in `#request`.

## Motivation and Context

It is currently not possible to define `$default` routes for `httpApi` events. The current workaround requires inconsistent implementation between Serverless Offline and AWS (using a `{proxy+}` hack locally).

The default event payload should reflect the default payload provisioned by Serverless/AWS.

The 2.0 payload format is currently wrong.

## How Has This Been Tested?

Compared event payloads (1.0 and 2.0) received on AWS against those received via Serverless Offline for both `$default` route and named routes.

Tested locally - payloads 1.0 and 2.0 are both handled successfully for named routes and `$default` route (defined in `serverless.yml` as `{ httpApi: '*' }`).

Updated related tests by removing stage prefix which is not used by Serverless (it unconditionally uses the `$default` stage).