### PR TITLE
Don't crash serverless process on error in async invocations

### DIFF
--- a/src/lambda/routes/invocations/InvocationsController.js
+++ b/src/lambda/routes/invocations/InvocationsController.js
@@ -36,7 +36,6 @@ export default class InvocationsController {
       lambdaFunction.runHandler().catch((err) => {
         // TODO handle error
         console.log(err)
-        throw err
       })
 
       return {

--- a/src/lambda/routes/invoke-async/InvokeAsyncController.js
+++ b/src/lambda/routes/invoke-async/InvokeAsyncController.js
@@ -14,7 +14,6 @@ export default class InvokeAsyncController {
     lambdaFunction.runHandler().catch((err) => {
       // TODO handle error
       console.log(err)
-      throw err
     })
 
     return {


### PR DESCRIPTION
## Description

Currently when invoking a function asynchronously and throwing an error to report failure it causes the whole serverless offline server to crash.

## Motivation and Context

I think it makes more sense to just log the error in this case and keep the server running.

## How Has This Been Tested?
Tested locally that throwing an error in a function invoked asynchronously no longer causes the sls offline process to crash.

## Screenshots (if appropriate):
N/A