### PR TITLE
added json override option to response body

### DIFF
--- a/src/config/commandOptions.js
+++ b/src/config/commandOptions.js
@@ -3,6 +3,11 @@ export default {
     type: 'string',
     usage: 'ALB port to listen on. Default: 3003.',
   },
+  allowJsonInBody: {
+    type: 'boolean',
+    usage:
+      'overrides forcing api response body to contain a string, can also be a JSON object.',
+  },
   corsAllowHeaders: {
     type: 'string',
     usage:

--- a/src/config/defaultOptions.js
+++ b/src/config/defaultOptions.js
@@ -1,5 +1,6 @@
 export default {
   albPort: 3003,
+  allowJsonInBody: false,
   corsAllowHeaders: 'accept,content-type,x-api-key,authorization',
   corsAllowOrigin: '*',
   corsDisallowCredentials: true,

--- a/src/events/http/HttpServer.js
+++ b/src/events/http/HttpServer.js
@@ -898,11 +898,18 @@ export default class HttpServer {
             response.source = Buffer.from(result.body, 'base64')
             response.variety = 'buffer'
           } else {
-            if (result && result.body && typeof result.body !== 'string') {
+            // allow overiding force stringified body, as aws allow you to send objects in the body now.
+
+            if (
+              result &&
+              result.body &&
+              !this.#options.allowJsonInBody &&
+              typeof result.body !== 'string'
+            ) {
               // FIXME TODO we should probably just write to console instead of returning a payload
               return this.#reply502(
                 response,
-                'According to the API Gateway specs, the body content must be stringified. Check your Lambda response and make sure you are invoking JSON.stringify(YOUR_CONTENT) on your body object',
+                'According to the API Gateway specs, the body content must be stringified. Check your Lambda response and make sure you are invoking JSON.stringify(YOUR_CONTENT) on your body object, to override set allowJsonInBody to true',
                 {},
               )
             }


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->
added an option for allowing json objects in the api response body, reason is Aws allows this functionality. ApiGateway doesnt restrict to only string anymore.  

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

<!--- If it fixes an open issue, please link to the issue here. -->


## How Has This Been Tested?

without the allowJsonInBody nothing changes, you still receive the 

> errorMessage: "According to the API Gateway specs, the body content must be stringified. Check your Lambda response and make sure you are invoking JSON.stringify(YOUR_CONTENT) on your body object",

by adding the option  allowJsonInBody: true in serverless.yml under  serverless-offline you can now pass json objects in the response body without the need to JSON.stringify() the contents. 

 
<!--- Please describe in detail how you tested your changes. -->
following the instructions on the contributing.md doc i added the custom plugin into my serverless project and then tested without the newly created option allowJsonInBody and the error remains the same, then adding in the option allowJsonInBody i now see the api response as aws does. 

<!--- Include details of your testing environment, and the tests you ran to -->

tests were manual the code change is a boolean check for allowJsonInBody and if its true we do not throw the error but give the respone. 
all existing tests passed locally. 

<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

