### PR TITLE
[Bug] Fix issue with incorrect 0 -> '' conversion in HTTP responses

### DIFF
--- a/src/lambda/routes/invocations/invocationsRoute.js
+++ b/src/lambda/routes/invocations/invocationsRoute.js
@@ -45,7 +45,7 @@ export default function invocationsRoute(lambda, options, v3Utils) {
       let statusCode = 200
       let functionError = null
       if (invokeResults) {
-        let isPayloadDefined = typeof invokeResults.Payload !== 'undefined'
+        const isPayloadDefined = typeof invokeResults.Payload !== 'undefined'
         resultPayload = isPayloadDefined ? invokeResults.Payload : ''
         statusCode = invokeResults.StatusCode || 200
         functionError = invokeResults.FunctionError || null

--- a/src/lambda/routes/invocations/invocationsRoute.js
+++ b/src/lambda/routes/invocations/invocationsRoute.js
@@ -45,9 +45,10 @@ export default function invocationsRoute(lambda, options, v3Utils) {
       let statusCode = 200
       let functionError = null
       if (invokeResults) {
-        resultPayload = invokeResults.Payload || ''
-        statusCode = invokeResults.StatusCode || 200
-        functionError = invokeResults.FunctionError || null
+        let isPayloadDefined = typeof invokeResults.Payload !== 'undefined';
+        resultPayload = isPayloadDefined ? invokeResults.Payload : '';
+        statusCode = invokeResults.StatusCode || 200;
+        functionError = invokeResults.FunctionError || null;
       }
       const response = h.response(resultPayload).code(statusCode)
       if (functionError) {

--- a/src/lambda/routes/invocations/invocationsRoute.js
+++ b/src/lambda/routes/invocations/invocationsRoute.js
@@ -45,10 +45,10 @@ export default function invocationsRoute(lambda, options, v3Utils) {
       let statusCode = 200
       let functionError = null
       if (invokeResults) {
-        let isPayloadDefined = typeof invokeResults.Payload !== 'undefined';
-        resultPayload = isPayloadDefined ? invokeResults.Payload : '';
-        statusCode = invokeResults.StatusCode || 200;
-        functionError = invokeResults.FunctionError || null;
+        let isPayloadDefined = typeof invokeResults.Payload !== 'undefined'
+        resultPayload = isPayloadDefined ? invokeResults.Payload : ''
+        statusCode = invokeResults.StatusCode || 200
+        functionError = invokeResults.FunctionError || null
       }
       const response = h.response(resultPayload).code(statusCode)
       if (functionError) {


### PR DESCRIPTION
## Description

If ```invokeResults.Payload === 0```, then it gets replaced by empty string ```''```, which causes buggy behavior in many cases.

## Motivation and Context

> Example case: 
> We have a lambda that returns a number of upvotes for a post. 
> So, when it returns ```0```, then HTTP response contains ```''``` (empty string) instead.

## How Has This Been Tested?

Manual testing (nothing should be broken).

## Screenshots (if appropriate):

[Screenshot](https://take.ms/4CLW5)
