### PR TITLE
Support catch-all routes with method and path properties

### DIFF
--- a/src/ServerlessOffline.js
+++ b/src/ServerlessOffline.js
@@ -358,11 +358,18 @@ export default class ServerlessOffline {
                 }
                 httpEvent.http.method = ''
               }
-              const resolvedMethod =
-                httpEvent.http.method === '*'
-                  ? 'ANY'
-                  : httpEvent.http.method.toUpperCase()
-              httpEvent.http.routeKey = `${resolvedMethod} ${httpEvent.http.path}`
+              if (
+                httpEvent.http.method === '*' &&
+                httpEvent.http.path === '*'
+              ) {
+                httpEvent.http.routeKey = '$default'
+              } else {
+                const resolvedMethod =
+                  httpEvent.http.method === '*'
+                    ? 'ANY'
+                    : httpEvent.http.method.toUpperCase()
+                httpEvent.http.routeKey = `${resolvedMethod} ${httpEvent.http.path}`
+              }
               // Clear these properties to avoid confusion (they will be derived from the routeKey
               // when needed later)
               delete httpEvent.http.method

--- a/tests/endToEnd/starRoutesWithProperties/handler.js
+++ b/tests/endToEnd/starRoutesWithProperties/handler.js
@@ -1,0 +1,10 @@
+'use strict'
+
+exports.hello = async () => {
+  return {
+    statusCode: 200,
+    body: JSON.stringify({
+      foo: 'bar',
+    }),
+  }
+}

--- a/tests/endToEnd/starRoutesWithProperties/serverless.yml
+++ b/tests/endToEnd/starRoutesWithProperties/serverless.yml
@@ -1,0 +1,20 @@
+service: uncategorized-tests
+
+plugins:
+  - ../../../
+
+provider:
+  memorySize: 128
+  name: aws
+  region: us-east-1 # default
+  runtime: nodejs12.x
+  stage: dev
+  versionFunctions: false
+
+functions:
+  hello:
+    handler: handler.hello
+    events:
+      - httpApi:
+          path: '*'
+          method: '*'

--- a/tests/endToEnd/starRoutesWithProperties/starRoutes.test.js
+++ b/tests/endToEnd/starRoutesWithProperties/starRoutes.test.js
@@ -1,0 +1,31 @@
+import { resolve } from 'path'
+import fetch from 'node-fetch'
+import {
+  joinUrl,
+  setup,
+  teardown,
+} from '../../integration/_testHelpers/index.js'
+
+jest.setTimeout(30000)
+
+describe('star routes with properties', () => {
+  // init
+  beforeAll(() =>
+    setup({
+      servicePath: resolve(__dirname),
+    }),
+  )
+
+  // cleanup
+  afterAll(() => teardown())
+
+  describe('when a catch-all route is defined with path and method', () => {
+    test('it should return a payload', async () => {
+      const url = joinUrl(TEST_BASE_URL, '/dev')
+      const response = await fetch(url)
+      const json = await response.json()
+
+      expect(json).toEqual({ foo: 'bar' })
+    })
+  })
+})


### PR DESCRIPTION
## Description

Allow the httpApi event to catch all the requests when specifying the path, method and other properties.

## Motivation and Context

Currently, the only way to catch all requests in an httpApi event is to define it in-line:
```
functions:
  hello:
    handler: handler.hello
    events:
      - httpApi: '*'
```
But when trying to add properties, it's necessary to include the path (AWS requirements) and the method, such as:

```
functions:
  hello:
    handler: handler.hello
    events:
      - httpApi:
          path: '*'
          method: '*'
          authorizer:
            type: request
            name: auth
```

serverless-offline fails to consider this route as the $default and will serve the 404 payload rather than route the request to the handler.

## How Has This Been Tested?

Automated tests have been added
