### PR TITLE
Fix: Skip clearing undefined modules in InProcessRunner

### DIFF
--- a/src/lambda/handler-runner/in-process-runner/InProcessRunner.js
+++ b/src/lambda/handler-runner/in-process-runner/InProcessRunner.js
@@ -46,6 +46,7 @@ const clearModule = (fP, opts) => {
         cleanup = false
         for (const fn of Object.keys(require.cache)) {
           if (
+            require.cache[fn] &&
             require.cache[fn].id !== '.' &&
             require.cache[fn].parent &&
             require.cache[fn].parent.id !== '.' &&


### PR DESCRIPTION
## Description

This PR fixes a bug where the `id` property of an undefined module from the cache is accessed before deleting the module from the cache.

## Motivation and Context

This problem came up while using `serverless-offline` in combination with `serverless-plugin-offline-dynamodb-stream`.
First i sent a request to a `join` endpoint of my API. This worked. Afterwards i sent a request to the `leave` endpoint of my API and the bug in the screenshot appeared.

To get rid of this bug, i added an existence check before accessing the `id` property of the record value in the cache object.

## How Has This Been Tested?

This has been tested with and without the fix on different HTTP API routes. Without the fix, the bug in the screenshot appeared at the second call on a different route as the first call. With the fix, everything worked as expected.

## Screenshots (if appropriate):

<img width="763" alt="image" src="https://user-images.githubusercontent.com/16644743/154669698-19fef2e1-c92c-4983-a73c-8e4613a971f6.png">
