### PR TITLE
feat: Support Ruby handlers with `::` in path definition

### DIFF
--- a/README.md
+++ b/README.md
@@ -729,6 +729,6 @@ We try to follow [Airbnb's JavaScript Style Guide](https://github.com/airbnb/jav
 :---: |:---: |:---: |:---: |:---: |
 [lteacher](https://github.com/lteacher) |[martinmicunda](https://github.com/martinmicunda) |[nori3tsu](https://github.com/nori3tsu) |[ppasmanik](https://github.com/ppasmanik) |[ryanzyy](https://github.com/ryanzyy) |
 
-[<img alt="m0ppers" src="https://avatars3.githubusercontent.com/u/819421?v=4&s=117" width="117">](https://github.com/m0ppers) |[<img alt="footballencarta" src="https://avatars0.githubusercontent.com/u/1312258?v=4&s=117" width="117">](https://github.com/footballencarta) |[<img alt="bryanvaz" src="https://avatars0.githubusercontent.com/u/9157498?v=4&s=117" width="117">](https://github.com/bryanvaz) |
-:---: |:---: |:---: |
-[m0ppers](https://github.com/m0ppers) |[footballencarta](https://github.com/footballencarta) |[bryanvaz](https://github.com/bryanvaz) |
+[<img alt="m0ppers" src="https://avatars3.githubusercontent.com/u/819421?v=4&s=117" width="117">](https://github.com/m0ppers) |[<img alt="footballencarta" src="https://avatars0.githubusercontent.com/u/1312258?v=4&s=117" width="117">](https://github.com/footballencarta) |[<img alt="bryanvaz" src="https://avatars0.githubusercontent.com/u/9157498?v=4&s=117" width="117">](https://github.com/bryanvaz) |[<img alt="njyjn" src="https://avatars.githubusercontent.com/u/10694375?v=4&s=117" width="117">](https://github.com/njyjn) |
+:---: |:---: |:---: |:---: |
+[m0ppers](https://github.com/m0ppers) |[footballencarta](https://github.com/footballencarta) |[bryanvaz](https://github.com/bryanvaz) | [njyjn](https://github.com/njyjn) |[kdybicz](https://github.com/kdybicz) |

--- a/package.json
+++ b/package.json
@@ -147,7 +147,8 @@
     "Utku Turunc (https://github.com/utkuturunc)",
     "Vasiliy Solovey (https://github.com/miltador)",
     "Dima Krutolianov (https://github.com/dimadk24)",
-    "Bryan Vaz (https://github.com/bryanvaz)"
+    "Bryan Vaz (https://github.com/bryanvaz)",
+    "Justin Ng (https://github.com/njyjn)"
   ],
   "engines": {
     "node": ">=10.13.0"

--- a/src/utils/__tests__/splitHandlerPathAndName.test.js
+++ b/src/utils/__tests__/splitHandlerPathAndName.test.js
@@ -1,0 +1,53 @@
+import splitHandlerPathAndName from '../splitHandlerPathAndName.js'
+
+const tests = [
+  {
+    description: 'ruby handler with namespace resolution operator ::',
+    expected: ['./src/somefolder/source', 'LambdaFunctions::Handler.process'],
+    handler: './src/somefolder/source.LambdaFunctions::Handler.process',
+  },
+  {
+    description: 'ruby handler with multiple namespace resolution operators ::',
+    expected: [
+      './src/somefolder/source',
+      'Functions::LambdaFunctions::Handler.process',
+    ],
+    handler:
+      './src/somefolder/source.Functions::LambdaFunctions::Handler.process',
+  },
+  {
+    description: 'ruby handler with namespace resolution operator ::, unnested',
+    expected: ['source', 'LambdaFunctions::Handler.process'],
+    handler: 'source.LambdaFunctions::Handler.process',
+  },
+  {
+    description:
+      'ruby handler with multiple namespace resolution operators ::, unnested',
+    expected: ['./source', 'Functions::LambdaFunctions::Handler.process'],
+    handler: './source.Functions::LambdaFunctions::Handler.process',
+  },
+  {
+    description: 'ruby handler from kernel',
+    expected: ['./src/somefolder/function', 'handler'],
+    handler: './src/somefolder/function.handler',
+  },
+  {
+    description: 'generic handler',
+    expected: ['./src/somefolder/.handlers/handler', 'run'],
+    handler: './src/somefolder/.handlers/handler.run',
+  },
+  {
+    description: 'generic handler, unnested',
+    expected: ['handler', 'run'],
+    handler: 'handler.run',
+  },
+]
+
+describe('splitHandlerPathAndName', () => {
+  tests.forEach(({ description, expected, handler }) => {
+    test(`should split ${description}`, () => {
+      const result = splitHandlerPathAndName(handler)
+      expect(result).toEqual(expected)
+    })
+  })
+})

--- a/src/utils/splitHandlerPathAndName.js
+++ b/src/utils/splitHandlerPathAndName.js
@@ -1,7 +1,28 @@
 // some-folder/src.index => some-folder/src
 export default function splitHandlerPathAndName(handler) {
   // Split handler into method name and path i.e. handler.run
+  // Support Ruby paths with namespace resolution operators e.g.
+  //  ./src/somefolder/source.LambdaFunctions::Handler.process
+  //  prepath: ./src/somefolder/
+  //  postpath: source.LambdaFunctions::Handler.process
+  //  filename: source
+  //  path: ./src/somefolder/source
+  //  name: LambdaFunctions::Handler.process
+  if (handler.match(/::/)) {
+    const prepathDelimiter = handler.lastIndexOf('/')
+    const prepath = handler.substr(0, prepathDelimiter + 1) // include '/' for path
+    const postpath = handler.substr(prepathDelimiter + 1)
+    const nameDelimiter = postpath.indexOf('.')
+    const filename = postpath.substr(0, nameDelimiter)
+    const path = prepath + filename
+    const name = postpath.substr(nameDelimiter + 1)
+
+    return [path, name]
+  }
+
   // Support nested paths i.e. ./src/somefolder/.handlers/handler.run
+  //  path: ./src/somefoler/.handlers/handler
+  //  name: run
   const delimiter = handler.lastIndexOf('.')
   const path = handler.substr(0, delimiter)
   const name = handler.substr(delimiter + 1)


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
This enhancement adds support for Ruby handlers that have namespace resolution operators (`::`) in their path definition, e.g. `handler: 'src/lambdas/examples/hello.Hello::Handler.process'`, etc. This was officially mentioned in the AWS documentation (see below). Logic was preserved for existing scenarios (without `::`) to reduce the risk of regression.

Without this enhancement, the following error message is triggered when the handler is invoked

```
offline: Failure: Command failed with exit code 1: ruby /PATH_TO_PROJECT/node_modules/serverless-offline/dist/lambda/handler-runner/ruby-runner/invoke.rb src/functions/source.LambdaFunctions::Handler process
~/.rbenv/versions/2.7.1/lib/ruby/2.7.0/rubygems/core_ext/kernel_require.rb:92:in `require': cannot load such file -- ./src/functions/source.LambdaFunctions::Handler (LoadError)
```

This seems to be because the handler paths and names are not being split correctly. For such Ruby handlers, the `name` should have the resolution operator instead of the `path`. Support for this already seems to be built-in

https://github.com/dherault/serverless-offline/blob/d319174c61a57ef66a0fc0eff6580f1ad8c592ce/src/lambda/handler-runner/ruby-runner/invoke.rb#L75-L78

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
AWS [officially demonstrates the use](https://docs.aws.amazon.com/lambda/latest/dg/ruby-handler.html) of handler methods within modules and classes. The specific example given is

```ruby
module LambdaFunctions
  class Handler
    def self.process(event:,context:)
      "Hello!"
    end
  end
end
```

where the handler setting is `source.LambdaFunctions::Handler.process`. Since this is the entry point for many developers, it would be great if it is supported by `serverless-offline`.

For projects that implement a large number of handlers, it would be optimal to not pollute the Kernel private_method namespace if such handlers can be encapsulated into their own modules and classes.

<!--- If it fixes an open issue, please link to the issue here. -->
Resolves #1031 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
Unit tests were added in https://github.com/dherault/serverless-offline/commit/4a6d0dc37d926a0617241f07bd323b73cfa69153 to validate this enhancement, as well as the original functionality that was left in tact.

<!--- Include details of your testing environment, and the tests you ran to -->
In addition to the additional unit tests, I was able to use `serverless-offline` for Ruby handlers with and without namespace separators

```ts
"serverless.ts"

  functions: {
    hello: {
      environment: {
        GEM_PATH: 'vendor/bundle/ruby/2.7.0/',
      },
      handler: 'src/lambdas/examples/hello.Hello::Handler.process',
      events: [
        {
          http: {
            path: '/hello',
            method: 'post',
            request: {
              schema: {
                'application/json': "${file(schemas/examples/hello.json)}"
              },
            },
          }
        }
      ]
    },
    hello2: {
      environment: {
        GEM_PATH: 'vendor/bundle/ruby/2.7.0/',
      },
      handler: 'src/lambdas/examples/hello2.handler',
      events: [
        {
          http: {
            path: '/hello2',
            method: 'post',
            request: {
              schema: {
                'application/json': "${file(schemas/examples/hello2.json)}"
              },
            },
          }
        }
      ]
    }
  }
...
```

Built locally using package.json and compiled used Babel per the contribution guide.

<!--- see how your change affects other areas of the code, etc. -->
Please let me know if you have any questions or if there is something I can improve on. Thanks!

Edit: Added more details on the current way serverless-offline is failing to invoke such handlers. Clarified that as long as the path string contains `::`, the enhancement will take effect.

## Screenshots (if appropriate):
