### PR TITLE
fix: Wrap native string responses from lambda invocation endpoint

### DIFF
--- a/package.json
+++ b/package.json
@@ -148,7 +148,8 @@
     "Vasiliy Solovey (https://github.com/miltador)",
     "Dima Krutolianov (https://github.com/dimadk24)",
     "Bryan Vaz (https://github.com/bryanvaz)",
-    "Justin Ng (https://github.com/njyjn)"
+    "Justin Ng (https://github.com/njyjn)",
+    "Fernando Alvarez (https://github.com/jefer590)"
   ],
   "engines": {
     "node": ">=12.0.0"

--- a/src/lambda/__tests__/fixtures/Lambda/LambdaFunctionThatReturnsJSONObject.fixture.js
+++ b/src/lambda/__tests__/fixtures/Lambda/LambdaFunctionThatReturnsJSONObject.fixture.js
@@ -1,0 +1,35 @@
+import { resolve } from 'path'
+import LambdaFunction from '../../../LambdaFunction.js'
+
+export default class LambdaFunctionThatReturnsJSONObject {
+  options = {}
+  serverless = {
+    config: {
+      serverlessPath: '',
+      servicePath: resolve(__dirname),
+    },
+    service: {
+      provider: {
+        runtime: 'nodejs12.x',
+      },
+    },
+  }
+
+  listFunctionNames() {
+    return ['foo']
+  }
+
+  getByFunctionName(functionName) {
+    const functionDefinition = {
+      handler:
+        '../../fixtures/lambdaFunction.fixture.asyncFunctionHandlerObject',
+    }
+
+    return new LambdaFunction(
+      functionName,
+      functionDefinition,
+      this.serverless,
+      this.options,
+    )
+  }
+}

--- a/src/lambda/__tests__/fixtures/Lambda/LambdaFunctionThatReturnsNativeString.fixture.js
+++ b/src/lambda/__tests__/fixtures/Lambda/LambdaFunctionThatReturnsNativeString.fixture.js
@@ -1,0 +1,34 @@
+import { resolve } from 'path'
+import LambdaFunction from '../../../LambdaFunction.js'
+
+export default class LambdaFunctionThatReturnsNativeString {
+  options = {}
+  serverless = {
+    config: {
+      serverlessPath: '',
+      servicePath: resolve(__dirname),
+    },
+    service: {
+      provider: {
+        runtime: 'nodejs12.x',
+      },
+    },
+  }
+
+  listFunctionNames() {
+    return ['foo']
+  }
+
+  getByFunctionName(functionName) {
+    const functionDefinition = {
+      handler: '../../fixtures/lambdaFunction.fixture.asyncFunctionHandler',
+    }
+
+    return new LambdaFunction(
+      functionName,
+      functionDefinition,
+      this.serverless,
+      this.options,
+    )
+  }
+}

--- a/src/lambda/__tests__/fixtures/lambdaFunction.fixture.js
+++ b/src/lambda/__tests__/fixtures/lambdaFunction.fixture.js
@@ -48,6 +48,12 @@ exports.asyncFunctionHandler = async function asyncFunctionHandler() {
   return 'foo'
 }
 
+exports.asyncFunctionHandlerObject = async function asyncFunctionHandler() {
+  return {
+    foo: 'bar',
+  }
+}
+
 // we deliberately test the case where a 'callback' is defined
 // in the handler, but a promise is being returned to protect from a
 // potential naive implementation, e.g.

--- a/src/lambda/__tests__/routes/invocations/InvocationsController.test.js
+++ b/src/lambda/__tests__/routes/invocations/InvocationsController.test.js
@@ -1,0 +1,43 @@
+import InvocationsController from '../../../routes/invocations/InvocationsController.js'
+import LambdaFunctionThatReturnsJSONObject from '../../fixtures/Lambda/LambdaFunctionThatReturnsJSONObject.fixture.js'
+import LambdaFunctionThatReturnsNativeString from '../../fixtures/Lambda/LambdaFunctionThatReturnsNativeString.fixture.js'
+
+jest.mock('../../../../serverlessLog')
+
+describe('InvocationController', () => {
+  const functionName = 'foo'
+
+  describe('when event type is "RequestResponse"', () => {
+    const eventType = 'RequestResponse'
+
+    test('should return json object if lambda response is json', async () => {
+      const expected = {
+        Payload: {
+          foo: 'bar',
+        },
+        StatusCode: 200,
+      }
+
+      const invocationController = new InvocationsController(
+        new LambdaFunctionThatReturnsJSONObject(),
+      )
+      const result = await invocationController.invoke(functionName, eventType)
+
+      expect(result).toStrictEqual(expected)
+    })
+
+    test('should wrap native string responses with ""', async () => {
+      const expected = {
+        Payload: '"foo"',
+        StatusCode: 200,
+      }
+
+      const invocationController = new InvocationsController(
+        new LambdaFunctionThatReturnsNativeString(),
+      )
+      const result = await invocationController.invoke(functionName, eventType)
+
+      expect(result).toStrictEqual(expected)
+    })
+  })
+})

--- a/src/lambda/routes/invocations/InvocationsController.js
+++ b/src/lambda/routes/invocations/InvocationsController.js
@@ -74,6 +74,14 @@ export default class InvocationsController {
         // RequestTooLargeException, InvalidParameterValueException,
         // and whatever response is thrown when the response is too large.
       }
+
+      // Checking if the result of the Lambda Invoke is a primitive string to wrap it. this is for future post-processing such as Step Functions Tasks
+      if (result) {
+        if (typeof result === 'string') {
+          result = `"${result}"`
+        }
+      }
+
       // result is actually the Payload.
       // So return in a standard structure so Hapi can
       // respond with the correct status codes


### PR DESCRIPTION
## Description
Wrap Lambda Invocation Responses that are native strings with `""`

## Motivation and Context
Using this library with [`serverless-step-functions`](https://github.com/serverless-operations/serverless-step-functions) and [AWS step functions local](https://docs.aws.amazon.com/step-functions/latest/dg/sfn-local-docker.html) we noticed that Lambda Invocations that returns a single native string threw an error on JSON parsing from the Step Functions Local App. After some investigation and feedback with the AWS support team, we noticed that AWS SAM and Serverless Offline responses for Lambda Invocations when returning a single string is a bit different 

Serverless Offline Lambda Endpoint

```js
=== { StatusCode: 200, Payload: '46585b35-b4fa-4db8-968d-5deef4ba2858' }
```

SAM CLI Lambda Endpoint:

```js
=== { StatusCode: 200, Payload: '"jhjdfhdf-djkfdjfhd-dfjdhfjdhfsdkjfh"' }
```

This PR fixes this behaviour to match was is expected for a native string

## How Has This Been Tested?
I created a SLS Project that included "fixed" version of SLS offline and just added a single lambda to invoke.

```js
const uuid = require('uuid');

export const handler = async (payload) => {
  return uuid.v4();
}
```

Using a JS script, I invoked the Lambda and compared the result from the console

```js
const AWS = require('aws-sdk');

(async function () {
    const lambdaClient = new AWS.Lambda({
        region: 'us-east-1',
        endpoint: new AWS.Endpoint('http://localhost:3002')
    })

    const response = await lambdaClient.invoke({
        InvocationType: 'RequestResponse',
        FunctionName: 'invoketest-dev-first'
    }).promise();

    console.debug("===", response)
})()
```

The response was:
```
{ StatusCode: 200, Payload: '"363a9330-548d-4823-9e3c-9e02d08593cf"' }
```


## Screenshots (if appropriate):
