### PR TITLE
feat: Add support for nodejs18.x runtime

### DIFF
--- a/src/config/supportedRuntimes.js
+++ b/src/config/supportedRuntimes.js
@@ -18,6 +18,7 @@ export const supportedNodejs = new Set([
   'nodejs12.x',
   'nodejs14.x',
   'nodejs16.x',
+  'nodejs18.x',
 ])
 
 // PROVIDED
@@ -49,5 +50,6 @@ export const supportedRuntimes = new Set([
 export const unsupportedDockerRuntimes = new Set([
   'nodejs14.x',
   'nodejs16.x',
+  'nodejs18.x',
   'python3.9',
 ])


### PR DESCRIPTION
## Description

Added Node 18 runtime.

Closes #1615 

## Motivation and Context

[AWS now supports Node 18.](https://docs.aws.amazon.com/lambda/latest/dg/lambda-nodejs.html)

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
