### PR TITLE
fix: Increase invocation payload limit to 6 mb

### DIFF
--- a/src/lambda/routes/invocations/invocationsRoute.js
+++ b/src/lambda/routes/invocations/invocationsRoute.js
@@ -66,6 +66,8 @@ export default function invocationsRoute(lambda, options) {
       payload: {
         // allow: ['binary/octet-stream'],
         defaultContentType: 'binary/octet-stream',
+        // Set maximum size to 6 MB to match maximum invocation payload size in synchronous responses
+        maxBytes: 1024 * 1024 * 6,
         // request.payload will be a raw buffer
         parse: false,
       },


### PR DESCRIPTION
Follow up to this PR that was missing some explanation - https://github.com/dherault/serverless-offline/pull/1344 - thanks to @guilhermebiegelmeyer for proposing it in the first place 👍 