### PR TITLE
feat: secure web sockets

### DIFF
--- a/src/events/websocket/HttpServer.js
+++ b/src/events/websocket/HttpServer.js
@@ -1,4 +1,6 @@
 import { exit } from 'node:process'
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
 import { Server } from '@hapi/hapi'
 import { log } from '@serverless/utils/log.js'
 import { catchAllRoute, connectionsRoutes } from './http-routes/index.js'
@@ -12,7 +14,7 @@ export default class HttpServer {
     this.#options = options
     this.#webSocketClients = webSocketClients
 
-    const { host, websocketPort } = options
+    const { host, websocketPort, httpsProtocol } = options
 
     const serverOptions = {
       host,
@@ -22,6 +24,14 @@ export default class HttpServer {
         // e.g. : /my-path is the same as /my-path/
         stripTrailingSlash: true,
       },
+    }
+
+    // HTTPS support
+    if (typeof httpsProtocol === 'string' && httpsProtocol.length > 0) {
+      serverOptions.tls = {
+        cert: readFileSync(resolve(httpsProtocol, 'cert.pem'), 'ascii'),
+        key: readFileSync(resolve(httpsProtocol, 'key.pem'), 'ascii'),
+      }
     }
 
     this.#server = new Server(serverOptions)


### PR DESCRIPTION
## Description

Add support for secure web sockets by using the TLS options when creating a server for the websockets.

## Motivation and Context

When adding the httpsProtocol configuration in the serverless.yml file
```
custom:
  serverless-offline:
    httpsProtocol: "dev-certs"
```
serverless-offline will show the endpoints as https://localhost:3000/{default*} for HTTP and wss://localhost:3001 for WebSockets, as opposed to http:// and ws://
While https works with the certificates, the websocket protocol is not upgraded and uses http rather than https


## How Has This Been Tested?

To test:
* Add a key and a certificate in dev-certs/key.pem and dev-certs/cert.pem respectively.
* Add websocket events to the serverless.yml file
* Enable https in serverless.yml to point to the dev-certs folder
* Connect to the websocket with `wscat -c wss://localhost:3001`

wscat will complain because it can't establish a TLS/SSL connection, however using `wscat -c ws://localhost:3001` will work because it's not secure. Although this is unintended (since the protocol is listed as wss) and unusable if you're using serverless-offline with https and want to communicate with the websocket from a front-end because any browser will refuse to allow a connection to a non-secure server if using https.

I've tested this with the version 8.8.0 since I couldn't figure out how to build master right now, but the code for the websocket server hasn't changed.

Also the code is the same as for the http event's http server since hapi's API is the same for both.

Cheers!