### PR TITLE
Root certificate authority added in --httpsProtocol option.

### DIFF
--- a/src/events/http/HttpServer.js
+++ b/src/events/http/HttpServer.js
@@ -76,6 +76,7 @@ export default class HttpServer {
       serverOptions.tls = {
         cert: readFileSync(resolve(httpsProtocol, 'cert.pem'), 'ascii'),
         key: readFileSync(resolve(httpsProtocol, 'key.pem'), 'ascii'),
+        ca: readFileSync(resolve(httpsProtocol, 'chain.pem'), 'ascii'),
       }
     }
 


### PR DESCRIPTION
I was working on this and trying to run the serverless-offline on SSL. The SSL certificates were working fine but I was getting this error.

`Error: unable to verify the first certificate`

The reason was, it was not including root ca from the certificates. I have resolved the issue and created this PR.