### PR TITLE
Improve tests handling

### DIFF
--- a/tests/integration/_testHelpers/setupTeardown.js
+++ b/tests/integration/_testHelpers/setupTeardown.js
@@ -19,8 +19,21 @@ export async function setup(options) {
     cwd: servicePath,
   })
 
-  await new Promise((res) => {
+  await new Promise((res, reject) => {
+    let stdData = ''
+    serverlessProcess.on('close', (code) => {
+      if (code) {
+        console.error(`Output: ${stdData}`)
+        reject(new Error('serverless offline crashed'))
+      } else {
+        reject(new Error('serverless offline ended prematurely'))
+      }
+    })
+    serverlessProcess.stderr.on('data', (data) => {
+      stdData += data
+    })
     serverlessProcess.stdout.on('data', (data) => {
+      stdData += data
       if (String(data).includes('[HTTP] server ready')) {
         res()
       }

--- a/tests/integration/_testHelpers/setupTeardown.js
+++ b/tests/integration/_testHelpers/setupTeardown.js
@@ -8,6 +8,8 @@ const serverlessPath = resolve(
   '../../../node_modules/serverless/bin/serverless',
 )
 
+const shouldPrintOfflineOutput = process.env.PRINT_OFFLINE_OUTPUT
+
 export async function setup(options) {
   const { args = [], servicePath } = options
 
@@ -30,9 +32,11 @@ export async function setup(options) {
       }
     })
     serverlessProcess.stderr.on('data', (data) => {
+      if (shouldPrintOfflineOutput) process._rawDebug(String(data))
       stdData += data
     })
     serverlessProcess.stdout.on('data', (data) => {
+      if (shouldPrintOfflineOutput) process._rawDebug(String(data))
       stdData += data
       if (String(data).includes('[HTTP] server ready')) {
         res()


### PR DESCRIPTION
When underlying `sls offline` command fails, so far tests did nothing just waited for timeout. This patch ensures we crash and print output of failed command

Additionally added option to unconditionally print output of underlying `sls offline` command. It helps diagnosing the issues
