### PR TITLE
fix: LambdaProxyIntegrationEventV2 authorizer context

### DIFF
--- a/src/events/http/lambda-events/LambdaProxyIntegrationEventV2.js
+++ b/src/events/http/lambda-events/LambdaProxyIntegrationEventV2.js
@@ -40,7 +40,7 @@ export default class LambdaProxyIntegrationEventV2 {
       {}
 
     // AWS adds the lambda key to the auth context object
-    const enhancedAuthContext = { lambda: authContext }
+    const lambdaAuthContext = { lambda: authContext }
 
     let authAuthorizer
 
@@ -156,8 +156,8 @@ export default class LambdaProxyIntegrationEventV2 {
         accountId: 'offlineContext_accountId',
         apiId: 'offlineContext_apiId',
         authorizer:
-          enhancedAuthContext ||
-          assign(enhancedAuthContext, {
+          authAuthorizer ||
+          assign(lambdaAuthContext, {
             jwt: {
               claims,
               scopes,

--- a/src/events/http/lambda-events/LambdaProxyIntegrationEventV2.js
+++ b/src/events/http/lambda-events/LambdaProxyIntegrationEventV2.js
@@ -39,6 +39,9 @@ export default class LambdaProxyIntegrationEventV2 {
         this.#request.auth.credentials.context) ||
       {}
 
+    // AWS adds the lambda key to the auth context object
+    const enhancedAuthContext = { lambda: authContext }
+
     let authAuthorizer
 
     if (env.AUTHORIZER) {
@@ -153,8 +156,8 @@ export default class LambdaProxyIntegrationEventV2 {
         accountId: 'offlineContext_accountId',
         apiId: 'offlineContext_apiId',
         authorizer:
-          authAuthorizer ||
-          assign(authContext, {
+          enhancedAuthContext ||
+          assign(enhancedAuthContext, {
             jwt: {
               claims,
               scopes,

--- a/tests/integration/custom-authentication/authenticationCustomVariable.test.js
+++ b/tests/integration/custom-authentication/authenticationCustomVariable.test.js
@@ -29,7 +29,7 @@ describe('custom authentication serverless-offline variable tests', function des
 
       const json = await response.json()
       assert.deepEqual(
-        json.event.requestContext.authorizer.expected,
+        json.event.requestContext.authorizer.lambda.expected,
         'it works',
       )
     })


### PR DESCRIPTION
## Description

The `LambdaProxyIntegrationEventV2` does not return custom authorizer contexts in the correct format. Currently, any context data is returned directly within the `authorizer` object:

```json
{
  "requestContext": {
    "authorizer": {
      "foo": "bar"
    }
  }
}
```

Instead of being nested in the `lambda` object:
```json
{
  "requestContext": {
    "authorizer": {
      "lambda": {
        "foo": "bar"
      }
    }
  }
}
```

## Motivation and Context
This change is required as it breaks the local implementation of the custom authorizer.