### PR TITLE
Fix websocket authorizers data located in wrong place

### DIFF
--- a/src/events/authValidateContext.js
+++ b/src/events/authValidateContext.js
@@ -1,5 +1,5 @@
 import Boom from '@hapi/boom'
-import serverlessLog from '../../serverlessLog.js'
+import serverlessLog from '../serverlessLog.js'
 
 function internalServerError(message) {
   const errorType = 'AuthorizerConfigurationException'

--- a/src/events/http/createAuthScheme.js
+++ b/src/events/http/createAuthScheme.js
@@ -1,6 +1,6 @@
 import Boom from '@hapi/boom'
 import authCanExecuteResource from '../authCanExecuteResource.js'
-import authValidateContext from './authValidateContext.js'
+import authValidateContext from '../authValidateContext.js'
 import debugLog from '../../debugLog.js'
 import serverlessLog from '../../serverlessLog.js'
 import {

--- a/src/events/websocket/WebSocketClients.js
+++ b/src/events/websocket/WebSocketClients.js
@@ -483,9 +483,9 @@ export default class WebSocketClients {
     }
 
     if (this.log) {
-      this.log.notice(`route '${definition}'`)
+      this.log.notice(`route '${definition.route} (λ: ${functionKey})'`)
     } else {
-      serverlessLog(`route '${definition}'`)
+      serverlessLog(`route '${definition.route} (λ: ${functionKey})'`)
     }
   }
 

--- a/src/events/websocket/WebSocketClients.js
+++ b/src/events/websocket/WebSocketClients.js
@@ -223,8 +223,8 @@ export default class WebSocketClients {
 
     const authorizerData = this.#webSocketAuthorizersCache.get(connectionId)
     if (authorizerData) {
-      connectEvent.identity = authorizerData.identity
-      connectEvent.authorizer = authorizerData.authorizer
+      connectEvent.requestContext.identity = authorizerData.identity
+      connectEvent.requestContext.authorizer = authorizerData.authorizer
     }
 
     const lambdaFunction = this.#lambda.get(route.functionKey)
@@ -341,8 +341,8 @@ export default class WebSocketClients {
 
       const authorizerData = this.#webSocketAuthorizersCache.get(connectionId)
       if (authorizerData) {
-        disconnectEvent.identity = authorizerData.identity
-        disconnectEvent.authorizer = authorizerData.authorizer
+        disconnectEvent.requestContext.identity = authorizerData.identity
+        disconnectEvent.requestContext.authorizer = authorizerData.authorizer
       }
 
       this._processEvent(
@@ -371,8 +371,8 @@ export default class WebSocketClients {
       const event = new WebSocketEvent(connectionId, route, message).create()
       const authorizerData = this.#webSocketAuthorizersCache.get(connectionId)
       if (authorizerData) {
-        event.identity = authorizerData.identity
-        event.authorizer = authorizerData.authorizer
+        event.requestContext.identity = authorizerData.identity
+        event.requestContext.authorizer = authorizerData.authorizer
       }
       this._onWebSocketUsed(connectionId)
 

--- a/src/events/websocket/WebSocketServer.js
+++ b/src/events/websocket/WebSocketServer.js
@@ -23,8 +23,7 @@ export default class WebSocketServer {
       server: sharedServer,
       verifyClient: ({ req }, cb) => {
         const connectionId = createUniqueId()
-        const { headers } = req
-        const key = headers['sec-websocket-key']
+        const key = req.headers['sec-websocket-key']
 
         if (this.log) {
           this.log.debug(`verifyClient:${key} ${connectionId}`)
@@ -37,10 +36,10 @@ export default class WebSocketServer {
 
         this.#webSocketClients
           .verifyClient(connectionId, req)
-          .then(({ verified, statusCode }) => {
+          .then(({ verified, statusCode, message, headers }) => {
             try {
               if (!verified) {
-                cb(false, statusCode)
+                cb(false, statusCode, message, headers)
                 return
               }
               cb(true)

--- a/tests/integration/websocket-authorizer/authorizer.js
+++ b/tests/integration/websocket-authorizer/authorizer.js
@@ -18,6 +18,9 @@ function generatePolicy(principalId, effect, resource) {
     }
 
     authResponse.policyDocument = policyDocument
+    authResponse.context = {
+      example: 'Example value',
+    }
   }
   return authResponse
 }

--- a/tests/integration/websocket-authorizer/handler.js
+++ b/tests/integration/websocket-authorizer/handler.js
@@ -8,6 +8,12 @@ exports.handler = async (event) => {
       : 200
 
   if (
+    requestContext &&
+    (!requestContext.identity || !requestContext.authorizer)
+  ) {
+    throw new Error('Missing authorizer data')
+  }
+  if (
     queryStringParameters &&
     queryStringParameters.throwError &&
     requestContext &&


### PR DESCRIPTION
Move authorizer and identity data to requestContext in order to follow lambda proxy specs.

## Description
This pull request fix a wrong identity and authorizer informations contained in the lambda event instead of requestContext object

Relates to #1379

## Motivation and Context
This fix a wrong behaviour for lambda and websocket authorizers.
Authorizer and identity data should be inside requestContext object when used with lambda proxy (like serverless-offline does)

https://docs.aws.amazon.com/apigateway/latest/developerguide/api-gateway-lambda-authorizer-output.html
https://docs.aws.amazon.com/apigateway/latest/developerguide/set-up-lambda-proxy-integrations.html

In particular a reference to:
```
For the Lambda proxy integration, API Gateway passes the context object from a Lambda authorizer directly to the backend Lambda function as part of the input event. You can retrieve the context key-value pairs in the Lambda function by calling $event.requestContext.authorizer.key.
```

Also integrated changes from #1376 in order to adhere to AWS behaviour: https://docs.aws.amazon.com/apigateway/latest/developerguide/api-gateway-lambda-authorizer-output.html
```
You can access the stringKey, numberKey, or booleanKey value (for example, "value", "1", or "true") of the context map in a mapping template by calling $context.authorizer.stringKey, $context.authorizer.numberKey, or $context.authorizer.booleanKey, respectively. The returned values are all stringified. Notice that you cannot set a JSON object or array as a valid value of any key in the context map. 
```

## How Has This Been Tested?
Detected the difference between AWS and serverless-offline
Reflect the changes in current websocket tests in order to catch the behaviour change

## Screenshots (if appropriate):
