### PR TITLE
serverless config: empty resources key handling

### DIFF
--- a/src/events/http/createAuthScheme.js
+++ b/src/events/http/createAuthScheme.js
@@ -1,5 +1,4 @@
 import Boom from '@hapi/boom'
-import authCanExecuteResource from './authCanExecuteResource.js'
 import debugLog from '../../debugLog.js'
 import serverlessLog from '../../serverlessLog.js'
 import {
@@ -9,12 +8,14 @@ import {
   parseMultiValueQueryStringParameters,
   parseQueryStringParameters,
 } from '../../utils/index.js'
+import toLowerCase from '../../utils/toLowercase.js'
+import authCanExecuteResource from './authCanExecuteResource.js'
 
 export default function createAuthScheme(authorizerOptions, provider, lambda) {
   const authFunName = authorizerOptions.name
   let identityHeader = 'authorization'
 
-  if (authorizerOptions.type !== 'request') {
+  if (toLowerCase(authorizerOptions.type) !== 'request') {
     const identitySourceMatch = /^method.request.header.((?:\w+-?)+\w+)$/.exec(
       authorizerOptions.identitySource,
     )
@@ -68,7 +69,7 @@ export default function createAuthScheme(authorizerOptions, provider, lambda) {
       // Create event Object for authFunction
       //   methodArn is the ARN of the function we are running we are authorizing access to (or not)
       //   Account ID and API ID are not simulated
-      if (authorizerOptions.type === 'request') {
+      if (toLowerCase(authorizerOptions.type) === 'request') {
         const { rawHeaders, url } = req
 
         event = {

--- a/src/events/http/parseResources.js
+++ b/src/events/http/parseResources.js
@@ -6,11 +6,9 @@ const APIGATEWAY_TYPE_METHOD = 'AWS::ApiGateway::Method'
 const APIGATEWAY_TYPE_RESOURCE = 'AWS::ApiGateway::Resource'
 
 function getApiGatewayTemplateObjects(resources) {
-  const Resources = resources && resources.Resources
-
-  if (!Resources) {
-    return {}
-  }
+  // return empty object if methodObjects are empty from serverless config resources key
+  // it'd still return methodObjects and pathObjects key
+  const Resources = resources && resources.Resources ? resources.Resources : {}
 
   const methodObjects = []
   const pathObjects = []
@@ -173,11 +171,6 @@ function constructHapiInterface(pathObjects, methodObjects, methodId) {
 
 export default function parseResources(resources) {
   const { methodObjects, pathObjects } = getApiGatewayTemplateObjects(resources)
-
-  // return empty object if methodObjects are empty from serverless config resources key
-  if (!methodObjects) {
-    return {}
-  }
 
   return fromEntries(
     keys(methodObjects).map((key) => [

--- a/src/events/http/parseResources.js
+++ b/src/events/http/parseResources.js
@@ -174,8 +174,8 @@ function constructHapiInterface(pathObjects, methodObjects, methodId) {
 export default function parseResources(resources) {
   const { methodObjects, pathObjects } = getApiGatewayTemplateObjects(resources)
 
-  // return empty object if methodObjects or pathObjects are empty from serverless config resources key
-  if (!methodObjects || pathObjects) {
+  // return empty object if methodObjects are empty from serverless config resources key
+  if (!methodObjects) {
     return {}
   }
 

--- a/src/events/http/parseResources.js
+++ b/src/events/http/parseResources.js
@@ -174,6 +174,11 @@ function constructHapiInterface(pathObjects, methodObjects, methodId) {
 export default function parseResources(resources) {
   const { methodObjects, pathObjects } = getApiGatewayTemplateObjects(resources)
 
+  // return empty object if methodObjects or pathObjects are empty from serverless config resources key
+  if (!methodObjects || pathObjects) {
+    return {}
+  }
+
   return fromEntries(
     keys(methodObjects).map((key) => [
       key,

--- a/src/utils/__tests__/toLowercase.test.js
+++ b/src/utils/__tests__/toLowercase.test.js
@@ -1,0 +1,23 @@
+import toLowerCase from '../toLowercase.js'
+
+describe('test lowercase function', () => {
+  test('it return itself when non-string is input', () => {
+    const value = toLowerCase(undefined)
+    const objectValue = toLowerCase({})
+    const numberValue = toLowerCase(100)
+    const nullValue = toLowerCase(null)
+
+    expect(value).toEqual(undefined)
+    expect(objectValue).toEqual({})
+    expect(numberValue).toEqual(100)
+    expect(nullValue).toEqual(null)
+  })
+
+  test('it lowercase string value', () => {
+    const value = toLowerCase('STRING')
+    const secondValue = toLowerCase('REQUEST')
+
+    expect(value).toBe('string')
+    expect(secondValue).toBe('request')
+  })
+})

--- a/src/utils/toLowercase.js
+++ b/src/utils/toLowercase.js
@@ -1,0 +1,8 @@
+// Used to lowercase string value e.g authorizerOptions.type
+export default function toLowerCase(value) {
+  if (!value || typeof value !== 'string') {
+    return value
+  }
+
+  return value.toLowerCase()
+}


### PR DESCRIPTION
## Description
handle serverless config (serverless.yml or ts) that had empty resources key to be able to run

## Motivation and Context
this change is required to handle serverless config file that has empty resources key which some project has.
previously it'd throw error
```
Type Error ----------------------------------------------
 
  TypeError: Cannot convert undefined or null to object
      at keys (<anonymous>)
      at parseResources (node_modules/serverless-offline/dist/events/http/parseResources.js:187:22)
      at HttpServer.createResourceRoutes (node_modules/serverless-offline/dist/events/http/HttpServer.js:856:56)
      at Http.createResourceRoutes (node_modules/serverless-offline/dist/events/http/Http.js:57:65)
      at ServerlessOffline._createHttp (node_modules/serverless-offline/dist/ServerlessOffline.js:219:53)
      at processTicksAndRejections (internal/process/task_queues.js:97:5)
      at async Promise.all (index 0)
      at async ServerlessOffline.start (node_modules/serverless-offline/dist/ServerlessOffline.js:131:5)
      at async ServerlessOffline._startWithExplicitEnd (node_modules/serverless-offline/dist/ServerlessOffline.js:180:5)
      at async PluginManager.invoke (node_modules/serverless/lib/classes/PluginManager.js:544:9)
 
     For debugging logs, run again after setting the "SLS_DEBUG=*" environment variable.
```

with the config of 
```
service:
  name: test

plugins:
  - serverless-webpack
  - serverless-offline

provider:
  name: aws
  runtime: nodejs12.x

functions:
  myAuthorizer:
    handler: functions/authorizers/index.handler
    description: Authorizer that checks that the headers is valid
    memorySize: 128
```

## How Has This Been Tested?
run `sls offline` command on the same project.
check the offline process running
```
offline: [HTTP] server ready: http://localhost:4000 🚀
offline: 
offline: Enter "rp" to replay the last request
```
