### PR TITLE
feat: Add support for Python 3.9 runtime

### DIFF
--- a/src/config/supportedRuntimes.js
+++ b/src/config/supportedRuntimes.js
@@ -37,6 +37,7 @@ export const supportedPython = new Set([
   'python3.6',
   'python3.7',
   'python3.8',
+  'python3.9',
 ])
 
 // RUBY

--- a/src/lambda/handler-runner/HandlerRunner.js
+++ b/src/lambda/handler-runner/HandlerRunner.js
@@ -47,6 +47,11 @@ export default class HandlerRunner {
         throw new Error('Unsupported runtime')
       }
 
+      if (runtime === 'python3.9') {
+        logWarning('"python3.9" runtime is not supported with docker.')
+        throw new Error('Unsupported runtime')
+      }
+
       const dockerOptions = {
         host: this.#options.dockerHost,
         hostServicePath: this.#options.dockerHostServicePath,


### PR DESCRIPTION
## Description
Add support for Python 3.9 runtime

## Motivation and Context
Motivation was to get serverless-offline to support latest stable Python version (3.9).

Fixes issue: https://github.com/dherault/serverless-offline/issues/1266

## How Has This Been Tested?
I cloned [serverless-offline](https://github.com/dherault/serverless-offline) repo, built it, and included it in my Serverless Framework project. Before my patch, when trying to use Python 3.9 I got error:

```
offline: Warning: found unsupported runtime 'python3.9' for function 'foo'
offline: Failure: Unsupported runtime
```

After this change there was no error and everything worked as expected.
