### PR TITLE
Add support for nodejs16.x

### DIFF
--- a/src/config/supportedRuntimes.js
+++ b/src/config/supportedRuntimes.js
@@ -26,6 +26,7 @@ export const supportedNodejs = new Set([
   'nodejs10.x',
   'nodejs12.x',
   'nodejs14.x',
+  'nodejs16.x',
 ])
 
 // PROVIDED


### PR DESCRIPTION
`serverless@3.17.0` finally landed with `nodejs16.x` support. This PR adds support for `serverless-offline`