### PR TITLE
feat: request authorizers with null identitySource should return 401

### DIFF
--- a/src/events/http/createAuthScheme.js
+++ b/src/events/http/createAuthScheme.js
@@ -78,8 +78,11 @@ export default function createAuthScheme(authorizerOptions, provider, lambda) {
         }
 
         if (authorization === undefined) {
-          throw new Error(
+          log.error(
             `Identity Source is null for ${identitySourceType} ${identitySourceField} (λ: ${authFunName})`,
+          )
+          return Boom.unauthorized(
+            'User is not authorized to access this resource',
           )
         }
 

--- a/tests/integration/request-authorizer/request-authorizer.test.js
+++ b/tests/integration/request-authorizer/request-authorizer.test.js
@@ -65,7 +65,7 @@ describe('request authorizer tests', () => {
 
       {
         description:
-          'should fail with an Unauthorized error when identity source is explicitly not allowed',
+          'should fail with an Unauthorized error when identity source is explicitly not handled',
         expected: {
           error: 'Unauthorized',
           message: 'Unauthorized',
@@ -121,7 +121,7 @@ describe('request authorizer tests', () => {
 
       {
         description:
-          'should fail with an Unauthorized error when identity source is explicitly not allowed',
+          'should fail with an Unauthorized error when identity source is explicitly not handled',
         expected: {
           error: 'Unauthorized',
           message: 'Unauthorized',
@@ -181,7 +181,7 @@ describe('request authorizer tests', () => {
 
       {
         description:
-          'should fail with an Unauthorized error when identity source is explicitly not allowed',
+          'should fail with an Unauthorized error when identity source is explicitly not handled',
         expected: {
           error: 'Unauthorized',
           message: 'Unauthorized',
@@ -237,7 +237,7 @@ describe('request authorizer tests', () => {
 
       {
         description:
-          'should fail with an Unauthorized error when identity source is explicitly not allowed',
+          'should fail with an Unauthorized error when identity source is explicitly not handled',
         expected: {
           error: 'Unauthorized',
           message: 'Unauthorized',
@@ -297,7 +297,7 @@ describe('request authorizer tests', () => {
 
       {
         description:
-          'should fail with an Unauthorized error when identity source is explicitly not allowed',
+          'should fail with an Unauthorized error when identity source is explicitly not handled',
         expected: {
           error: 'Unauthorized',
           message: 'Unauthorized',
@@ -353,7 +353,7 @@ describe('request authorizer tests', () => {
 
       {
         description:
-          'should fail with an Unauthorized error when identity source is explicitly not allowed',
+          'should fail with an Unauthorized error when identity source is explicitly not handled',
         expected: {
           error: 'Unauthorized',
           message: 'Unauthorized',

--- a/tests/integration/request-authorizer/request-authorizer.test.js
+++ b/tests/integration/request-authorizer/request-authorizer.test.js
@@ -64,7 +64,8 @@ describe('request authorizer tests', () => {
       },
 
       {
-        description: 'should fail with an Unauthorized error',
+        description:
+          'should fail with an Unauthorized error when identity source is explicitly not allowed',
         expected: {
           error: 'Unauthorized',
           message: 'Unauthorized',
@@ -75,6 +76,19 @@ describe('request authorizer tests', () => {
             Authorization: 'Bearer fc3e55ea-e6ec-4bf2-94d2-06ae6efe6e5c',
           },
         },
+        path: '/user1-header',
+        status: 401,
+      },
+
+      {
+        description:
+          'should fail with an Unauthorized error when identity source is not present on the request',
+        expected: {
+          error: 'Unauthorized',
+          message: 'User is not authorized to access this resource',
+          statusCode: 401,
+        },
+        options: {},
         path: '/user1-header',
         status: 401,
       },
@@ -106,7 +120,8 @@ describe('request authorizer tests', () => {
       },
 
       {
-        description: 'should fail with an Unauthorized error',
+        description:
+          'should fail with an Unauthorized error when identity source is explicitly not allowed',
         expected: {
           error: 'Unauthorized',
           message: 'Unauthorized',
@@ -114,6 +129,19 @@ describe('request authorizer tests', () => {
         },
         options: {},
         path: '/user1-querystring?query1=fc3e55ea-e6ec-4bf2-94d2-06ae6efe6e5c',
+        status: 401,
+      },
+
+      {
+        description:
+          'should fail with an Unauthorized error when identity source is not present on the request',
+        expected: {
+          error: 'Unauthorized',
+          message: 'User is not authorized to access this resource',
+          statusCode: 401,
+        },
+        options: {},
+        path: '/user1-querystring',
         status: 401,
       },
     ].forEach(doTest)
@@ -152,7 +180,8 @@ describe('request authorizer tests', () => {
       },
 
       {
-        description: 'should fail with an Unauthorized error',
+        description:
+          'should fail with an Unauthorized error when identity source is explicitly not allowed',
         expected: {
           error: 'Unauthorized',
           message: 'Unauthorized',
@@ -163,6 +192,19 @@ describe('request authorizer tests', () => {
             Authorization: 'Bearer fc3e55ea-e6ec-4bf2-94d2-06ae6efe6e5c',
           },
         },
+        path: '/user2-header',
+        status: 401,
+      },
+
+      {
+        description:
+          'should fail with an Unauthorized error when identity source is not present on the request',
+        expected: {
+          error: 'Unauthorized',
+          message: 'User is not authorized to access this resource',
+          statusCode: 401,
+        },
+        options: {},
         path: '/user2-header',
         status: 401,
       },
@@ -194,7 +236,8 @@ describe('request authorizer tests', () => {
       },
 
       {
-        description: 'should fail with an Unauthorized error',
+        description:
+          'should fail with an Unauthorized error when identity source is explicitly not allowed',
         expected: {
           error: 'Unauthorized',
           message: 'Unauthorized',
@@ -202,6 +245,19 @@ describe('request authorizer tests', () => {
         },
         options: {},
         path: '/user2-querystring?query2=fc3e55ea-e6ec-4bf2-94d2-06ae6efe6e5c',
+        status: 401,
+      },
+
+      {
+        description:
+          'should fail with an Unauthorized error when identity source is not present on the request',
+        expected: {
+          error: 'Unauthorized',
+          message: 'User is not authorized to access this resource',
+          statusCode: 401,
+        },
+        options: {},
+        path: '/user2-querystring',
         status: 401,
       },
     ].forEach(doTest)
@@ -240,7 +296,8 @@ describe('request authorizer tests', () => {
       },
 
       {
-        description: 'should fail with an Unauthorized error',
+        description:
+          'should fail with an Unauthorized error when identity source is explicitly not allowed',
         expected: {
           error: 'Unauthorized',
           message: 'Unauthorized',
@@ -251,6 +308,19 @@ describe('request authorizer tests', () => {
             AuthorizationSimple: 'Bearer fc3e55ea-e6ec-4bf2-94d2-06ae6efe6e5c',
           },
         },
+        path: '/user2simple-header',
+        status: 401,
+      },
+
+      {
+        description:
+          'should fail with an Unauthorized error when identity source is not present on the request',
+        expected: {
+          error: 'Unauthorized',
+          message: 'User is not authorized to access this resource',
+          statusCode: 401,
+        },
+        options: {},
         path: '/user2simple-header',
         status: 401,
       },
@@ -282,7 +352,8 @@ describe('request authorizer tests', () => {
       },
 
       {
-        description: 'should fail with an Unauthorized error',
+        description:
+          'should fail with an Unauthorized error when identity source is explicitly not allowed',
         expected: {
           error: 'Unauthorized',
           message: 'Unauthorized',
@@ -290,6 +361,19 @@ describe('request authorizer tests', () => {
         },
         options: {},
         path: '/user2simple-querystring?query2simple=fc3e55ea-e6ec-4bf2-94d2-06ae6efe6e5c',
+        status: 401,
+      },
+
+      {
+        description:
+          'should fail with an Unauthorized error when identity source is not present on the request',
+        expected: {
+          error: 'Unauthorized',
+          message: 'User is not authorized to access this resource',
+          statusCode: 401,
+        },
+        options: {},
+        path: '/user2simple-querystring',
         status: 401,
       },
     ].forEach(doTest)


### PR DESCRIPTION
## Description

According to the official [Amazon docs](https://docs.aws.amazon.com/apigatewayv2/latest/api-reference/apis-apiid-authorizers.html), whenever you set a request authorizer with a specific identity source, such as `$request.header.Authorization`, and a request comes WITHOUT this identity source, then API Gateway responds with a 401 Unauthorized error.

## Motivation and Context

Currently, when doing a request to a function that has an Authorizer attached to it, if the identitySource is not present on the request, then serverless-offline responds with an error 500. I've made the change so it returns a 401 instead.

## How Has This Been Tested?

The `request-authorizers` suite of tests have been updated with a new test case per `describe` block (this change applies to payload format 1.0, 2.0 with simple response, with headers/query params). 

We previously had a test with description `should fail with an Unauthorized error`.
Now, we have TWO tests, one with description `should fail with an Unauthorized error when identity source is explicitly not handled` and another one with `should fail with an Unauthorized error when identity source is not present on the request`. 