### PR TITLE
fix: Lambda timeout status code

### DIFF
--- a/src/events/alb/HttpServer.js
+++ b/src/events/alb/HttpServer.js
@@ -247,14 +247,14 @@ export default class HttpServer {
 
       let statusCode = 200
 
-      if (err) {
-        statusCode = errorStatusCode
-      }
-
       if (result && !result.errorType) {
         statusCode = result.statusCode || 200
       } else {
-        statusCode = 502
+        if (err) {
+          statusCode = errorStatusCode || 502
+        } else {
+          statusCode = 502
+        }
       }
 
       response.statusCode = statusCode

--- a/src/events/alb/HttpServer.js
+++ b/src/events/alb/HttpServer.js
@@ -249,12 +249,10 @@ export default class HttpServer {
 
       if (result && !result.errorType) {
         statusCode = result.statusCode || 200
+      } else if (err) {
+        statusCode = errorStatusCode || 502
       } else {
-        if (err) {
-          statusCode = errorStatusCode || 502
-        } else {
-          statusCode = 502
-        }
+        statusCode = 502
       }
 
       response.statusCode = statusCode

--- a/src/events/http/HttpServer.js
+++ b/src/events/http/HttpServer.js
@@ -828,12 +828,10 @@ export default class HttpServer {
 
         if (result && !result.errorType) {
           statusCode = result.statusCode || 200
+        } else if (err) {
+          statusCode = errorStatusCode || 502
         } else {
-          if (err) {
-            statusCode = errorStatusCode || 502
-          } else {
-            statusCode = 502
-          }
+          statusCode = 502
         }
 
         response.statusCode = statusCode

--- a/src/events/http/HttpServer.js
+++ b/src/events/http/HttpServer.js
@@ -829,7 +829,11 @@ export default class HttpServer {
         if (result && !result.errorType) {
           statusCode = result.statusCode || 200
         } else {
-          statusCode = 502
+          if (err) {
+            statusCode = errorStatusCode || 502
+          } else {
+            statusCode = 502
+          }
         }
 
         response.statusCode = statusCode

--- a/src/lambda/LambdaFunction.js
+++ b/src/lambda/LambdaFunction.js
@@ -280,7 +280,7 @@ export default class LambdaFunction {
   async #timeoutAndTerminate() {
     await setTimeoutPromise(this.#timeout)
 
-    throw new LambdaTimeoutError('Lambda timeout.')
+    throw new LambdaTimeoutError('[504] - Lambda timeout.')
   }
 
   async runHandler() {


### PR DESCRIPTION
## Description

`serverless-offline` returns wrong status code when timeout occurs. Instead of `502`, it should return `504`.
This pull request fixes this issue.

## Motivation and Context

According to serverless docs, it should be `504`.
<img width="369" alt="image" src="https://user-images.githubusercontent.com/46839236/205072124-7a4750fa-3bd6-414a-9546-cfe621c106d7.png">
<img width="682" alt="image" src="https://user-images.githubusercontent.com/46839236/205072198-2717cd6e-52c4-4c94-be33-adbdaa1cb82a.png">
https://github.com/serverless/serverless/blob/main/test/integration/aws/api-gateway.test.js#L226

## How Has This Been Tested?

At the moment I have tested against our own project which already specified a lambda.
The majority of the code has been untouched so it should work.

