### PR TITLE
Handle multiple cookies with the same name in the same way API Gateway does.

### DIFF
--- a/src/events/http/lambda-events/LambdaProxyIntegrationEventV2.js
+++ b/src/events/http/lambda-events/LambdaProxyIntegrationEventV2.js
@@ -118,8 +118,13 @@ export default class LambdaProxyIntegrationEventV2 {
     const requestTime = formatToClfTime(received)
     const requestTimeEpoch = received
 
-    const cookies = Object.entries(this.#request.state).map(
-      ([key, value]) => `${key}=${value}`,
+    const cookies = Object.entries(this.#request.state).flatMap(
+      ([key, value]) => {
+        if (Array.isArray(value)) {
+          return value.map((v) => `${key}=${v}`)
+        }
+        return `${key}=${value}`
+      },
     )
 
     return {


### PR DESCRIPTION
## Description
This PR makes `serverless-offline`'s handling of multiple cookies with the same name reflect that of API Gateway.

The existing implementation merges cookies with the same name into a single cookie with a comma separated value, i.e. given cookies `foo=bar` & `foo=baz`, `APIGatewayProxyEventV2.cookies` resolves to `foo=bar,baz`. 

After the change, cookies with the same name are kept separate, i.e. given cookies `foo=bar` & `foo=baz`, `APIGatewayProxyEventV2.cookies` resolves to `foo=bar,foo=baz` (as API Gateway behaves). 

## Motivation and Context
The current implementation is not representative.

## How Has This Been Tested?
I would be quite happy to add automated tests but I could find no existing precedent for testing code in this class. Please feel free to suggest an automated testing strategy if you would like me to employ one.

I tested my implementation manually using the Node terminal, and tested a build of `serverless-offline` locally.
