### PR TITLE
fix: checking generated api key

### DIFF
--- a/src/events/http/HttpServer.js
+++ b/src/events/http/HttpServer.js
@@ -906,8 +906,10 @@ export default class HttpServer {
         const apiKey = createApiKey()
 
         this.#apiKeysValues = getApiKeysValues(
-          this.#serverless.service.provider.apiGateway?.apiKeys ?? [apiKey],
+          this.#serverless.service.provider.apiGateway?.apiKeys ?? [],
         )
+
+        this.#apiKeysValues.push(apiKey)
 
         log.notice(`Key with token: ${apiKey}`)
       }


### PR DESCRIPTION
## Description

A recent change prevented the default generated API key from working: https://github.com/dherault/serverless-offline/pull/1585/files#diff-c2aeb87128097ca7cd2056b14fba597e31a08404b3bedd046fb550ca602147a3L925

## Motivation and Context

Fix a bug that was recently introduced and shipped in v11

## How Has This Been Tested?

I've tested this fix locally. This probably should have been covered by a unit test to prevent this from breaking originally. I can add some better tests if that's desired. I figure you probably want to ship a patch release with this fix soon though.

## Screenshots (if appropriate):

N/A