### PR TITLE
test: Fix http cors integration test URL paths

### DIFF
--- a/tests/integration/httpApi-cors/httpApi-cors.test.js
+++ b/tests/integration/httpApi-cors/httpApi-cors.test.js
@@ -19,7 +19,7 @@ describe('HttpApi Cors Tests', () => {
   afterAll(() => teardown())
 
   test('Fetch OPTIONS with valid origin', async () => {
-    const url = joinUrl(TEST_BASE_URL, '/dev/user')
+    const url = joinUrl(TEST_BASE_URL, '/user')
     const options = {
       method: 'OPTIONS',
       headers: {
@@ -51,7 +51,7 @@ describe('HttpApi Cors Tests', () => {
   })
 
   test('Fetch OPTIONS with invalid origin', async () => {
-    const url = joinUrl(TEST_BASE_URL, '/dev/user')
+    const url = joinUrl(TEST_BASE_URL, '/user')
     const options = {
       method: 'OPTIONS',
       headers: {


### PR DESCRIPTION
## Description
Fix HTTP CORS integration tests to call proper PATH after changes introduced in: https://github.com/dherault/serverless-offline/pull/1175

## Motivation and Context
Failing tests on master, visible e.g. here: https://github.com/dherault/serverless-offline/runs/2391560450?check_suite_focus=true

## How Has This Been Tested?
Automated tests
