### PR TITLE
Add command line option for disabling scheduled events.

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,7 @@ All CLI options are optional:
 --corsDisallowCredentials   When provided, the default Access-Control-Allow-Credentials header value will be passed as 'false'. Default: true
 --corsExposedHeaders        Used as additional Access-Control-Exposed-Headers header value for responses. Delimit multiple values with commas. Default: 'WWW-Authenticate,Server-Authorization'
 --disableCookieValidation   Used to disable cookie-validation on hapi.js-server
+--disableScheduledEvents    Disables all scheduled events. Overrides configurations in serverless.yml.
 --dockerHost                The host name of Docker. Default: localhost
 --dockerHostServicePath     Defines service path which is used by SLS running inside Docker container
 --dockerNetwork             The network that the Docker container will connect to

--- a/package.json
+++ b/package.json
@@ -102,6 +102,7 @@
     "Gert Jansen van Rensburg (https://github.com/gertjvr)",
     "Guillaume Carbonneau (https://github.com/guillaume)",
     "György Balássy (https://github.com/balassy)",
+    "James Relyea (https://github.com/james-relyea)",
     "Jarda Snajdr (https://github.com/jsnajdr)",
     "Jaryd Carolin (https://github.com/horyd)",
     "Jeff Hall (https://github.com/electrikdevelopment)",

--- a/src/ServerlessOffline.js
+++ b/src/ServerlessOffline.js
@@ -94,7 +94,7 @@ export default class ServerlessOffline {
       eventModules.push(this._createHttp(httpEvents))
     }
 
-    if (scheduleEvents.length > 0) {
+    if (!this.#options.disableScheduledEvents && scheduleEvents.length > 0) {
       eventModules.push(this._createSchedule(scheduleEvents))
     }
 

--- a/src/config/commandOptions.js
+++ b/src/config/commandOptions.js
@@ -28,6 +28,10 @@ export default {
     usage: 'Used to disable cookie-validation on hapi.js-server',
     type: 'boolean',
   },
+  disableScheduledEvents: {
+    usage:
+      'Disables all scheduled events. Overrides configurations in serverless.yml.',
+  },
   enforceSecureCookies: {
     usage: 'Enforce secure cookies',
     type: 'boolean',

--- a/src/config/commandOptions.js
+++ b/src/config/commandOptions.js
@@ -30,7 +30,8 @@ export default {
   },
   disableScheduledEvents: {
     usage:
-      'Disables all scheduled events. Overrides configurations in serverless.yml.',
+      'Disables all scheduled events. Overrides configurations in serverless.yml. Default: false',
+    type: 'boolean',
   },
   enforceSecureCookies: {
     usage: 'Enforce secure cookies',

--- a/src/config/defaultOptions.js
+++ b/src/config/defaultOptions.js
@@ -8,6 +8,7 @@ export default {
   corsAllowOrigin: '*',
   corsExposedHeaders: 'WWW-Authenticate,Server-Authorization',
   disableCookieValidation: false,
+  disableScheduledEvents: false,
   dockerHost: 'localhost',
   dockerHostServicePath: null,
   dockerNetwork: null,


### PR DESCRIPTION
## Description
* Add support for using `--disableScheduledEvents` from the command line to force all scheduled events to become disabled.  Resolves #1123.

* Also included a fix for husky pre-commit lint error I was receiving while trying to create this PR by moving the :
```
> serverless-offline@6.8.0 lint /serverless-offline
> eslint .


/serverless-offline/src/lambda/LambdaFunction.js
  39:3  error  'status' is not defined  no-undef

✖ 1 problem (1 error, 0 warnings)
```


## Motivation and Context
During development some of us are wanting to disable all scheduled events from being scheduled without also needing to modify our `serverless.yml`.

## How Has This Been Tested?
Tested out a `serverless.yml` configuration with a scheduled event configuration:
```
  testEvent:
    handler: src/index.testEvent
    events:
      - schedule:
          enabled: true
          rate: rate(1 minute)
          
  testEvent2:
    handler: src/index.testEvent2
    events:
      - schedule:
          enabled: true
          rate: rate(2 minutes)
          
  testEvent3:
    handler: src/index.testEvent3
    events:
      - schedule:
          enabled: false
          rate: rate(5 minutes)
```

While starting with `serverless offline --disableScheduledEvents`, confirmed that none of the enabled events were triggered. With that option not specified, confirmed that `testEvent1` and `testEvent2` were triggered relative to their `rate` configuration.