### PR TITLE
fix: Remove multiplication of `this.#timeout` by 1000

### DIFF
--- a/src/lambda/__tests__/LambdaFunction.test.js
+++ b/src/lambda/__tests__/LambdaFunction.test.js
@@ -155,13 +155,11 @@ describe('LambdaFunction', () => {
     )
     const remainingTime = await lambdaFunction.runHandler()
 
-    expect(DEFAULT_LAMBDA_TIMEOUT * 1000).toBeGreaterThan(remainingTime)
+    expect(remainingTime).toBeLessThan(DEFAULT_LAMBDA_TIMEOUT * 1000)
 
     // result might be flaky/unreliable:
     // (assmuning handler runs no longer than 1 s)
-    expect(DEFAULT_LAMBDA_TIMEOUT * 1000).toBeLessThanOrEqual(
-      remainingTime + 1000,
-    )
+    expect(remainingTime + 1000).toBeGreaterThan(DEFAULT_LAMBDA_TIMEOUT * 1000)
   })
 
   // // might run flaky (unreliable)

--- a/src/lambda/__tests__/LambdaFunction.test.js
+++ b/src/lambda/__tests__/LambdaFunction.test.js
@@ -142,7 +142,6 @@ describe('LambdaFunction', () => {
     expect(second).toBeGreaterThan(third - 200)
   })
 
-  // might run flaky (unreliable)
   test('should use default lambda timeout when timeout is not provided', async () => {
     const functionDefinition = {
       handler: 'fixtures/lambdaFunction.fixture.defaultTimeoutHandler',
@@ -156,9 +155,13 @@ describe('LambdaFunction', () => {
     )
     const remainingTime = await lambdaFunction.runHandler()
 
+    expect(DEFAULT_LAMBDA_TIMEOUT * 1000).toBeGreaterThan(remainingTime)
+
     // result might be flaky/unreliable:
-    // (assmuning handler runs no longer than 100 ms)
-    expect(DEFAULT_LAMBDA_TIMEOUT * 1000).toBeLessThanOrEqual(remainingTime)
+    // (assmuning handler runs no longer than 1 s)
+    expect(DEFAULT_LAMBDA_TIMEOUT * 1000).toBeLessThanOrEqual(
+      remainingTime + 1000,
+    )
   })
 
   // // might run flaky (unreliable)

--- a/src/lambda/handler-runner/in-process-runner/InProcessRunner.js
+++ b/src/lambda/handler-runner/in-process-runner/InProcessRunner.js
@@ -122,7 +122,7 @@ export default class InProcessRunner {
       }
     })
 
-    const executionTimeout = performance.now() + this.#timeout * 1000
+    const executionTimeout = performance.now() + this.#timeout
 
     // attach doc-deprecated functions
     // create new immutable object


### PR DESCRIPTION

## Description
<!--- Describe your changes in detail -->

Remove a multiplication of `this.#timeout` by 1000

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

The value returned by `context.getRemainingTimeMillis()` was 1000 times greater than expected, ie. 900000000 not 900000.

It has already been multiplied by 1000 at
https://github.com/dherault/serverless-offline/blob/91592d3b5bc51fb0975862dcbd06f66be80a7f51/src/lambda/LambdaFunction.js#L67 so after multiplying it again at https://github.com/dherault/serverless-offline/blob/1454da7dcff5f48da9f19135cb18590b22e29cc2/src/lambda/handler-runner/in-process-runner/InProcessRunner.js#L125 it was 1000 times greater than expected.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

The `getRemainingTimeMillis` (timeout) check in the `LambdaFunction` test was incorrectly checking that the function returns a value greater than the original timeout instead of less than the original timeout.

After fixing the checks, the test fails as expected:

```
  ● LambdaFunction › should use default lambda timeout when timeout is not provided

    expect(received).toBeLessThan(expected)

    Expected: < 900000
    Received:   899999999.83861

      156 |     const remainingTime = await lambdaFunction.runHandler()
      157 | 
    > 158 |     expect(remainingTime).toBeLessThan(DEFAULT_LAMBDA_TIMEOUT * 1000)
          |                           ^
      159 | 
      160 |     // result might be flaky/unreliable:
      161 |     // (assmuning handler runs no longer than 1 s)

      at Object.<anonymous> (src/lambda/__tests__/LambdaFunction.test.js:158:27)
```

Removing the 1000 multiplication the test is passing again.