### PR TITLE
fix: Cleanly exit node process

### DIFF
--- a/src/events/http/HttpServer.js
+++ b/src/events/http/HttpServer.js
@@ -201,18 +201,13 @@ export default class HttpServer {
     log.notice()
     log.notice('Enter "rp" to replay the last request')
 
-    process.openStdin().addListener('data', (data) => {
-      // note: data is an object, and when converted to a string it will
-      // end with a linefeed.  so we (rather crudely) account for that
-      // with toString() and then trim()
-      if (data.toString().trim() === 'rp') {
-        this.#injectLastRequest()
-      }
-    })
+    process.stdin.addListener('data', this.#handleStdin)
   }
 
   // stops the server
   stop(timeout) {
+    process.stdin.removeListener('data', this.#handleStdin)
+    process.stdin.pause()
     return this.#server.stop({
       timeout,
     })
@@ -223,6 +218,15 @@ export default class HttpServer {
       await this.#server.register([h2o2])
     } catch (err) {
       log.error(err)
+    }
+  }
+
+  #handleStdin = (data) => {
+    // note: data is an object, and when converted to a string it will
+    // end with a linefeed.  so we (rather crudely) account for that
+    // with toString() and then trim()
+    if (data.toString().trim() === 'rp') {
+      this.#injectLastRequest()
     }
   }
 


### PR DESCRIPTION
## Description

Fixes a bug where node.js process fails to exit even though `ServerlessOffline.stop` was called.

## Motivation and Context

Upgrading to `v9` I noticed my node.js process was no longer exiting cleanly during integration tests.
After some debugging I found that the reason is that in `v9`, `process.stdin.addListener` is not conditional anymore in `HttpServer`.
This leaves the `process.stdin` handle open, and prevents the process from exiting.
The fix is to add a `process.stdin.pause()` call to the `stop` function of `HttpServer`.

More info:
https://stackoverflow.com/questions/33831978/unknown-method-process-openstdin

## How Has This Been Tested?

I tested this locally and it fixed my issue, but since I didn't find relevant tests to this feature in the test-suite I didn't add any regression tests...