### PR TITLE
Replicate AWS behavior of lambda exposed through API Gateway WebSockets

### DIFF
--- a/src/events/websocket/WebSocketClients.js
+++ b/src/events/websocket/WebSocketClients.js
@@ -115,12 +115,12 @@ export default class WebSocketClients {
 
     lambdaFunction.setEvent(event)
 
-    // let result
-
     try {
-      /* result = */ await lambdaFunction.runHandler()
+      const result = await lambdaFunction.runHandler()
 
-      // TODO what to do with "result"?
+      if (websocketClient.readyState === OPEN && result && result.body) {
+        websocketClient.send(result.body)
+      }
     } catch (err) {
       console.log(err)
       sendError(err)


### PR DESCRIPTION
## Description
I changed the implementation of `WebSocketClients._processEvent` in order to use the result of lambda invocation.
If the result contains a body and the `websocketClient` is still `OPEN`, the body of the lambda result is sent to the client.

## Motivation and Context
The current implementation doesn't behave like an AWS API Gateway with WebSockets. This change replicates the behavior exposed by AWS API Gateway.

## How Has This Been Tested?
serverless.yml
```YAML 
service:
  name: test

plugins:
  - serverless-plugin-typescript
  - serverless-offline

provider:
  name: aws
  runtime: nodejs12.x

functions:
  actionHandler:
    handler: src/echo-handler.handler
    events:
      - websocket:
          route: echo
          routeResponseSelectionExpression: $default

```
src/echo-handler.ts
```TypeScript
import { APIGatewayProxyEvent, APIGatewayProxyResult, Callback, Context } from "aws-lambda"

export const handler = async (
    event: APIGatewayProxyEvent,
    context: Context,
    callback: Callback<APIGatewayProxyResult>,
): Promise<APIGatewayProxyResult> => {
    const body = JSON.parse(event.body)
    return {
        statusCode: 200,
        body: JSON.stringify({ message: `echo ${body.message}` }),
    }
}
```
Run serverless with `serverless offline`
Use `wscat` to interact with serverless:
```Bash
$ wscat -c "ws://localhost:3001"
Connected (press CTRL+C to quit)
> {"action": "echo", "message": "ooooooooooooooooo"}
< {"message":"echo ooooooooooooooooo"}
```
Second to last line is the message sent to the API Gateway.
Last line is the lambda response which is missing in the current implementation

