### PR TITLE
fix!: remove print output option

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,7 +134,6 @@ All CLI options are optional:
 --noStripTrailingSlashInUrl Don't strip trailing slash from http routes.
 --noTimeout             -t  Disables the timeout feature.
 --prefix                -p  Adds a prefix to every path, to send your requests to http://localhost:3000/[prefix]/[your_path] instead. Default: ''
---printOutput               Turns on logging of your lambda outputs in the terminal.
 --reloadHandler             Reloads handler with each request.
 --resourceRoutes            Turns on loading of your HTTP proxy settings from serverless.yml
 --useChildProcesses         [This option is deprecated] Run handlers in a child process.

--- a/src/config/commandOptions.js
+++ b/src/config/commandOptions.js
@@ -118,10 +118,6 @@ export default {
     usage:
       'Adds a prefix to every path, to send your requests to http://localhost:3000/prefix/[your_path] instead.',
   },
-  printOutput: {
-    type: 'boolean',
-    usage: 'Outputs your lambda response to the terminal.',
-  },
   reloadHandler: {
     type: 'boolean',
     usage: 'Reloads handler with each request.',

--- a/src/config/defaultOptions.js
+++ b/src/config/defaultOptions.js
@@ -26,7 +26,6 @@ export default {
   noStripTrailingSlashInUrl: false,
   noTimeout: false,
   prefix: '',
-  printOutput: false,
   reloadHandler: false,
   resourceRoutes: false,
   useChildProcesses: false,

--- a/src/events/http/HttpServer.js
+++ b/src/events/http/HttpServer.js
@@ -894,20 +894,6 @@ export default class HttpServer {
         }
       }
 
-      let whatToLog = result
-
-      try {
-        whatToLog = stringify(result)
-      } catch {
-        // nothing
-      } finally {
-        if (this.#options.printOutput) {
-          log.notice(
-            err ? `Replying ${statusCode}` : `[${statusCode}] ${whatToLog}`,
-          )
-        }
-      }
-
       return response
     }
   }


### PR DESCRIPTION
## Description

this PR removes the `--printOuput` flag. this can be easily accomplished by just using `console.log` in your own lambda code, or by just reading the http status code and the response body in a REST client. it's less code and one option less to maintain.

**BREAKING**, next major release, v10

<!--- Describe your changes in detail -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
