### PR TITLE
fix: using name instead of schema from provider

### DIFF
--- a/src/ServerlessOffline.js
+++ b/src/ServerlessOffline.js
@@ -346,6 +346,29 @@ If you are experiencing any issues please let us know: https://github.com/dherau
             hasPrivateHttpEvent = true
           }
 
+          if (
+            http?.request?.schemas &&
+            http?.request?.schemas['application/json'] &&
+            typeof http?.request?.schemas['application/json'] === 'string'
+          ) {
+            const requiredModel = http.request.schemas['application/json']
+            if (
+              service?.provider?.apiGateway?.request?.schemas &&
+              service?.provider?.apiGateway?.request?.schemas[requiredModel] &&
+              service?.provider?.apiGateway?.request?.schemas[requiredModel]
+                ?.schema
+            ) {
+              httpEvent.http.request.schemas['application/json'] =
+                service.provider.apiGateway.request.schemas[
+                  requiredModel
+                ].schema
+            } else {
+              log.warning(
+                `Schema definition is missing for "${http.request.schemas['application/json']}" as required in function "${functionKey}"`,
+              )
+            }
+          }
+
           httpEvents.push(httpEvent)
         }
 


### PR DESCRIPTION
## Description

As per [this](https://www.serverless.com/framework/docs/providers/aws/events/apigateway#request-schema-validators) documentation you can define both your schema in provider or in function but When defining in provider and using in function Its not picking up definition instead It just passes the name of the schema to the validator which always fails. This change replaces the model with the model defined in the provider. 

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This change is required to validate your request with the model otherwise it will keep on throwing errors irrespective of body. 

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Node Version: 16.16.0
Test Method: 
+ Installed this changed code in my repository
+ Run with defining schema in function to check if it breaks previous functionality
+ Again Run with defining schema in provider to verify changes 
+ Now remove random properties from `serverless.yml` to verify if it breaks something else


## Screenshots (if appropriate):
