### PR TITLE
fix: Prevent logging `undefined`  for event schedule

### DIFF
--- a/src/events/schedule/Schedule.js
+++ b/src/events/schedule/Schedule.js
@@ -39,9 +39,9 @@ export default class Schedule {
       const cron = this.#convertExpressionToCron(entry)
 
       log.notice(
-        `Scheduling [${functionKey}] cron: [${cron}] input: ${stringify(
-          input,
-        )}`,
+        `Scheduling [${functionKey}] cron: [${cron}]${
+          input ? ` input: ${stringify(input)}` : ''
+        }`,
       )
 
       nodeSchedule.scheduleJob(cron, async () => {


### PR DESCRIPTION
## Description

This pull request prevents logging `undefined` if the `input` key is undefined.

## Motivation and Context
Before and after:
`Scheduling [upload] cron: [*/1 * * * *] input: undefined`
`Scheduling [upload] cron: [*/1 * * * *]`

## How Has This Been Tested?
Running `sls offline`.