### PR TITLE
Support httpApi payload override on handler

### DIFF
--- a/src/ServerlessOffline.js
+++ b/src/ServerlessOffline.js
@@ -369,10 +369,14 @@ export default class ServerlessOffline {
             }
 
             httpEvent.http.isHttpApi = true
-            httpEvent.http.payload =
-              service.provider.httpApi && service.provider.httpApi.payload
-                ? service.provider.httpApi.payload
-                : '2.0'
+            if (functionDefinition.httpApi && functionDefinition.httpApi.payload) {
+              httpEvent.http.payload = functionDefinition.httpApi.payload;
+            } else {
+              httpEvent.http.payload =
+                service.provider.httpApi && service.provider.httpApi.payload
+                  ? service.provider.httpApi.payload
+                  : '2.0'
+            }
           }
 
           if (http && http.private) {

--- a/src/ServerlessOffline.js
+++ b/src/ServerlessOffline.js
@@ -369,8 +369,11 @@ export default class ServerlessOffline {
             }
 
             httpEvent.http.isHttpApi = true
-            if (functionDefinition.httpApi && functionDefinition.httpApi.payload) {
-              httpEvent.http.payload = functionDefinition.httpApi.payload;
+            if (
+              functionDefinition.httpApi &&
+              functionDefinition.httpApi.payload
+            ) {
+              httpEvent.http.payload = functionDefinition.httpApi.payload
             } else {
               httpEvent.http.payload =
                 service.provider.httpApi && service.provider.httpApi.payload


### PR DESCRIPTION
## Description

This PR adds support for getting the payload version for `httpApi` functions from the function definition (ie overriding the `provider` level).

## Motivation and Context

According to the [serverless docs](https://www.serverless.com/framework/docs/providers/aws/events/http-api#event--payload-format), you can specify `httpApi.payload` at either the service or function level. However, serverless-offline was ignoring the value set at the function level. This PR fixes that.

## How Has This Been Tested?

I've tested this in my current project.
