### PR TITLE
fix: fixed issues caused by nested handler modules logic

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -8,6 +8,12 @@ module.exports = {
         loose: true,
       },
     ],
+    [
+      '@babel/plugin-proposal-private-methods',
+      {
+        loose: true,
+      },
+    ],
     '@babel/plugin-proposal-dynamic-import',
     '@babel/plugin-proposal-nullish-coalescing-operator',
     '@babel/plugin-proposal-optional-chaining',

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "serverless-offline",
-  "version": "8.5.0",
+  "version": "8.7.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "serverless-offline",
-      "version": "8.5.0",
+      "version": "8.7.0",
       "license": "MIT",
       "dependencies": {
         "@hapi/boom": "^9.1.4",
@@ -45,6 +45,7 @@
         "@babel/plugin-proposal-dynamic-import": "^7.16.7",
         "@babel/plugin-proposal-nullish-coalescing-operator": "^7.16.7",
         "@babel/plugin-proposal-optional-chaining": "^7.16.7",
+        "@babel/plugin-proposal-private-methods": "^7.16.11",
         "@babel/plugin-transform-modules-commonjs": "^7.17.7",
         "@babel/register": "^7.17.7",
         "archiver": "^5.3.0",
@@ -587,6 +588,22 @@
         "@babel/helper-plugin-utils": "^7.16.7",
         "@babel/helper-skip-transparent-expression-wrappers": "^7.16.0",
         "@babel/plugin-syntax-optional-chaining": "^7.8.3"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-proposal-private-methods": {
+      "version": "7.16.11",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-private-methods/-/plugin-proposal-private-methods-7.16.11.tgz",
+      "integrity": "sha512-F/2uAkPlXDr8+BHpZvo19w3hLFKge+k75XUprE6jaqKxjGkSYcK+4c+bup5PdW/7W/Rpjwql7FTVEDW+fRAQsw==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-create-class-features-plugin": "^7.16.10",
+        "@babel/helper-plugin-utils": "^7.16.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -17635,6 +17652,16 @@
         "@babel/helper-plugin-utils": "^7.16.7",
         "@babel/helper-skip-transparent-expression-wrappers": "^7.16.0",
         "@babel/plugin-syntax-optional-chaining": "^7.8.3"
+      }
+    },
+    "@babel/plugin-proposal-private-methods": {
+      "version": "7.16.11",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-private-methods/-/plugin-proposal-private-methods-7.16.11.tgz",
+      "integrity": "sha512-F/2uAkPlXDr8+BHpZvo19w3hLFKge+k75XUprE6jaqKxjGkSYcK+4c+bup5PdW/7W/Rpjwql7FTVEDW+fRAQsw==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-create-class-features-plugin": "^7.16.10",
+        "@babel/helper-plugin-utils": "^7.16.7"
       }
     },
     "@babel/plugin-syntax-async-generators": {

--- a/package.json
+++ b/package.json
@@ -238,6 +238,7 @@
     "@babel/plugin-proposal-dynamic-import": "^7.16.7",
     "@babel/plugin-proposal-nullish-coalescing-operator": "^7.16.7",
     "@babel/plugin-proposal-optional-chaining": "^7.16.7",
+    "@babel/plugin-proposal-private-methods": "^7.16.11",
     "@babel/plugin-transform-modules-commonjs": "^7.17.7",
     "@babel/register": "^7.17.7",
     "archiver": "^5.3.0",

--- a/src/lambda/LambdaFunction.js
+++ b/src/lambda/LambdaFunction.js
@@ -57,8 +57,7 @@ export default class LambdaFunction {
     const _servicePath = resolve(servicePath, options.location || '')
 
     const { handler, name, package: functionPackage = {} } = functionDefinition
-    const [handlerPath, handlerName, handlerModuleNesting] =
-      splitHandlerPathAndName(handler)
+    const [handlerPath, handlerName] = splitHandlerPathAndName(handler)
 
     const memorySize =
       functionDefinition.memorySize ||
@@ -114,7 +113,6 @@ export default class LambdaFunction {
       functionKey,
       handler,
       handlerName,
-      handlerModuleNesting,
       codeDir: this.#codeDir,
       handlerPath: resolve(this.#codeDir, handlerPath),
       runtime,

--- a/src/lambda/handler-runner/HandlerRunner.js
+++ b/src/lambda/handler-runner/HandlerRunner.js
@@ -31,14 +31,8 @@ export default class HandlerRunner {
     const { useDocker, useChildProcesses, useWorkerThreads, allowCache } =
       this.#options
 
-    const {
-      functionKey,
-      handlerName,
-      handlerPath,
-      handlerModuleNesting,
-      runtime,
-      timeout,
-    } = this.#funOptions
+    const { functionKey, handlerName, handlerPath, runtime, timeout } =
+      this.#funOptions
 
     if (this.log) {
       this.log.debug(`Loading handler... (${handlerPath})`)
@@ -117,7 +111,6 @@ export default class HandlerRunner {
         functionKey,
         handlerPath,
         handlerName,
-        handlerModuleNesting,
         this.#env,
         timeout,
         allowCache,

--- a/src/lambda/handler-runner/child-process-runner/ChildProcessRunner.js
+++ b/src/lambda/handler-runner/child-process-runner/ChildProcessRunner.js
@@ -8,18 +8,11 @@ export default class ChildProcessRunner {
   #functionKey = null
   #handlerName = null
   #handlerPath = null
-  #handlerModuleNesting = null
   #timeout = null
   #allowCache = false
 
   constructor(funOptions, env, allowCache, v3Utils) {
-    const {
-      functionKey,
-      handlerName,
-      handlerPath,
-      handlerModuleNesting,
-      timeout,
-    } = funOptions
+    const { functionKey, handlerName, handlerPath, timeout } = funOptions
 
     if (v3Utils) {
       this.log = v3Utils.log
@@ -32,7 +25,6 @@ export default class ChildProcessRunner {
     this.#functionKey = functionKey
     this.#handlerName = handlerName
     this.#handlerPath = handlerPath
-    this.#handlerModuleNesting = handlerModuleNesting
     this.#timeout = timeout
     this.#allowCache = allowCache
   }
@@ -44,12 +36,7 @@ export default class ChildProcessRunner {
   async run(event, context) {
     const childProcess = node(
       childProcessHelperPath,
-      [
-        this.#functionKey,
-        this.#handlerName,
-        this.#handlerPath,
-        this.#handlerModuleNesting,
-      ],
+      [this.#functionKey, this.#handlerName, this.#handlerPath],
       {
         env: this.#env,
         stdio: 'inherit',

--- a/src/lambda/handler-runner/worker-thread-runner/WorkerThreadRunner.js
+++ b/src/lambda/handler-runner/worker-thread-runner/WorkerThreadRunner.js
@@ -10,13 +10,7 @@ export default class WorkerThreadRunner {
   constructor(funOptions /* options */, env, allowCache) {
     // this._options = options
 
-    const {
-      functionKey,
-      handlerName,
-      handlerPath,
-      handlerModuleNesting,
-      timeout,
-    } = funOptions
+    const { functionKey, handlerName, handlerPath, timeout } = funOptions
 
     this.#allowCache = allowCache
     this.#workerThread = new Worker(workerThreadHelperPath, {
@@ -26,7 +20,6 @@ export default class WorkerThreadRunner {
         functionKey,
         handlerName,
         handlerPath,
-        handlerModuleNesting,
         timeout,
       },
     })

--- a/src/lambda/handler-runner/worker-thread-runner/workerThreadHelper.js
+++ b/src/lambda/handler-runner/worker-thread-runner/workerThreadHelper.js
@@ -1,8 +1,7 @@
 import { parentPort, workerData } from 'worker_threads' // eslint-disable-line import/no-unresolved
 import InProcessRunner from '../in-process-runner/index.js'
 
-const { functionKey, handlerName, handlerPath, handlerModuleNesting } =
-  workerData
+const { functionKey, handlerName, handlerPath } = workerData
 
 parentPort.on('message', async (messageData) => {
   const { context, event, port, timeout, allowCache } = messageData
@@ -12,7 +11,6 @@ parentPort.on('message', async (messageData) => {
     functionKey,
     handlerPath,
     handlerName,
-    handlerModuleNesting,
     process.env,
     timeout,
     allowCache,

--- a/src/utils/__tests__/splitHandlerPathAndName.test.js
+++ b/src/utils/__tests__/splitHandlerPathAndName.test.js
@@ -28,32 +28,18 @@ const tests = [
   },
   {
     description: 'ruby handler from kernel',
-    expected: ['./src/somefolder/function', 'handler', ['handler']],
+    expected: ['./src/somefolder/function', 'handler'],
     handler: './src/somefolder/function.handler',
   },
   {
     description: 'generic handler',
-    expected: ['./src/somefolder/.handlers/handler', 'run', ['run']],
+    expected: ['./src/somefolder/.handlers/handler', 'run'],
     handler: './src/somefolder/.handlers/handler.run',
   },
   {
     description: 'generic handler, unnested',
-    expected: ['handler', 'run', ['run']],
+    expected: ['handler', 'run'],
     handler: 'handler.run',
-  },
-  {
-    description: 'generic handler with module nesting',
-    expected: [
-      './src/somefolder/.handlers/handler',
-      'run',
-      ['layer1', 'layer2', 'run'],
-    ],
-    handler: './src/somefolder/.handlers/handler.layer1.layer2.run',
-  },
-  {
-    description: 'generic handler, unnested with module nesting',
-    expected: ['handler', 'run', ['layer1', 'layer2', 'run']],
-    handler: 'handler.layer1.layer2.run',
   },
 ]
 

--- a/src/utils/splitHandlerPathAndName.js
+++ b/src/utils/splitHandlerPathAndName.js
@@ -1,10 +1,6 @@
 // some-folder/src.index => some-folder/src
 export default function splitHandlerPathAndName(handler) {
   // Split handler into method name and path i.e. handler.run
-  const prepathDelimiter = handler.lastIndexOf('/')
-  const prepath = handler.substr(0, prepathDelimiter + 1) // include '/' for path
-  const postpath = handler.substr(prepathDelimiter + 1)
-
   // Support Ruby paths with namespace resolution operators e.g.
   //  ./src/somefolder/source.LambdaFunctions::Handler.process
   //  prepath: ./src/somefolder/
@@ -13,6 +9,9 @@ export default function splitHandlerPathAndName(handler) {
   //  path: ./src/somefolder/source
   //  name: LambdaFunctions::Handler.process
   if (handler.match(/::/)) {
+    const prepathDelimiter = handler.lastIndexOf('/')
+    const prepath = handler.substr(0, prepathDelimiter + 1) // include '/' for path
+    const postpath = handler.substr(prepathDelimiter + 1)
     const nameDelimiter = postpath.indexOf('.')
     const filename = postpath.substr(0, nameDelimiter)
     const path = prepath + filename
@@ -24,13 +23,9 @@ export default function splitHandlerPathAndName(handler) {
   // Support nested paths i.e. ./src/somefolder/.handlers/handler.run
   //  path: ./src/somefoler/.handlers/handler
   //  name: run
-  const [filename, ...moduleNesting] = postpath.split('.')
-  const [name] = moduleNesting.slice(-1)
-  const path = prepath + filename
+  const delimiter = handler.lastIndexOf('.')
+  const path = handler.substr(0, delimiter)
+  const name = handler.substr(delimiter + 1)
 
-  // module nesting has been added to support when the
-  // handler function is buried deep inside of a module
-  // e.g /src/somefoler/handlers/index.layer1.layer2.handler
-  // AWS supports this feature
-  return [path, name, moduleNesting]
+  return [path, name]
 }


### PR DESCRIPTION
## Description
The was an earlier commit that introduced nested handler modules into `serverless-offline`. That commit broke the usage of the flag `--useChildProcesses` and the python runtime deep handler.

This change returns things to the status quo and isolates the module nesting logic to only happen for the `nodejs` runtime

## Motivation and Context
Fixes issues https://github.com/dherault/serverless-offline/issues/1377 and https://github.com/dherault/serverless-offline/issues/1381