### PR TITLE
Support request.schemas

### DIFF
--- a/src/events/http/HttpServer.js
+++ b/src/events/http/HttpServer.js
@@ -563,10 +563,10 @@ export default class HttpServer {
           ? requestTemplates[contentType]
           : ''
 
-      const schema =
-        typeof endpoint?.request?.schema !== 'undefined'
-          ? endpoint.request.schema[contentType]
-          : ''
+      const schemaConfig =
+        endpoint?.request?.schema ?? endpoint?.request?.schemas
+
+      const schema = schemaConfig?.[contentType]
 
       // https://hapijs.com/api#route-configuration doesn't seem to support selectively parsing
       // so we have to do it ourselves

--- a/tests/integration/handler/handler.js
+++ b/tests/integration/handler/handler.js
@@ -216,3 +216,10 @@ exports.TestPayloadSchemaValidation = (event, context, callback) => {
     body: stringify(event.body),
   })
 }
+
+exports.TestPayloadSchemaValidationSchemas = (event, context, callback) => {
+  callback(null, {
+    statusCode: 200,
+    body: stringify(event.body),
+  })
+}

--- a/tests/integration/handler/handlerPayload.test.js
+++ b/tests/integration/handler/handlerPayload.test.js
@@ -335,19 +335,35 @@ describe('handler payload scehma validation tests', () => {
   // cleanup
   afterAll(() => teardown())
   ;[
+    // using request.schema
     {
       description: 'test with valid payload',
       expectedBody: `{"foo":"bar"}`,
-      path: '/test-payload-schema-validator',
+      path: '/test-payload-schema-validator-schema',
       body: {
         foo: 'bar',
       },
       status: 200,
     },
-
     {
       description: 'test with invalid payload',
-      path: '/test-payload-schema-validator',
+      path: '/test-payload-schema-validator-schema',
+      body: {},
+      status: 400,
+    },
+    // using request.schemas
+    {
+      description: 'test with valid payload',
+      expectedBody: `{"foo":"bar"}`,
+      path: '/test-payload-schema-validator-schemas',
+      body: {
+        foo: 'bar',
+      },
+      status: 200,
+    },
+    {
+      description: 'test with invalid payload',
+      path: '/test-payload-schema-validator-schemas',
       body: {},
       status: 400,
     },

--- a/tests/integration/handler/serverless.yml
+++ b/tests/integration/handler/serverless.yml
@@ -167,11 +167,11 @@ functions:
     events:
       - http:
           method: post
-          path: /test-payload-schema-validator
+          path: /test-payload-schema-validator-schema
           integration: lambda
           request:
             schema:
-              application/json: 
+              application/json:
                 $schema: http://json-schema.org/draft-07/schema
                 type: object
                 required:
@@ -180,3 +180,21 @@ functions:
                   foo:
                     type: string
     handler: handler.TestPayloadSchemaValidation
+
+  TestPayloadSchemaValidationSchemas:
+    events:
+      - http:
+          method: post
+          path: /test-payload-schema-validator-schemas
+          integration: lambda
+          request:
+            schemas:
+              application/json:
+                $schema: http://json-schema.org/draft-07/schema
+                type: object
+                required:
+                  - foo
+                properties:
+                  foo:
+                    type: string
+    handler: handler.TestPayloadSchemaValidationSchemas


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Serverless now supports `request.schemas` for Request Schema Validators, which is missing from this package

[Please see serverless documentation here](https://www.serverless.com/framework/docs/providers/aws/events/apigateway/#request-schema-validators
)
## Motivation and Context
To bring `serverless-offline` inline with `serverless`
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
Unit tests
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->