### PR TITLE
feat: add SELinux z volume option

### DIFF
--- a/src/lambda/handler-runner/docker-runner/DockerContainer.js
+++ b/src/lambda/handler-runner/docker-runner/DockerContainer.js
@@ -67,10 +67,13 @@ export default class DockerContainer {
     if (!this.#dockerOptions.readOnly) {
       permissions = 'rw'
     }
+
+    const selinux = ',z'
+
     // https://github.com/serverless/serverless/blob/v1.57.0/lib/plugins/aws/invokeLocal/index.js#L291-L293
     const dockerArgs = [
       '-v',
-      `${codeDir}:/var/task:${permissions},delegated`,
+      `${codeDir}:/var/task:${permissions},delegated${selinux}`,
       '-p',
       9001,
       '-e',


### PR DESCRIPTION
SELinux requires adding the z or Z option so Docker can label the volume
correctly when mounting. This fixes:
```
open /var/task: permission denied
```

## Description
Add the z flag to the volume bind option so Docker knows to apply SELinux context.

## Motivation and Context
On systems with SELinux enabled, you get the error:
```
2021/10/17 15:22:56 open /var/task: permission denied
```
as SELinux denies the write.

## How Has This Been Tested?
This was tested on Fedora 34 using moby-engine 20.10.8 (Fedora respin of Docker CE 20.10). I believe additional testing is required on Docker for Windows and non SELinux systems, like Ubuntu.

Additional info from `docker version`:
```
Client:
 Version:           20.10.8
 API version:       1.41
 Go version:        go1.16.6
 Git commit:        3967b7d
 Built:             Sun Aug 15 22:43:35 2021
 OS/Arch:           linux/amd64
 Context:           default
 Experimental:      true

Server:
 Engine:
  Version:          20.10.8
  API version:      1.41 (minimum version 1.12)
  Go version:       go1.16.6
  Git commit:       75249d8
  Built:            Sun Aug 15 00:00:00 2021
  OS/Arch:          linux/amd64
  Experimental:     true
 containerd:
  Version:          1.4.6
  GitCommit:        d71fcd7d8303cbf684402823e425e9dd2e99285d
 runc:
  Version:          1.0.0-rc95
  GitCommit:        b9ee9c6314599f1b4a7f497e1f1f856fe433d3b7
 docker-init:
  Version:          0.19.0
  GitCommit:
```