### PR TITLE
Add support for the AUTHORIZER env variable for LambdaIntegration

### DIFF
--- a/src/events/http/lambda-events/LambdaIntegrationEvent.js
+++ b/src/events/http/lambda-events/LambdaIntegrationEvent.js
@@ -1,6 +1,8 @@
 import renderVelocityTemplateObject from './renderVelocityTemplateObject.js'
 import VelocityContext from './VelocityContext.js'
 
+const { parse } = JSON
+
 export default class LambdaIntegrationEvent {
   #path = null
   #request = null
@@ -16,6 +18,28 @@ export default class LambdaIntegrationEvent {
   }
 
   create() {
+    if (process.env.AUTHORIZER) {
+      try {
+        const authorizerContext = parse(process.env.AUTHORIZER)
+        if (authorizerContext) {
+          this.#request.auth = {
+            ...this.#request.auth,
+            authorizer: authorizerContext,
+          }
+        }
+      } catch (error) {
+        if (this.log) {
+          this.log.error(
+            'Could not parse process.env.AUTHORIZER, make sure it is correct JSON',
+          )
+        } else {
+          console.error(
+            'Serverless-offline: Could not parse process.env.AUTHORIZER, make sure it is correct JSON.',
+          )
+        }
+      }
+    }
+
     const velocityContext = new VelocityContext(
       this.#request,
       this.#stage,

--- a/src/events/http/lambda-events/LambdaIntegrationEvent.js
+++ b/src/events/http/lambda-events/LambdaIntegrationEvent.js
@@ -24,7 +24,9 @@ export default class LambdaIntegrationEvent {
         if (authorizerContext) {
           this.#request.auth = {
             ...this.#request.auth,
-            authorizer: authorizerContext,
+            credentials: {
+              authorizer: authorizerContext,
+            },
           }
         }
       } catch (error) {


### PR DESCRIPTION
## Description

Added support for the AUTHORIZER env variable for LambdaIntegration (non-proxy) http requests 

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The `AUTHORIZER` env variable was not working for LambdaIntegration http requests. I just added support for it.

This resolves #816 

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I've run the unit tests. Full test run fails even on `master` in my computer.

## Screenshots (if appropriate):
