### PR TITLE
Reduce log level of CORS settings

### DIFF
--- a/src/utils/getHttpApiCorsConfig.js
+++ b/src/utils/getHttpApiCorsConfig.js
@@ -1,5 +1,4 @@
 import debugLog from '../debugLog.js'
-import { logWarning } from '../serverlessLog.js'
 
 export default function getHttpApiCorsConfig(httpApiCors, { log }) {
   if (httpApiCors === true) {

--- a/src/utils/getHttpApiCorsConfig.js
+++ b/src/utils/getHttpApiCorsConfig.js
@@ -19,18 +19,16 @@ export default function getHttpApiCorsConfig(httpApiCors, { log }) {
     }
 
     if (log) {
-      log.warning(c)
+      log.debug('Using CORS policy', c)
     } else {
-      debugLog(c)
-      logWarning(c)
+      debugLog('Using CORS policy', c)
     }
     return c
   }
   if (log) {
-    log.warning(httpApiCors)
+    log.debug('Using CORS policy', httpApiCors)
   } else {
-    debugLog(httpApiCors)
-    logWarning(httpApiCors)
+    debugLog('Using CORS policy', httpApiCors)
   }
 
   return httpApiCors


### PR DESCRIPTION
## Description

Reduces log level of CORS policy, so there's not a warning log for every request to an endpoint that has CORS enabled.

## Motivation and Context

Reduces noise in logs. Users can still find out this information if they want by tweaking their log settings.

Also see #1335

## How Has This Been Tested?

Reviewed the log levels in Serverless, and how the logging framework works there.