### PR TITLE
Enable support for cron schedules

### DIFF
--- a/src/events/schedule/Schedule.js
+++ b/src/events/schedule/Schedule.js
@@ -5,7 +5,7 @@ import nodeSchedule from 'node-schedule'
 import ScheduleEvent from './ScheduleEvent.js'
 import ScheduleEventDefinition from './ScheduleEventDefinition.js'
 
-// const CRON_LENGTH_WITH_YEAR = 6
+const CRON_LENGTH_WITH_YEAR = 6
 
 const { stringify } = JSON
 
@@ -94,13 +94,13 @@ export default class Schedule {
     })
   }
 
-  // _convertCronSyntax(cronString) {
-  //   if (cronString.split(' ').length < CRON_LENGTH_WITH_YEAR) {
-  //     return cronString
-  //   }
-  //
-  //   return cronString.replace(/\s\S+$/, '')
-  // }
+  _convertCronSyntax(cronString) {
+    if (cronString.split(' ').length < CRON_LENGTH_WITH_YEAR) {
+      return cronString
+    }
+
+    return cronString.replace(/\s\S+$/, '')
+  }
 
   _convertRateToCron(rate) {
     const [number, unit] = rate.split(' ')
@@ -139,8 +139,7 @@ export default class Schedule {
       .replace(')', '')
 
     if (scheduleEvent.startsWith('cron(')) {
-      if (!this.log) console.log('schedule rate "cron" not yet supported!')
-      // return this._convertCronSyntax(params)
+      return this._convertCronSyntax(params)
     }
 
     if (scheduleEvent.startsWith('rate(')) {


### PR DESCRIPTION
## Description

Simply enable the cron support that was disabled. It works, why not use it?
If there is an edge case it doesn't work for, then let's create an issue for it,
and i will gladly fix that.

In any case, for what is essentially a mocked dev environment, it's better to be able to
work for 90% of the use cases than none of them, and so far i haven't
been able to find any problems with it in my local development.

## Motivation and Context

Need to test lambda functions w/ cron schedules
Please see issue: https://github.com/dherault/serverless-offline/issues/1044

## How Has This Been Tested?

Was able to successfully run cron schedules locally