### PR TITLE
Add validation and transformation to authorizer context return values

### DIFF
--- a/src/events/http/authValidateContext.js
+++ b/src/events/http/authValidateContext.js
@@ -1,0 +1,48 @@
+import Boom from '@hapi/boom'
+import serverlessLog from '../../serverlessLog.js'
+
+function internalServerError(message) {
+  const errorType = 'AuthorizerConfigurationException'
+
+  const error = Boom.internal()
+  error.output.payload.message = message
+  error.output.payload.error = errorType
+  error.output.headers['x-amzn-ErrorType'] = errorType
+
+  return error
+}
+
+function isValidContext(context) {
+  return Object.values(context).every(
+    (i) =>
+      typeof i === 'string' || typeof i === 'boolean' || typeof i === 'number',
+  )
+}
+
+function transform(context) {
+  Object.keys(context).forEach((i) => {
+    context[i] = context[i].toString()
+  })
+
+  return context
+}
+
+export default function authValidateContext(context, authFunName) {
+  if (typeof context !== 'object') {
+    return internalServerError('Authorizer response context must be an object')
+  }
+
+  if (!isValidContext(context)) {
+    const error =
+      'Authorizer response context values must be of type string, number, or boolean'
+
+    serverlessLog(
+      `Detected invalid value types returned in authorizer context: (λ: ${authFunName}). ${error}. ` +
+        'More info: https://docs.aws.amazon.com/apigateway/latest/developerguide/api-gateway-lambda-authorizer-output.html',
+    )
+
+    return internalServerError(error)
+  }
+
+  return transform(context)
+}

--- a/tests/integration/authorizer/authorizer.test.js
+++ b/tests/integration/authorizer/authorizer.test.js
@@ -47,6 +47,78 @@ describe('authorizer tests', () => {
       path: '/dev/user2',
       status: 200,
     },
+
+    {
+      description: 'should return acceptable context object',
+      expected: {
+        authorizer: {
+          principalId: 'user123',
+          stringKey: 'value',
+          numberKey: '1',
+          booleanKey: 'true',
+        },
+      },
+      options: {
+        headers: {
+          Authorization: 'Bearer recommendedContext',
+        },
+      },
+      path: '/dev/context',
+      status: 200,
+    },
+
+    {
+      description: 'should return stringified context objects',
+      expected: {
+        authorizer: {
+          principalId: 'user123',
+          stringKey: 'value',
+          numberKey: '1',
+          booleanKey: 'true',
+        },
+      },
+      options: {
+        headers: {
+          Authorization: 'Bearer stringifiedContext',
+        },
+      },
+      path: '/dev/context',
+      status: 200,
+    },
+
+    {
+      description:
+        'should return 500 error if context contains forbidden types (array, object)',
+      expected: {
+        statusCode: 500,
+        error: 'AuthorizerConfigurationException',
+        message:
+          'Authorizer response context values must be of type string, number, or boolean',
+      },
+      options: {
+        headers: {
+          Authorization: 'Bearer contextWithObjectKeys',
+        },
+      },
+      path: '/dev/context',
+      status: 500,
+    },
+
+    {
+      description: 'should return 500 error if context is not an object',
+      expected: {
+        statusCode: 500,
+        error: 'AuthorizerConfigurationException',
+        message: 'Authorizer response context must be an object',
+      },
+      options: {
+        headers: {
+          Authorization: 'Bearer contextNotAnObject',
+        },
+      },
+      path: '/dev/context',
+      status: 500,
+    },
   ].forEach(({ description, expected, options, path, status }) => {
     test(description, async () => {
       const url = joinUrl(TEST_BASE_URL, path)

--- a/tests/integration/authorizer/handler.js
+++ b/tests/integration/authorizer/handler.js
@@ -8,3 +8,10 @@ exports.user = async function get() {
     statusCode: 200,
   }
 }
+
+exports.context = async function get(event) {
+  return {
+    body: stringify({ authorizer: event.requestContext.authorizer }),
+    statusCode: 200,
+  }
+}

--- a/tests/integration/authorizer/serverless.yml
+++ b/tests/integration/authorizer/serverless.yml
@@ -23,9 +23,19 @@ functions:
           method: get
           path: user2
     handler: handler.user
+  context:
+    events:
+      - http:
+          authorizer: authorizerWithContext
+          method: get
+          path: context
+    handler: handler.context
 
   authorizerCallback:
     handler: authorizer.authorizerCallback
 
   authorizerAsyncFunction:
     handler: authorizer.authorizerAsyncFunction
+
+  authorizerWithContext:
+    handler: authorizer.authorizerWithContext


### PR DESCRIPTION
## Description
When successfully returning a policy from an Authorizer function, if the returned policy contains a context object containing values that are not of type `string`, `number`, or `boolean`, it will cause the endpoint to return 500, with the header: `x-amzn-ErrorType: AuthorizerConfigurationException`. In addition, `string`, `number`, and `boolean` values returned in the authorizer context are all coerced to string values when supplied to the downstream method implementation lambda.

None of this behavior is currently accounted for in the serverless-offline authorizer handling logic. This change fixes that issue, and makes serverless-offline authorizers behave near exactly like those of ApiGateway.

## Motivation and Context
This change helps prevent developers from returning invalid types of authorizer contexts that work in serverless-offline but do not work on AWS. This change also helps developers understand exactly what the `event.requestContext.authorizer` property will contain in the cloud.

fixes #826

## How Has This Been Tested?
I began by experimenting with the authorizer context response in ApiGateway with a pair of lambdas, one authorizer, and one downstream method implementation. I confirmed the string coercion behavior as described in [this](https://docs.aws.amazon.com/apigateway/latest/developerguide/api-gateway-lambda-authorizer-output.html) developer guide. I used the current authorizer integration tests as a starting point and added four context validation tests, ensuring that each type of valid and invalid context mimicked the behavior of ApiGateway authorizers as closely as possible.
