### PR TITLE
Do not validate compatibility against serverless pre-releases

### DIFF
--- a/src/ServerlessOffline.js
+++ b/src/ServerlessOffline.js
@@ -1,4 +1,5 @@
 import updateNotifier from 'update-notifier'
+import { parse as semverParse } from 'semver'
 import debugLog from './debugLog.js'
 import serverlessLog, { logWarning, setLog } from './serverlessLog.js'
 import { satisfiesVersionRange } from './utils/index.js'
@@ -377,6 +378,11 @@ export default class ServerlessOffline {
   _verifyServerlessVersionCompatibility() {
     const currentVersion = this.#serverless.version
     const requiredVersionRange = pkg.peerDependencies.serverless
+
+    if (semverParse(currentVersion).prerelease.length) {
+      // Do not validate, if run against serverless pre-release
+      return
+    }
 
     const versionIsSatisfied = satisfiesVersionRange(
       currentVersion,


### PR DESCRIPTION
Currently if the plugin would be run with Framework v3 pre-release, a warning will be shown about incompatibility.

As pre-releases cannot be targetted with elastic semver ranges, ideally they should not be validated in any case
