### PR TITLE
fix: Child processes are cleaned up when `useChildProcesses` is used

### DIFF
--- a/src/lambda/handler-runner/child-process-runner/ChildProcessRunner.js
+++ b/src/lambda/handler-runner/child-process-runner/ChildProcessRunner.js
@@ -1,7 +1,7 @@
-import { resolve } from 'path'
+import path from 'path'
 import { node } from 'execa'
 
-const childProcessHelperPath = resolve(__dirname, 'childProcessHelper.js')
+const childProcessHelperPath = path.resolve(__dirname, 'childProcessHelper.js')
 
 export default class ChildProcessRunner {
   #env = null
@@ -36,17 +36,20 @@ export default class ChildProcessRunner {
       },
     )
 
+    const message = new Promise((resolve, reject) => {
+      childProcess.on('message', (data) => {
+        if (data.error) reject(data.error)
+        else resolve(data)
+      })
+    }).finally(() => {
+      childProcess.kill()
+    })
+
     childProcess.send({
       context,
       event,
       allowCache: this.#allowCache,
       timeout: this.#timeout,
-    })
-
-    const message = new Promise((_resolve) => {
-      childProcess.on('message', _resolve)
-      // TODO
-      // on error? on exit? ..
     })
 
     let result


### PR DESCRIPTION
## Description
When using useChildProcesses: true, child processes are killed when they finish their execution

## Motivation and Context
#1105 

## How Has This Been Tested?
In the latest version of serverless-offline, using the v12.20.1 version of node and using the task manager, I was able to verify that when the invocation of the function finishes it closes it correctly

I wanted to do unit tests for this but I really don't know what they would be like