### PR TITLE
Fix: Adding maxbytes to payload as limits aws lambda

### DIFF
--- a/src/lambda/routes/invocations/invocationsRoute.js
+++ b/src/lambda/routes/invocations/invocationsRoute.js
@@ -68,6 +68,7 @@ export default function invocationsRoute(lambda, options, v3Utils) {
         defaultContentType: 'binary/octet-stream',
         // request.payload will be a raw buffer
         parse: false,
+        maxBytes: 1024 * 1024 * 6
       },
       cors: options.corsConfig,
       tags: ['api'],


### PR DESCRIPTION
## Description

Added maxbytes into payload options as limits aws quotas (6mb)

## Motivation and Context

AWS allows limits to payload with  6MB, but the serverless-offline is limited to 1MB

## Screenshots (if appropriate):

![quotas](https://user-images.githubusercontent.com/28955419/156419843-1272ab8a-e8a4-4abb-932a-6b74a6151c11.png)

