### PR TITLE
Add '--noStripTrailingSlashInUrl' option

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,7 @@ All CLI options are optional:
 --layersDir                 The directory layers should be stored in. Default: ${codeDir}/.serverless-offline/layers'
 --noAuth                    Turns off all authorizers
 --noPrependStageInUrl       Don't prepend http routes with the stage.
+--noStripTrailingSlashInUrl Don't strip trailing slash from http routes.
 --noTimeout             -t  Disables the timeout feature.
 --prefix                -p  Adds a prefix to every path, to send your requests to http://localhost:3000/[prefix]/[your_path] instead. Default: ''
 --printOutput               Turns on logging of your lambda outputs in the terminal.

--- a/src/config/commandOptions.js
+++ b/src/config/commandOptions.js
@@ -59,6 +59,10 @@ export default {
     usage: "Don't prepend http routes with the stage.",
     type: 'boolean',
   },
+  noStripTrailingSlashInUrl: {
+    usage: "Don't strip trailing slash from http routes.",
+    type: 'boolean',
+  },
   noAuth: {
     usage: 'Turns off all authorizers',
     type: 'boolean',

--- a/src/config/defaultOptions.js
+++ b/src/config/defaultOptions.js
@@ -22,6 +22,7 @@ export default {
   layersDir: null,
   noAuth: false,
   noPrependStageInUrl: false,
+  noStripTrailingSlashInUrl: false,
   noTimeout: false,
   prefix: '',
   printOutput: false,

--- a/src/events/http/HttpServer.js
+++ b/src/events/http/HttpServer.js
@@ -47,6 +47,7 @@ export default class HttpServer {
       host,
       httpPort,
       httpsProtocol,
+      noStripTrailingSlashInUrl,
     } = this.#options
 
     const serverOptions = {
@@ -55,7 +56,7 @@ export default class HttpServer {
       router: {
         // allows for paths with trailing slashes to be the same as without
         // e.g. : /my-path is the same as /my-path/
-        stripTrailingSlash: true,
+        stripTrailingSlash: !noStripTrailingSlashInUrl,
       },
       state: enforceSecureCookies
         ? {

--- a/src/utils/generateHapiPath.js
+++ b/src/utils/generateHapiPath.js
@@ -12,7 +12,11 @@ export default function generateHapiPath(path = '', options, serverless) {
     hapiPath = `/${options.prefix}${hapiPath}`
   }
 
-  if (hapiPath !== '/' && hapiPath.endsWith('/')) {
+  if (
+    hapiPath !== '/' &&
+    hapiPath.endsWith('/') &&
+    (!options.noStripTrailingSlashInUrl || hapiPath.endsWith('+}/'))
+  ) {
     hapiPath = hapiPath.slice(0, -1)
   }
 

--- a/tests/endToEnd/trailingSlash/handler.js
+++ b/tests/endToEnd/trailingSlash/handler.js
@@ -1,0 +1,11 @@
+'use strict'
+
+exports.echo = async (event) => {
+  return {
+    statusCode: 200,
+    body: JSON.stringify({
+      path: event.path,
+      resource: event.resource,
+    }),
+  }
+}

--- a/tests/endToEnd/trailingSlash/serverless.yml
+++ b/tests/endToEnd/trailingSlash/serverless.yml
@@ -1,0 +1,27 @@
+service: uncategorized-tests
+
+plugins:
+  - ../../../
+
+provider:
+  memorySize: 128
+  name: aws
+  region: us-east-1 # default
+  runtime: nodejs12.x
+  stage: dev
+  versionFunctions: false
+
+functions:
+  echo:
+    handler: handler.echo
+    events:
+      - http:
+          method: get
+          path: /echo/test
+      - http:
+          method: get
+          path: /echo/test/
+      - http:
+          method: get
+          path: /echo/{any+}
+

--- a/tests/endToEnd/trailingSlash/trailingSlash.test.js
+++ b/tests/endToEnd/trailingSlash/trailingSlash.test.js
@@ -1,0 +1,55 @@
+import { resolve } from 'path'
+import fetch from 'node-fetch'
+import {
+  joinUrl,
+  setup,
+  teardown,
+} from '../../integration/_testHelpers/index.js'
+
+jest.setTimeout(30000)
+
+describe('noStripTrailingSlashInUrl option', () => {
+  // init
+  beforeAll(() =>
+    setup({
+      servicePath: resolve(__dirname),
+      args: ['--noStripTrailingSlashInUrl'],
+    }),
+  )
+
+  // cleanup
+  afterAll(() => teardown())
+
+  describe('when --noStripTrailingSlashInUrl is used, and request is made ending with slash', () => {
+    test('it should not be removed', async () => {
+      const url = joinUrl(TEST_BASE_URL, '/dev/echo/something/')
+      const response = await fetch(url)
+      const json = await response.json()
+
+      expect(json).toEqual({
+        path: '/echo/something/',
+        resource: '/echo/{any*}',
+      })
+    })
+  })
+
+  describe('when --noStripTrailingSlashInUrl is used, events with and without slash can co-exist', () => {
+    test('it should not be removed', async () => {
+      let url = joinUrl(TEST_BASE_URL, '/dev/echo/test')
+      let response = await fetch(url)
+      let json = await response.json()
+      expect(json).toEqual({
+        path: '/echo/test',
+        resource: '/echo/test',
+      })
+
+      url = joinUrl(TEST_BASE_URL, '/dev/echo/test/')
+      response = await fetch(url)
+      json = await response.json()
+      expect(json).toEqual({
+        path: '/echo/test/',
+        resource: '/echo/test/',
+      })
+    })
+  })
+})


### PR DESCRIPTION
## Description
Add `--noStripTrailingSlashInUrl` option passing ending slash to Lambda event.

## Motivation and Context
We have Lambda responding on HTTP event having `/{any+}` path. Currently it is not possible to receive trailing slash in the requested event path. Both `/dev/hello` and `/dev/hello/` are sent to Lambda as `/dev/hello`.

Extra option allows event to be set with a trailing slash and allows request to be sent to Lambda with a trailing slash.