### PR TITLE
Allow ApiGatewayV2 proxy resources without lambdas

### DIFF
--- a/src/ServerlessOffline.js
+++ b/src/ServerlessOffline.js
@@ -82,7 +82,8 @@ export default class ServerlessOffline {
       eventModules.push(this.#createAlb(albEvents))
     }
 
-    if (httpApiEvents.length > 0 || httpEvents.length > 0) {
+    const forceProxies = this.#options.resourceRoutes?.force
+    if (forceProxies || httpApiEvents.length > 0 || httpEvents.length > 0) {
       eventModules.push(this.#createHttp([...httpApiEvents, ...httpEvents]))
     }
 

--- a/src/events/http/HttpServer.js
+++ b/src/events/http/HttpServer.js
@@ -1144,7 +1144,8 @@ export default class HttpServer {
     log.notice('Routes defined in resources:')
 
     entries(resourceRoutes).forEach(([methodId, resourceRoutesObj]) => {
-      const { isProxy, method, pathResource, proxyUri } = resourceRoutesObj
+      const { isProxy, method, pathResource, proxyUri, headers } =
+        resourceRoutesObj
 
       if (!isProxy) {
         log.warning(
@@ -1224,6 +1225,13 @@ export default class HttpServer {
           log.notice(
             `PROXY ${request.method} ${request.url.pathname} -> ${resultUri}`,
           )
+
+          if (headers) {
+            return h.proxy({
+              mapUri: () => ({ headers, uri: resultUri }),
+              passThrough: true,
+            })
+          }
 
           return h.proxy({
             passThrough: true,

--- a/src/events/http/parseResources.js
+++ b/src/events/http/parseResources.js
@@ -212,20 +212,26 @@ function getIntegrationType(Integration) {
   return Integration.Properties.IntegrationType
 }
 
+function parseRouteKey(routeObject) {
+  if (!routeObject || !routeObject.Properties) return undefined
+  const routeKey = routeObject.Properties.RouteKey
+  if (typeof routeKey !== 'string') return undefined
+  const [method, pathResource] = routeKey.split(' ')
+  return { method, pathResource }
+}
+
 function constructHapiInterfaceV2(integrationObjects, routeObjects, routeId) {
   // returns all info necessary so that routes can be added in index.js
   const routeObject = routeObjects[routeId]
   const integrationId = getIntegrationId(routeObject)
   const Integration = integrationObjects[integrationId] || {}
   const integrationType = getIntegrationType(Integration)
+  const { method, pathResource } = parseRouteKey(routeObject) || []
 
   let proxyUri
   if (integrationType === APIGATEWAY_INTEGRATION_TYPE_HTTP_PROXY) {
     proxyUri = parseJoin(Integration.Properties.IntegrationUri)
   }
-
-  const routeKey = routeObject.Properties.RouteKey
-  const [method, pathResource] = routeKey.split(' ')
 
   return {
     isProxy: !!proxyUri,

--- a/src/events/http/parseResources.js
+++ b/src/events/http/parseResources.js
@@ -220,6 +220,24 @@ function parseRouteKey(routeObject) {
   return { method, pathResource }
 }
 
+function parseHeaders(Integration) {
+  if (!Integration || !Integration.RequestParameters) return undefined
+  const requestParameters = Integration.RequestParameters
+
+  const headers = {}
+  keys(requestParameters).forEach((key) => {
+    if (key.includes('header')) {
+      const split = key.split('.')
+      const name = split.length > 1 && split[1]
+      if (name) {
+        headers[name] = requestParameters[key]
+      }
+    }
+  })
+  if (keys(headers).length < 1) return undefined
+  return headers
+}
+
 function constructHapiInterfaceV2(integrationObjects, routeObjects, routeId) {
   // returns all info necessary so that routes can be added in index.js
   const routeObject = routeObjects[routeId]
@@ -233,7 +251,10 @@ function constructHapiInterfaceV2(integrationObjects, routeObjects, routeId) {
     proxyUri = parseJoin(Integration.Properties.IntegrationUri)
   }
 
+  const headers = parseHeaders(Integration.Properties)
+
   return {
+    headers,
     isProxy: !!proxyUri,
     method,
     pathResource,


### PR DESCRIPTION
## Description

* Adds ApiGatewayV2 proxy resource parsing
* Adds headers support for AWS::ApiGatewayV2::Integration
* Adds `resourceRoutes.force` configuration parameter that enables adding proxies without lambda functions.

## Motivation and Context

There is no reason that proxies must only be used with lambdas, because they work fine without them.
I use ApiGatewayV2 proxies as a simple proxy layer that does authorization or passes on authorization headers. Problem was that it was not supported by serverless-offline

## How Has This Been Tested?
Ran all tests in the repository
Have been using in my projects on a Macbook
All changes are backwards compatible, do not need any changes elsewhere

## Screenshots (if appropriate):
