### PR TITLE
fix: Custom Authorizer Lambda Request context missing accountId and apiId fields

### DIFF
--- a/src/events/http/createAuthScheme.js
+++ b/src/events/http/createAuthScheme.js
@@ -111,6 +111,7 @@ export default function createAuthScheme(authorizerOptions, provider, lambda) {
             pathParameters: nullIfEmpty(pathParams),
             queryStringParameters: parseQueryStringParameters(url),
             requestContext: {
+              ...event.requestContext,
               extendedRequestId: requestId,
               httpMethod,
               path: request.path,
@@ -132,6 +133,7 @@ export default function createAuthScheme(authorizerOptions, provider, lambda) {
             rawPath: request.path,
             rawQueryString: getRawQueryParams(url),
             requestContext: {
+              ...event.requestContext,
               http: {
                 method: httpMethod,
                 path: resourcePath,


### PR DESCRIPTION
## Description


Prior to https://github.com/dherault/serverless-offline/pull/1600 change, APIGatewayEvent.requestContext object available in custom authorizer lambda had accountId and apiId fields. We used these fields construct methodArn inside our authorizer lambda. But the above change deleted these fields. Any reason why the fields are removed? AWS Lambda https://github.com/types still refer to [these fields](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/b1531302ae0883690b6424400d7b9e9295c6277f/types/aws-lambda/common/api-gateway.d.ts#L23).

Fixed: #1635 