### PR TITLE
fix: Log uncaught exceptions in worker thread handlers

### DIFF
--- a/src/lambda/handler-runner/in-process-runner/InProcessRunner.js
+++ b/src/lambda/handler-runner/in-process-runner/InProcessRunner.js
@@ -85,14 +85,9 @@ export default class InProcessRunner {
       },
     }
 
-    let result
-
     // execute (run) handler
-    try {
-      result = handler(event, lambdaContext, callback)
-    } catch {
-      throw new Error(`Uncaught error in '${this.#functionKey}' handler.`)
-    }
+    // no try/catch so that errors bubble up and are logged with root stack traces
+    const result = handler(event, lambdaContext, callback)
 
     // // not a Promise, which is not supported by aws
     // if (result == null || typeof result.then !== 'function') {


### PR DESCRIPTION
## Motivation and Context
- Fixes https://github.com/dherault/serverless-offline/issues/1541
- First attempt at #1543 did not work b/c logs from the worker thread do not go to the console
    - alternative considered was to add log here, but the error has been swallowed already at that point, so that won't work either: https://github.com/dherault/serverless-offline/blob/0f6c9f40ab94df8e1743ff7f4e3521abd9084f0b/src/lambda/handler-runner/worker-thread-runner/WorkerThreadRunner.js#L40-L43
- Cleanest way to solve this appears to be just removing try/catch (what this PR proposes), so root error gets logged here: https://github.com/dherault/serverless-offline/blob/0f6c9f40ab94df8e1743ff7f4e3521abd9084f0b/src/events/http/HttpServer.js#L615-L619

## How Has This Been Tested?
- `npm run lint` passes locally
- `npm run test:unit` - cannot get this to work locally. `jest` dependency appears to be missing?
- Locally after this change, per the bug report, I now see:
```
✖ Example failure
✖ Error: Example failure
      at handler (/Users/alden/.../appHandler.js:27:11)
      at InProcessRunner.run (file:///Users/alden/.../node_modules/serverless-offline/src/lambda/handler-runner/in-process-runner/InProcessRunner.js:87:20)
      at async MessagePort.<anonymous> (file:///Users/alden/.../node_modules/serverless-offline/src/lambda/handler-runner/worker-thread-runner/workerThreadHelper.js:25:14)
```
- So I get both the underlying error message and the correct stack trace