### PR TITLE
Concat stderr and stdout before parsing incoming events, including la…

### DIFF
--- a/src/lambda/handler-runner/go-runner/GoRunner.js
+++ b/src/lambda/handler-runner/go-runner/GoRunner.js
@@ -30,7 +30,7 @@ export default class GoRunner {
     }
 
     // Make sure we have the mock-lambda runner
-    sync('go', ['get', 'github.com/icarus-sullivan/mock-lambda@e065469'])
+    sync('go', ['get', 'github.com/icarus-sullivan/mock-lambda@b33d704'])
   }
 
   async cleanup() {
@@ -130,24 +130,17 @@ export default class GoRunner {
         AWS_LAMBDA_FUNCTION_MEMORY_SIZE: context.memoryLimitInMB,
         AWS_LAMBDA_FUNCTION_VERSION: context.functionVersion,
         LAMBDA_EVENT: stringify(event),
-        LAMBDA_TEST_EVENT: `${event}`,
         LAMBDA_CONTEXT: stringify(context),
-        IS_LAMBDA_AUTHORIZER:
-          event.type === 'REQUEST' || event.type === 'TOKEN',
-        IS_LAMBDA_REQUEST_AUTHORIZER: event.type === 'REQUEST',
-        IS_LAMBDA_TOKEN_AUTHORIZER: event.type === 'TOKEN',
         PATH: process.env.PATH,
       },
       encoding: 'utf-8',
     })
 
+    const output = [stderr, stdout].join('\n')
+
     // Clean up after we created the temporary file
     await this.cleanup()
 
-    if (stderr) {
-      return stderr
-    }
-
-    return this._parsePayload(stdout)
+    return this._parsePayload(output)
   }
 }

--- a/tests/integration/go/go1.x/go.mod
+++ b/tests/integration/go/go1.x/go.mod
@@ -4,6 +4,6 @@ go 1.13
 
 require (
 	github.com/aws/aws-lambda-go v1.28.0
-	github.com/icarus-sullivan/mock-lambda v0.0.0-20220115083805-e065469e964a // indirect
+	github.com/icarus-sullivan/mock-lambda v0.0.0-20220217054640-b33d704534c9 // indirect
 	github.com/urfave/cli v1.22.1 // indirect
 )

--- a/tests/integration/go/go1.x/go.sum
+++ b/tests/integration/go/go1.x/go.sum
@@ -12,6 +12,8 @@ github.com/icarus-sullivan/mock-lambda v0.0.0-20220114085425-44091545252e h1:cPv
 github.com/icarus-sullivan/mock-lambda v0.0.0-20220114085425-44091545252e/go.mod h1:2iuLAENWZqxe/B6XUDWw/3ioQ9d1fwhgFTlwVeIBpzY=
 github.com/icarus-sullivan/mock-lambda v0.0.0-20220115083805-e065469e964a h1:gmFO6gLHZkdJlkZ41QiQ5tzH8LORPVJCuKk6YKyquU0=
 github.com/icarus-sullivan/mock-lambda v0.0.0-20220115083805-e065469e964a/go.mod h1:2iuLAENWZqxe/B6XUDWw/3ioQ9d1fwhgFTlwVeIBpzY=
+github.com/icarus-sullivan/mock-lambda v0.0.0-20220217054640-b33d704534c9 h1:ffSGx+QCXfCe/Zpvkb5laI0r8CeXaNXuXimbjETd3TA=
+github.com/icarus-sullivan/mock-lambda v0.0.0-20220217054640-b33d704534c9/go.mod h1:2iuLAENWZqxe/B6XUDWw/3ioQ9d1fwhgFTlwVeIBpzY=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/russross/blackfriday/v2 v2.0.1/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=

--- a/tests/integration/go/go1.x/hello/main.go
+++ b/tests/integration/go/go1.x/hello/main.go
@@ -2,12 +2,15 @@ package main
 
 import (
 	"context"
+	"log"
 
 	"github.com/aws/aws-lambda-go/events"
 	"github.com/aws/aws-lambda-go/lambda"
 )
 
 func Handler(ctx context.Context, req events.APIGatewayProxyRequest) (events.APIGatewayProxyResponse, error) {
+	log.Println("No logs should interrupt response stdio")
+
 	return events.APIGatewayProxyResponse{
 		Body:       "{\"message\": \"Hello Go 1.x!\"}",
 		StatusCode: 200,


### PR DESCRIPTION
…test mock-lambda

## Description

Merge stderr and stdout in the response parsing from go invocation

## Motivation and Context

There was a check for stderr to return early during the lambda invocation. This was to improve performance as it would ignore stdout. Apparently standard log outputs will write to the stderr channel in golang, so instead we should merge all output and parse it. Any extra lines not marked with the identifier `offline_payload` will be output to the console. Also adding and pinning a change to the mock-lambda which runs the code to support SQS events as well as uses reflection to infer incoming events. 

Why is this change required? What problem does it solve? [Issue 1352](https://github.com/dherault/serverless-offline/issues/1352)

## How Has This Been Tested?

Added an additional log call in the test go runner to verify these changes fix 1352 and don't break existing functionality. 
