### PR TITLE
fix: don't require context (#1471)

### DIFF
--- a/src/events/websocket/WebSocketClients.js
+++ b/src/events/websocket/WebSocketClients.js
@@ -178,17 +178,20 @@ export default class WebSocketClients {
           `Authorization function returned a successful response: (λ: ${authFunName})`,
         )
 
-        const validatedContext = authValidateContext(
-          policy.context,
-          authorizerFunction,
-        )
-        if (validatedContext instanceof Error) throw validatedContext
+        if (policy.context) {
+          const validatedContext = authValidateContext(
+            policy.context,
+            authorizerFunction,
+          )
+          if (validatedContext instanceof Error) throw validatedContext
+          policy.context = validatedContext
+        }
 
         this.#webSocketAuthorizersCache.set(connectionId, {
           authorizer: {
             integrationLatency: '42',
             principalId: policy.principalId,
-            ...validatedContext,
+            ...policy.context,
           },
           identity: {
             apiKey: policy.usageIdentifierKey,

--- a/tests/integration/websocket-authorizer/src/authorizer.js
+++ b/tests/integration/websocket-authorizer/src/authorizer.js
@@ -40,6 +40,12 @@ exports.authorizerAsyncFunction = async function authorizerAsyncFunction(
     return generatePolicy('user123', 'Deny', event.methodArn)
   }
 
+  if (credential === 'noContext') {
+    const policy = generatePolicy('user123', 'Allow', event.methodArn)
+    delete policy.context
+    return policy
+  }
+
   if (credential === 'exception') {
     throw new Error('Failed')
   }

--- a/tests/integration/websocket-authorizer/websocket-authorizer.test.js
+++ b/tests/integration/websocket-authorizer/websocket-authorizer.test.js
@@ -8,7 +8,7 @@ import websocketSend from '../_testHelpers/websocketPromise.js'
 
 const __dirname = dirname(fileURLToPath(import.meta.url))
 
-describe.skip('websocket authorizer tests', function desc() {
+describe('websocket authorizer tests', function desc() {
   this.timeout(30000)
 
   beforeEach(() =>
@@ -45,6 +45,20 @@ describe.skip('websocket authorizer tests', function desc() {
     assert.equal(code, undefined)
     assert.equal(err.message, 'Unexpected server response: 403')
     assert.equal(data, undefined)
+  })
+
+  it('websocket authorization without context', async () => {
+    const url = new URL(joinUrl(env.TEST_BASE_URL, '/dev'))
+    url.port = url.port ? '3001' : url.port
+    url.protocol = 'ws'
+    url.searchParams.append('credential', 'noContext')
+
+    const ws = new WebSocket(url.toString())
+    const { data, code, err } = await websocketSend(ws, '{}')
+
+    assert.equal(code, undefined)
+    assert.equal(err, undefined)
+    assert.equal(data, '{}')
   })
 
   it('websocket authorization with authorizer crash', async () => {


### PR DESCRIPTION
## Description

- Fixes #1471
- The policy's context should be *optional*, but the code crashed if the context wasn't provided
- Followed a model similar to createAuthScheme where the context is properly checked for existence before being validated and used
- Add a test to verify the websocket authorizer works when the policy doesn't contain a context. This test fails with the existing code.
- Un-skipped the tests so they're actually run and verified the test now passes.

## Motivation and Context

Policy context should be optional, and I was getting mysterious 500s by not providing it in a websocket authorizer.

## How Has This Been Tested?

I added a test to ensure websocket authorizers run properly without a policy context.