### PR TITLE
chore: remove unused portfinder dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -226,7 +226,6 @@
     "p-queue": "^6.6.2",
     "p-retry": "^4.6.1",
     "please-upgrade-node": "^3.2.0",
-    "portfinder": "^1.0.28",
     "semver": "^7.3.5",
     "update-notifier": "^5.1.0",
     "velocityjs": "^2.0.6",


### PR DESCRIPTION
## Description

This change removes the unused portfinder dependency.

## Motivation and Context

The portfinder dependency is the lone source of an `npm audit` warning on end-user installation. This change fixes that problem.

## How Has This Been Tested?

I ran `npm test` on the current master branch and on this feature branch and got the same results. I also did a `grep` for `portfinder` throughout the code base and it only appeared in `package.json` one time, in the list of dependencies.

