### PR TITLE
Fixed the problem that the binary is not uploaded normally.

### DIFF
--- a/src/events/http/HttpServer.js
+++ b/src/events/http/HttpServer.js
@@ -501,8 +501,8 @@ export default class HttpServer {
       // Payload processing
       const encoding = detectEncoding(request)
 
-      request.payload = request.payload && request.payload.toString(encoding)
       request.rawPayload = request.payload
+      request.payload = request.payload && request.payload.toString(encoding)
 
       // Incomming request message
       this._printBlankLine()

--- a/src/events/http/lambda-events/LambdaProxyIntegrationEvent.js
+++ b/src/events/http/lambda-events/LambdaProxyIntegrationEvent.js
@@ -64,9 +64,10 @@ export default class LambdaProxyIntegrationEvent {
     const headers = parseHeaders(rawHeaders || []) || {}
 
     if (body) {
-      if (typeof body !== 'string') {
+      const { rawPayload } = this.#request
+      if (typeof rawPayload !== 'string') {
         // this.#request.payload is NOT the same as the rawPayload
-        body = this.#request.rawPayload
+        body = rawPayload
       }
 
       if (

--- a/src/events/http/lambda-events/LambdaProxyIntegrationEventV2.js
+++ b/src/events/http/lambda-events/LambdaProxyIntegrationEventV2.js
@@ -52,9 +52,10 @@ export default class LambdaProxyIntegrationEventV2 {
     const headers = parseHeaders(rawHeaders || []) || {}
 
     if (body) {
-      if (typeof body !== 'string') {
+      const { rawPayload } = this.#request
+      if (typeof rawPayload !== 'string') {
         // this.#request.payload is NOT the same as the rawPayload
-        body = this.#request.rawPayload
+        body = rawPayload
       }
 
       if (


### PR DESCRIPTION
## Description

An error occurred that the binary could not be passed normally.

## Motivation and Context

serverless-offline is currently unable to handle binaries normally.

1. ``rawPayload`` has the same value as ``payload`` because ``rawPayload`` has been allocated while ``payload`` has already been converted to ``.toString()``. Changed the order in which ``payload`` is converted after assigning ``rawPayload``.

2. Since the ``body`` (or ``payload``) is converted by ``.toString()``, the unconditional type is String. Changed to use ``rawPayload`` only if ``rawPayload`` is not a String.

## How Has This Been Tested?

By applying the unit test through ``npm test:unit`` and the serverless project under development, we confirmed that the binary was inserted normally.