### PR TITLE
fix: case-insensitive handling on authorizer type config

### DIFF
--- a/src/events/http/createAuthScheme.js
+++ b/src/events/http/createAuthScheme.js
@@ -1,5 +1,4 @@
 import Boom from '@hapi/boom'
-import authCanExecuteResource from './authCanExecuteResource.js'
 import debugLog from '../../debugLog.js'
 import serverlessLog from '../../serverlessLog.js'
 import {
@@ -9,12 +8,14 @@ import {
   parseMultiValueQueryStringParameters,
   parseQueryStringParameters,
 } from '../../utils/index.js'
+import toLowerCase from '../../utils/toLowercase.js'
+import authCanExecuteResource from './authCanExecuteResource.js'
 
 export default function createAuthScheme(authorizerOptions, provider, lambda) {
   const authFunName = authorizerOptions.name
   let identityHeader = 'authorization'
 
-  if (authorizerOptions.type !== 'request') {
+  if (toLowerCase(authorizerOptions.type) !== 'request') {
     const identitySourceMatch = /^method.request.header.((?:\w+-?)+\w+)$/.exec(
       authorizerOptions.identitySource,
     )
@@ -68,7 +69,7 @@ export default function createAuthScheme(authorizerOptions, provider, lambda) {
       // Create event Object for authFunction
       //   methodArn is the ARN of the function we are running we are authorizing access to (or not)
       //   Account ID and API ID are not simulated
-      if (authorizerOptions.type === 'request') {
+      if (toLowerCase(authorizerOptions.type) === 'request') {
         const { rawHeaders, url } = req
 
         event = {

--- a/src/utils/__tests__/toLowercase.test.js
+++ b/src/utils/__tests__/toLowercase.test.js
@@ -1,0 +1,23 @@
+import toLowerCase from '../toLowercase.js'
+
+describe('test lowercase function', () => {
+  test('it return itself when non-string is input', () => {
+    const value = toLowerCase(undefined)
+    const objectValue = toLowerCase({})
+    const numberValue = toLowerCase(100)
+    const nullValue = toLowerCase(null)
+
+    expect(value).toEqual(undefined)
+    expect(objectValue).toEqual({})
+    expect(numberValue).toEqual(100)
+    expect(nullValue).toEqual(null)
+  })
+
+  test('it lowercase string value', () => {
+    const value = toLowerCase('STRING')
+    const secondValue = toLowerCase('REQUEST')
+
+    expect(value).toBe('string')
+    expect(secondValue).toBe('request')
+  })
+})

--- a/src/utils/toLowercase.js
+++ b/src/utils/toLowercase.js
@@ -1,0 +1,8 @@
+// Used to lowercase string value e.g authorizerOptions.type
+export default function toLowerCase(value) {
+  if (!value || typeof value !== 'string') {
+    return value
+  }
+
+  return value.toLowerCase()
+}


### PR DESCRIPTION
## Description
Using these authorizer config type `REQUEST` would cause error
```
test:
  handler: src/handlers/test.handler
  events:
    - http:
        authorizer:
          name: authUser
          identitySource: method.request.header.X-signature, method.request.header.X-timestamp
          type: REQUEST
          resultTtlInSeconds: 0
```

## Motivation and Context
Case insensitive config for authorizer type in `serverless.yml` or `ts`
Opened issue https://github.com/dherault/serverless-offline/issues/432

## How Has This Been Tested?
- unit tests
- run locally with authorizer config type `REQUEST`

