### PR TITLE
fix: prevent overwriting host.docker.internal in wsl

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "chalk": "^5.1.2",
         "execa": "^6.1.0",
         "fs-extra": "^10.1.0",
+        "is-wsl": "^2.2.0",
         "java-invoke-local": "0.0.6",
         "jose": "^4.10.3",
         "js-string-escape": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -91,6 +91,7 @@
     "chalk": "^5.1.2",
     "execa": "^6.1.0",
     "fs-extra": "^10.1.0",
+    "is-wsl": "^2.2.0",
     "java-invoke-local": "0.0.6",
     "jose": "^4.10.3",
     "js-string-escape": "^1.0.1",

--- a/src/lambda/handler-runner/docker-runner/DockerContainer.js
+++ b/src/lambda/handler-runner/docker-runner/DockerContainer.js
@@ -9,6 +9,7 @@ import { execa } from 'execa'
 import { ensureDir, pathExists } from 'fs-extra'
 import jszip from 'jszip'
 import pRetry from 'p-retry'
+import isWsl from 'is-wsl'
 import DockerImage from './DockerImage.js'
 
 const { stringify } = JSON
@@ -148,7 +149,7 @@ export default class DockerContainer {
       dockerArgs.push('-e', `${key}=${value}`)
     })
 
-    if (platform() === 'linux') {
+    if (platform() === 'linux' && !isWsl) {
       // Add `host.docker.internal` DNS name to access host from inside the container
       // https://github.com/docker/for-linux/issues/264
       const gatewayIp = await this.#getBridgeGatewayIp()


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->
This PR prevents overwriting `host.docker.internal` host in WSL environment.
I added [is-wsl](https://github.com/sindresorhus/is-wsl) for checking if the process is running inside WSL.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
In WSL, it seems that the host is not reachable with the gateway ip adress of `bridge` network.
For this reason, [`--add-host host.docker.internal:${gatewayIp}`](https://github.com/dherault/serverless-offline/blob/6485b017c6a5f2a1e1275b0e0642de4486c807ac/src/lambda/handler-runner/docker-runner/DockerContainer.js#L156) does not work as expected.

Docker for Windows supports `host.docker.internal` natively, so just avoid adding `host.docker.internal` and it works.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
This has been tested by running [accessHost.test.js](https://github.com/dherault/serverless-offline/blob/6485b017c6a5f2a1e1275b0e0642de4486c807ac/tests/integration/docker/access-host/accessHost.test.js) in WSL.
