### PR TITLE
fix: Don't override Ruby `stdout` with `stderr`

### DIFF
--- a/src/lambda/handler-runner/ruby-runner/RubyRunner.js
+++ b/src/lambda/handler-runner/ruby-runner/RubyRunner.js
@@ -110,8 +110,6 @@ export default class RubyRunner {
       } else {
         console.log(stderr)
       }
-
-      return stderr
     }
 
     return this._parsePayload(stdout)


### PR DESCRIPTION
## Description

This PR prevents from `stdout` from being replaced with `stderr` in responses from Ruby handlers.

## Motivation and Context

When I run my Ruby handler (which uses [serverless-rack](https://github.com/logandk/serverless-rack) to run a Sinatra application, I noticed that whenever I add a logging statement (such as `puts` or `logger.info`), the response from my handler no longer shows in my browser. Instead, I get the logs in my browser (in addition to the console).

Same thing happens when there's an uncaught error. My app's error page is bypassed, and instead my error logs are printed to the browser.

I found out that this is because Rack's error stream is stderr (as it should be), and these lines in this project:

https://github.com/dherault/serverless-offline/blob/febfe77d470b2e5e4fbfe5243b265d6a27fb84f3/src/lambda/handler-runner/ruby-runner/RubyRunner.js#L105-L115

return stderr as the response when it is non-empty. But there is no good reason for this. The framework's [own guide](https://www.serverless.com/framework/docs/guides/plugins/cli-output) says plugins should write logs (not just errors) to stderr and output to stdout, so it makes no sense to sometimes return the logs instead of the output. Also, the other runners don't do this.

## How Has This Been Tested?

I pointed my local app to this change, and it worked as expected. My response is always returned, and logs remain on the console only.
