### PR TITLE
Fix: Log ruby stdout to console

### DIFF
--- a/src/lambda/handler-runner/ruby-runner/RubyRunner.js
+++ b/src/lambda/handler-runner/ruby-runner/RubyRunner.js
@@ -26,6 +26,8 @@ export default class RubyRunner {
   cleanup() {}
 
   _parsePayload(value) {
+    let payload
+
     for (const item of value.split(EOL)) {
       let json
 
@@ -43,11 +45,13 @@ export default class RubyRunner {
         typeof json === 'object' &&
         has(json, '__offline_payload__')
       ) {
-        return json.__offline_payload__
+        payload = json.__offline_payload__
+      } else {
+        console.log(item) // log non-JSON stdout to console (puts, p, logger.info, ...)
       }
     }
 
-    return undefined
+    return payload
   }
 
   // invokeLocalRuby, loosely based on:


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
This fix allows stdout to be logged to the console, allowing Ruby output operations like `logger.info`, `puts` and `p` to materialize.

Emulates the way `sls invoke local --function ...` logs such statements.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
The use of `logger` is [officially supported](https://github.com/awsdocs/aws-lambda-developer-guide/blob/main/sample-apps/blank-ruby/function/lambda_function.rb) by AWS in Lambda, and should produce the same result when running offline. It is also useful to be able to print to console for debugging purposes. The implementation of the Python runner [does a similar thing](https://github.com/dherault/serverless-offline/blob/b55c846a0f0cdae14b320f50c1f6c8e9acb80c70/src/lambda/handler-runner/python-runner/PythonRunner.js).

<!--- If it fixes an open issue, please link to the issue here. -->
Resolves https://github.com/dherault/serverless-offline/issues/1206

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
I installed and built the local fork into my project and added the following print statements

```ruby
def handler(event:, context:)
  logger = Logger.new($stdout)

  logger.info('This is a logger.info message')
  p 'This is a p message'
  puts 'This is a puts message'
  ...
```
Output was 
```zsh
offline: POST /local/hello (λ: hello)
I, [2021-04-14T16:46:02.387705 #74974]  INFO -- : This is a logger.info message
"This is a p message"
This is a puts message
offline: (λ: hello) RequestId: ckni3qx290005qqku6jww556f  Duration: 831.02 ms  Billed Duration: 832 ms
offline: [200] {"statusCode":200,"body":"{\"message\":\"OK\",\"output\":{\"output\":\"hello\"}}"}```
```

<!--- Include details of your testing environment, and the tests you ran to -->
Built locally using package.json and compiled using Babel per the contribution guide.
<!--- see how your change affects other areas of the code, etc. -->

Please let me know if you have any questions or if there is something I missed. Thanks!

## Screenshots (if appropriate):
