### PR TITLE
fix: package exports for usage in plugins

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -9,4 +9,7 @@ if (globalThis.fetch === undefined) {
   globalThis.Headers = Headers
 }
 
+// named exports for usage in plugins like sqs-offline or eventbridge-offline
+export { default as Lambda } from './lambda/index.js'
+
 export { default } from './ServerlessOffline.js'


### PR DESCRIPTION
named export of lambda for usage in plugins like sqs-offline or eventbridge-offline