### PR TITLE
feat: Add `httpEvent.operationId` to the request context

### DIFF
--- a/src/events/http/HttpServer.js
+++ b/src/events/http/HttpServer.js
@@ -544,6 +544,11 @@ export default class HttpServer {
       }
     }
 
+    const additionalRequestContext = {}
+    if (httpEvent.operationId) {
+      additionalRequestContext.operationName = httpEvent.operationId
+    }
+
     hapiOptions.tags = ['api']
 
     const hapiHandler = async (request, h) => {
@@ -740,6 +745,7 @@ export default class HttpServer {
                 stage,
                 endpoint.routeKey,
                 stageVariables,
+                additionalRequestContext,
                 this.v3Utils,
               )
             : new LambdaProxyIntegrationEvent(
@@ -748,6 +754,7 @@ export default class HttpServer {
                 requestPath,
                 stageVariables,
                 endpoint.isHttpApi ? endpoint.routeKey : null,
+                additionalRequestContext,
                 this.v3Utils,
               )
 

--- a/src/events/http/lambda-events/LambdaProxyIntegrationEvent.js
+++ b/src/events/http/lambda-events/LambdaProxyIntegrationEvent.js
@@ -23,13 +23,23 @@ export default class LambdaProxyIntegrationEvent {
   #request = null
   #stage = null
   #stageVariables = null
+  #additionalRequestContext = null
 
-  constructor(request, stage, path, stageVariables, routeKey = null, v3Utils) {
+  constructor(
+    request,
+    stage,
+    path,
+    stageVariables,
+    routeKey = null,
+    additionalRequestContext = null,
+    v3Utils,
+  ) {
     this.#path = path
     this.#routeKey = routeKey
     this.#request = request
     this.#stage = stage
     this.#stageVariables = stageVariables
+    this.#additionalRequestContext = additionalRequestContext || {}
     if (v3Utils) {
       this.log = v3Utils.log
       this.progress = v3Utils.progress
@@ -202,6 +212,7 @@ export default class LambdaProxyIntegrationEvent {
           userAgent: _headers['user-agent'] || '',
           userArn: 'offlineContext_userArn',
         },
+        operationName: this.#additionalRequestContext.operationName,
         path: this.#path,
         protocol: 'HTTP/1.1',
         requestId: createUniqueId(),

--- a/src/events/http/lambda-events/LambdaProxyIntegrationEventV2.js
+++ b/src/events/http/lambda-events/LambdaProxyIntegrationEventV2.js
@@ -17,12 +17,21 @@ export default class LambdaProxyIntegrationEventV2 {
   #request = null
   #stage = null
   #stageVariables = null
+  #additionalRequestContext = null
 
-  constructor(request, stage, routeKey, stageVariables, v3Utils) {
+  constructor(
+    request,
+    stage,
+    routeKey,
+    stageVariables,
+    additionalRequestContext,
+    v3Utils,
+  ) {
     this.#routeKey = routeKey
     this.#request = request
     this.#stage = stage
     this.#stageVariables = stageVariables
+    this.#additionalRequestContext = additionalRequestContext || {}
     if (v3Utils) {
       this.log = v3Utils.log
       this.progress = v3Utils.progress
@@ -164,6 +173,7 @@ export default class LambdaProxyIntegrationEventV2 {
           sourceIp: remoteAddress,
           userAgent: _headers['user-agent'] || '',
         },
+        operationName: this.#additionalRequestContext.operationName,
         requestId: 'offlineContext_resourceId',
         routeKey: this.#routeKey,
         stage: this.#stage,

--- a/tests/integration/lambda-integration/handler.js
+++ b/tests/integration/lambda-integration/handler.js
@@ -14,3 +14,13 @@ exports.lambdaIntegrationStringified =
       foo: 'bar',
     })
   }
+
+exports.lambdaIntegrationWithOperationName =
+  async function lambdaIntegrationWithOperationName(event) {
+    return {
+      body: stringify({
+        operationName: event.requestContext.operationName,
+      }),
+      statusCode: 200,
+    }
+  }

--- a/tests/integration/lambda-integration/lambdaIntegration.test.js
+++ b/tests/integration/lambda-integration/lambdaIntegration.test.js
@@ -36,6 +36,14 @@ describe('lambda integration tests', () => {
       path: '/dev/lambda-integration-stringified',
       status: 200,
     },
+    {
+      description: 'should return operation name from request context',
+      expected: {
+        operationName: 'getIntegrationWithOperationName',
+      },
+      path: '/dev/lambda-integration-with-operation-name',
+      status: 200,
+    },
   ].forEach(({ description, expected, path, status }) => {
     test(description, async () => {
       const url = joinUrl(TEST_BASE_URL, path)

--- a/tests/integration/lambda-integration/serverless.yml
+++ b/tests/integration/lambda-integration/serverless.yml
@@ -31,3 +31,11 @@ functions:
           method: get
           path: '/lambda-integration-stringified'
     handler: handler.lambdaIntegrationStringified
+
+  integrationWithOperationName:
+    events:
+      - http:
+          method: get
+          operationId: getIntegrationWithOperationName
+          path: '/lambda-integration-with-operation-name'
+    handler: handler.lambdaIntegrationWithOperationName

--- a/tests/old-unit/LambdaProxyIntegrationEvent.test.js
+++ b/tests/old-unit/LambdaProxyIntegrationEvent.test.js
@@ -75,6 +75,12 @@ describe('LambdaProxyIntegrationEvent', () => {
     test('should match fixed attributes', () => {
       expectFixedAttributes(lambdaProxyIntegrationEvent)
     })
+
+    test('should not have operation name', () => {
+      expect(lambdaProxyIntegrationEvent.requestContext.operationName).toEqual(
+        undefined,
+      )
+    })
   })
 
   describe('with a GET /fn1 request with headers', () => {
@@ -695,6 +701,30 @@ describe('LambdaProxyIntegrationEvent', () => {
 
       expect(lambdaProxyIntegrationEvent.stageVariables).toEqual(
         'stageVariables',
+      )
+    })
+  })
+
+  describe('with operation name', () => {
+    const requestBuilder = new RequestBuilder('GET', '/fn1')
+    const request = requestBuilder.toObject()
+
+    let lambdaProxyIntegrationEvent
+
+    beforeEach(() => {
+      lambdaProxyIntegrationEvent = new LambdaProxyIntegrationEvent(
+        request,
+        stage,
+        null,
+        null,
+        null,
+        { operationName: 'getFunctionOne' },
+      ).create()
+    })
+
+    test('should have operation name', () => {
+      expect(lambdaProxyIntegrationEvent.requestContext.operationName).toEqual(
+        'getFunctionOne',
       )
     })
   })


### PR DESCRIPTION
## Description

AWS ApiGateway defines a `operationId` value for each http event. This value is available in the running Lambda in the `event.requestContext.operationName` property. This property value is very helpful if validating requests against an OpenApi spec.

This PR takes the `operationId` value and makes it available in the `event` model for both `LambdaProxyIntegrationEvent` and `LambdaProxyIntegrationEventV2`

## Motivation and Context

This supplies a value that is available when running the Serverless deployment in the AWS environment, but until now, not available in the offline environment.

## How Has This Been Tested?

I have added unit and integration tests. We have also been using this code internally for the past year.

## Screenshots (if appropriate):
