### PR TITLE
Allow the trailing slash to be removed when path='' or path='/' is defined in serverless.yml

### DIFF
--- a/src/utils/generateHapiPath.js
+++ b/src/utils/generateHapiPath.js
@@ -12,7 +12,7 @@ export default function generateHapiPath(path, options, serverless) {
     hapiPath = `/${options.prefix}${hapiPath}`
   }
 
-  if (hapiPath !== '/' && hapiPath.endsWith('/') && hapiPath.endsWith('+}/')) {
+  if (hapiPath !== '/' && hapiPath.endsWith('/') && (path === '/' || path === '' || hapiPath.endsWith('+}/'))) {
     hapiPath = hapiPath.slice(0, -1)
   }
 


### PR DESCRIPTION
## Description

This is an attempt to address problem as described in #1601 

## Motivation and Context

The problem has been discovered when migrating from serverless-offline 8 to 11: https://github.com/dherault/serverless-offline/issues/1601

## How Has This Been Tested?

I've manually tested it on my laptop by replace serverless-offline source code under `node_modules` directory.

- serverless version: 3.23.0
- serverless-offline version: 11.1.3
- node.js version: 14.19.3
- OS: macOS 12.6

Without this change, the behaviour is as described in the issue #1601.
With this change, the behaviour is as expected in the issue #1601. That means accessing through the URL without trailing slash is allowed.

More info:

- Behaviour in version 8: accessing both with and without trailing slash would be successful, and this is consistent with AWS
- Behaviour in version 11: accessing with trailing slash would be successful, accessing without trailing slash would fail, and this is not consistent with AWS 
- With this PR: accessing with trailing slash would fail, accessing without trailing slash would succeed, and this is not consistent with AWS either 

