### PR TITLE
fix: worker-runner timout option

### DIFF
--- a/src/lambda/handler-runner/worker-thread-runner/workerThreadHelper.js
+++ b/src/lambda/handler-runner/worker-thread-runner/workerThreadHelper.js
@@ -2,10 +2,10 @@ import { env } from 'node:process'
 import { parentPort, workerData } from 'node:worker_threads'
 import InProcessRunner from '../in-process-runner/index.js'
 
-const { functionKey, handlerName, handlerPath } = workerData
+const { functionKey, handlerName, handlerPath, timeout } = workerData
 
 parentPort.on('message', async (messageData) => {
-  const { context, event, port, timeout } = messageData
+  const { context, event, port } = messageData
 
   // TODO we could probably cache this in the module scope?
   const inProcessRunner = new InProcessRunner(


### PR DESCRIPTION
## Description

In worker-runner `timeout` value was `NaN` because the timeout is passed via `workerData` not `message`.

https://github.com/dherault/serverless-offline/blob/master/src/lambda/handler-runner/worker-thread-runner/WorkerThreadRunner.js#L16-L25

## Motivation and Context

Using `context.getRemainingTimeInMillis()` always returns `0`

## How Has This Been Tested?

Tested locally on a project

## Screenshots (if appropriate):
