### PR TITLE
feat: websocket parity with api gateway

### DIFF
--- a/src/events/websocket/WebSocketServer.js
+++ b/src/events/websocket/WebSocketServer.js
@@ -6,6 +6,7 @@ import { createUniqueId } from '../../utils/index.js'
 export default class WebSocketServer {
   #options = null
   #webSocketClients = null
+  #connectionIds = new Map()
 
   constructor(options, webSocketClients, sharedServer, v3Utils) {
     this.#options = options
@@ -20,6 +21,35 @@ export default class WebSocketServer {
 
     const server = new Server({
       server: sharedServer,
+      verifyClient: ({ req }, cb) => {
+        const connectionId = createUniqueId()
+        const { headers } = req
+        const key = headers['sec-websocket-key']
+
+        if (this.log) {
+          this.log.debug(`verifyClient:${key} ${connectionId}`)
+        } else {
+          debugLog(`verifyClient:${key} ${connectionId}`)
+        }
+
+        // Use the websocket key to coorelate connection IDs
+        this.#connectionIds[key] = connectionId
+
+        this.#webSocketClients
+          .verifyClient(connectionId, req)
+          .then(({ verified, statusCode }) => {
+            try {
+              if (!verified) {
+                cb(false, statusCode)
+                return
+              }
+              cb(true)
+            } catch (e) {
+              debugLog(`Error verifying`, e)
+              cb(false)
+            }
+          })
+      },
     })
 
     server.on('connection', (webSocketClient, request) => {
@@ -29,7 +59,10 @@ export default class WebSocketServer {
         console.log('received connection')
       }
 
-      const connectionId = createUniqueId()
+      const { headers } = request
+      const key = headers['sec-websocket-key']
+
+      const connectionId = this.#connectionIds[key]
 
       if (this.log) {
         this.log.debug(`connect:${connectionId}`)
@@ -63,6 +96,13 @@ export default class WebSocketServer {
   stop() {}
 
   addRoute(functionKey, webSocketEvent) {
+    if (
+      webSocketEvent.route === '$connect' &&
+      webSocketEvent.routeResponseSelectionExpression
+    ) {
+      this.#webSocketClients.routeResponseSelectionExpression =
+        webSocketEvent.routeResponseSelectionExpression
+    }
     this.#webSocketClients.addRoute(functionKey, webSocketEvent.route)
     // serverlessLog(`route '${route}'`)
   }


### PR DESCRIPTION
## Description

This PR gives `serverless-offline` handling of Web Sockets parity with how AWS API Gateway V2 handles Web Sockets

### Discrepancies

#### Status Code Handling

When a client connects, the Lambda Handler (or Authorizer) can set a `statusCode` to control whether the connection is allowed or not.

*AWS API Gateway*: 
 - If a non-2xx Status Code is returned, the handshake is rejected
 - A `wscat` command produces the following error: `error: Unexpected server response: {statusCode}`

*Serverless Offline*:
 - Websocket is connected, `statusCode` is ignored

#### `routeResponseSelectionExpression`

From the AWS Docs, a `routeResponseSelectionExpression` (of value `$default`) can be placed on the `$connect` handler to enable 2-way communication for websockets.

*AWS API Gateway*: 
 - After enabling a route response, API Gateway will return whatever is in `body` to the client.  
 - If disabled, no response is propagated back the the client

*Serverless Offline*:
 - Does no such handling, no checking of the `routeResponseSelectionExpression` option in `serverless.yml`

## Motivation and Context

Most notably, the current implementation of Web Socket handling is a `TODO`, and this should remedy the `TODO` to make behavior similar to AWS.

https://github.com/dherault/serverless-offline/blob/2ac804b81d2e155b6dd8453291c67437ae66357e/src/events/websocket/WebSocketClients.js#L147

This issue has been raised before in two PRs, and this PR likely supersedes them:
 - #1188 from @VenomAV
 - #1064 from @kevbot-git

### Fixing connections

Using `WebSocketServer.verifyClient`, initial connections now invoke the lambda `$connect` handler, and if the status code is non-2xx, it will properly abort the handshake with the `statusCode` from the lambda response.

This results in the same abort handling as AWS API Gateway, when running offline:

Local:

```
$ wscat -c "ws://localhost:3001/cool?statusCode=200"
Connected (press CTRL+C to quit)
$ wscat -c "ws://localhost:3001/cool?statusCode=301"
error: Unexpected server response: 301
```

Remote:
```
wscat -c "wss://ws-sly.scaffoldly-demo.scaffoldly.dev/cool?statusCode=200"
Connected (press CTRL+C to quit)
$ wscat -c "wss://ws-sly.scaffoldly-demo.scaffoldly.dev/cool?statusCode=301"
error: Unexpected server response: 301
```

### Two-way responses

If the optional `routeResponseSelectionExpression` has been specified the content of `body` will be sent back to the websocket.

## How Has This Been Tested?

I have the following service running in Lambda:
https://github.com/scaffoldly-demo/cool-sls-rest-api

The `$connect` handler takes the `statusCode` query parameter and returns it as a number to simulate response code handling. 2xx's allow the connection to go through.

`serverless.yml` has also been outfitted with `routeResponseSelectionExpression` and responses are returned when the setting is enabled
