### PR TITLE
Never remove cached node_modules or binary modules

### DIFF
--- a/src/lambda/handler-runner/in-process-runner/InProcessRunner.js
+++ b/src/lambda/handler-runner/in-process-runner/InProcessRunner.js
@@ -50,7 +50,8 @@ const clearModule = (fP, opts) => {
             require.cache[fn].id !== '.' &&
             require.cache[fn].parent &&
             require.cache[fn].parent.id !== '.' &&
-            !require.cache[require.cache[fn].parent.id]
+            !require.cache[require.cache[fn].parent.id] &&
+            !fn.match(/node_modules/)
           ) {
             delete require.cache[fn]
             cleanup = true

--- a/src/lambda/handler-runner/in-process-runner/InProcessRunner.js
+++ b/src/lambda/handler-runner/in-process-runner/InProcessRunner.js
@@ -34,8 +34,11 @@ const clearModule = (fP, opts) => {
     const cld = require.cache[filePath].children
     delete require.cache[filePath]
     for (const c of cld) {
-      // Unload any non node_modules children
-      if (!c.filename.match(/node_modules/)) {
+      // Unload any non node_modules and non-binary children
+      if (
+        !c.filename.match(/\/node_modules\//i) &&
+        !c.filename.match(/\.node$/i)
+      ) {
         clearModule(c.id, { ...options, cleanup: false })
       }
     }
@@ -51,7 +54,8 @@ const clearModule = (fP, opts) => {
             require.cache[fn].parent &&
             require.cache[fn].parent.id !== '.' &&
             !require.cache[require.cache[fn].parent.id] &&
-            !fn.match(/node_modules/)
+            !fn.match(/\/node_modules\//i) &&
+            !fn.match(/\.node$/i)
           ) {
             delete require.cache[fn]
             cleanup = true


### PR DESCRIPTION
## Description
Adding node_modules check to orphan unloading.

## Motivation and Context
if the module in question included a binary plugin, this can cause problems when reloading. We should probably never unload a node_modules package and require the developer to restart if they update or change them. This will force any code outside of node_modules to reload which I think is acceptable, however, if the developer has their OWN binary plugin, this could still be an issue.

## How Has This Been Tested?
Included a binary module into the handler that is only used there and called the handler more than once

## Screenshots (if appropriate):
