### PR TITLE
Fix require error for url

### DIFF
--- a/src/lambda/handler-runner/in-process-runner/aws-lambda-ric/UserFunction.js
+++ b/src/lambda/handler-runner/in-process-runner/aws-lambda-ric/UserFunction.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const { pathToFileURL } = require('node:url')
+const { pathToFileURL } = require('url')
 
 // node_modules/lambda-runtime/dist/node16/UserFunction.js
 ;(function () {


### PR DESCRIPTION
## Description

Follow up to https://github.com/dherault/serverless-offline/pull/1534

Fixed import error added in v9.2.0.

## Motivation and Context

```
✖ Uncaught exception
Environment: darwin, node 14.17.5, framework 3.21.0 (local), plugin 6.2.2, SDK 4.3.2
Credentials: Local, "default" profile
Docs:        docs.serverless.com
Support:     forum.serverless.com
Bugs:        github.com/serverless/serverless/issues

Error:
Error: Cannot find module 'node:url'
Require stack:
- ....../node_modules/serverless-offline/src/lambda/handler-runner/in-process-runner/aws-lambda-ric/UserFunction.js
    at Function.Module._resolveFilename (internal/modules/cjs/loader.js:889:15)
    at Function.Module._load (internal/modules/cjs/loader.js:745:27)
    at Module.require (internal/modules/cjs/loader.js:961:19)
    at require (internal/modules/cjs/helpers.js:92:18)
    at Object.<anonymous> (/Users/yusukegoto/src/immo/immo-platform/node_modules/serverless-offline/src/lambda/handler-runner/in-process-runner/aws-lambda-ric/UserFunction.js:3:27)
    at Module._compile (internal/modules/cjs/loader.js:1072:14)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:1101:10)
    at Module.load (internal/modules/cjs/loader.js:937:32)
    at Function.Module._load (internal/modules/cjs/loader.js:778:12)
    at ModuleWrap.<anonymous> (internal/modules/esm/translators.js:199:29)
```

## How Has This Been Tested?

I ran `sls offline` .