### PR TITLE
feat: Add support for context and multiple identity sources

### DIFF
--- a/src/events/http/createAuthScheme.js
+++ b/src/events/http/createAuthScheme.js
@@ -70,7 +70,7 @@ export default function createAuthScheme(authorizerOptions, provider, lambda) {
           switch (type) {
             case IDENTITY_SOURCE_TYPE_HEADER: {
               const headers = request.raw.req.headers ?? {}
-              identitySource = headers[field]
+              identitySource = headers[field.toLowerCase()]
               break
             }
 
@@ -83,7 +83,7 @@ export default function createAuthScheme(authorizerOptions, provider, lambda) {
 
             case IDENTITY_SOURCE_TYPE_CONTEXT: {
               // Context is handled differently by different providers,
-              // our context is very limited so we return the field name by default.
+              // Serverless Offline's context is very limited so we return the field name by default.
               identitySource = event.requestContext[field] ?? field
               break
             }

--- a/tests/integration/request-authorizer/request-authorizer.test.js
+++ b/tests/integration/request-authorizer/request-authorizer.test.js
@@ -160,6 +160,36 @@ describe('request authorizer tests', () => {
   describe('authorizer with payload format 1.0 and mixed identity sources', () => {
     ;[
       {
+        description: 'respond with Allow policy',
+        expected: {
+          status: 'Authorized',
+        },
+        options: {
+          headers: {
+            Authorization: 'Bearer fc3e55ea-e6ec-4bf2-94d2-06ae6efe6e5a',
+          },
+        },
+        path: '/user1-mixed?query1=fc3e55ea-e6ec-4bf2-94d2-06ae6efe6e5a',
+        status: 200,
+      },
+
+      {
+        description: 'respond with Deny policy',
+        expected: {
+          error: 'Forbidden',
+          message: 'User is not authorized to access this resource',
+          statusCode: 403,
+        },
+        options: {
+          headers: {
+            Authorization: 'Bearer fc3e55ea-e6ec-4bf2-94d2-06ae6efe6e5b',
+          },
+        },
+        path: '/user1-mixed?query1=fc3e55ea-e6ec-4bf2-94d2-06ae6efe6e5b',
+        status: 403,
+      },
+
+      {
         description:
           'should fail with an Unauthorized error when authorization identity source is not present on the request',
         expected: {
@@ -336,6 +366,36 @@ describe('request authorizer tests', () => {
   describe('authorizer with payload format 2.0 and mixed identity sources', () => {
     ;[
       {
+        description: 'respond with Allow policy',
+        expected: {
+          status: 'Authorized',
+        },
+        options: {
+          headers: {
+            Authorization: 'Bearer fc3e55ea-e6ec-4bf2-94d2-06ae6efe6e5a',
+          },
+        },
+        path: '/user2-mixed?query1=fc3e55ea-e6ec-4bf2-94d2-06ae6efe6e5a',
+        status: 200,
+      },
+
+      {
+        description: 'respond with Deny policy',
+        expected: {
+          error: 'Forbidden',
+          message: 'User is not authorized to access this resource',
+          statusCode: 403,
+        },
+        options: {
+          headers: {
+            Authorization: 'Bearer fc3e55ea-e6ec-4bf2-94d2-06ae6efe6e5b',
+          },
+        },
+        path: '/user2-mixed?query1=fc3e55ea-e6ec-4bf2-94d2-06ae6efe6e5b',
+        status: 403,
+      },
+
+      {
         description:
           'should fail with an Unauthorized error when authorization identity source is not present on the request',
         expected: {
@@ -511,6 +571,36 @@ describe('request authorizer tests', () => {
 
   describe('authorizer with payload format 2.0 with simple responses enabled and mixed identity sources', () => {
     ;[
+      {
+        description: 'respond with Allow policy',
+        expected: {
+          status: 'Authorized',
+        },
+        options: {
+          headers: {
+            Authorization: 'Bearer fc3e55ea-e6ec-4bf2-94d2-06ae6efe6e5a',
+          },
+        },
+        path: '/user2simple-mixed?query1=fc3e55ea-e6ec-4bf2-94d2-06ae6efe6e5a',
+        status: 200,
+      },
+
+      {
+        description: 'respond with Deny policy',
+        expected: {
+          error: 'Forbidden',
+          message: 'User is not authorized to access this resource',
+          statusCode: 403,
+        },
+        options: {
+          headers: {
+            Authorization: 'Bearer fc3e55ea-e6ec-4bf2-94d2-06ae6efe6e5b',
+          },
+        },
+        path: '/user2simple-mixed?query1=fc3e55ea-e6ec-4bf2-94d2-06ae6efe6e5a',
+        status: 403,
+      },
+
       {
         description:
           'should fail with an Unauthorized error when authorization identity source is not present on the request',

--- a/tests/integration/request-authorizer/request-authorizer.test.js
+++ b/tests/integration/request-authorizer/request-authorizer.test.js
@@ -144,6 +144,66 @@ describe('request authorizer tests', () => {
     ].forEach(doTest)
   })
 
+  describe('authorizer with payload format 1.0 and context identity source', () => {
+    ;[
+      {
+        description: 'should respond with Allow policy',
+        expected: {
+          status: 'Authorized',
+        },
+        path: '/user1-context',
+        status: 200,
+      },
+    ].forEach(doTest)
+  })
+
+  describe('authorizer with payload format 1.0 and mixed identity sources', () => {
+    ;[
+      {
+        description:
+          'should fail with an Unauthorized error when authorization identity source is not present on the request',
+        expected: {
+          error: 'Unauthorized',
+          message: 'User is not authorized to access this resource',
+          statusCode: 401,
+        },
+        options: {},
+        path: '/user1-mixed?query1=fc3e55ea-e6ec-4bf2-94d2-06ae6efe6e5a',
+        status: 401,
+      },
+
+      {
+        description:
+          'should fail with an Unauthorized error when queryString identity source is not present on the request',
+        expected: {
+          error: 'Unauthorized',
+          message: 'User is not authorized to access this resource',
+          statusCode: 401,
+        },
+        options: {
+          headers: {
+            Authorization: 'Bearer fc3e55ea-e6ec-4bf2-94d2-06ae6efe6e5a',
+          },
+        },
+        path: '/user1-mixed',
+        status: 401,
+      },
+
+      {
+        description:
+          'should fail with an Unauthorized error when neither queryString or authorization identity source is not present on the request',
+        expected: {
+          error: 'Unauthorized',
+          message: 'User is not authorized to access this resource',
+          statusCode: 401,
+        },
+        options: {},
+        path: '/user1-mixed',
+        status: 401,
+      },
+    ].forEach(doTest)
+  })
+
   describe('authorizer with payload format 2.0 and header identity source', () => {
     ;[
       {
@@ -260,6 +320,66 @@ describe('request authorizer tests', () => {
     ].forEach(doTest)
   })
 
+  describe('authorizer with payload format 2.0 and context identity source', () => {
+    ;[
+      {
+        description: 'should respond with Allow policy',
+        expected: {
+          status: 'Authorized',
+        },
+        path: '/user2-context',
+        status: 200,
+      },
+    ].forEach(doTest)
+  })
+
+  describe('authorizer with payload format 2.0 and mixed identity sources', () => {
+    ;[
+      {
+        description:
+          'should fail with an Unauthorized error when authorization identity source is not present on the request',
+        expected: {
+          error: 'Unauthorized',
+          message: 'User is not authorized to access this resource',
+          statusCode: 401,
+        },
+        options: {},
+        path: '/user2-mixed?query1=fc3e55ea-e6ec-4bf2-94d2-06ae6efe6e5a',
+        status: 401,
+      },
+
+      {
+        description:
+          'should fail with an Unauthorized error when queryString identity source is not present on the request',
+        expected: {
+          error: 'Unauthorized',
+          message: 'User is not authorized to access this resource',
+          statusCode: 401,
+        },
+        options: {
+          headers: {
+            Authorization: 'Bearer fc3e55ea-e6ec-4bf2-94d2-06ae6efe6e5a',
+          },
+        },
+        path: '/user2-mixed',
+        status: 401,
+      },
+
+      {
+        description:
+          'should fail with an Unauthorized error when neither queryString or authorization identity source is not present on the request',
+        expected: {
+          error: 'Unauthorized',
+          message: 'User is not authorized to access this resource',
+          statusCode: 401,
+        },
+        options: {},
+        path: '/user2-mixed',
+        status: 401,
+      },
+    ].forEach(doTest)
+  })
+
   describe('authorizer with payload format 2.0 with simple responses enabled and header identity source', () => {
     ;[
       {
@@ -371,6 +491,66 @@ describe('request authorizer tests', () => {
         },
         options: {},
         path: '/user2simple-querystring',
+        status: 401,
+      },
+    ].forEach(doTest)
+  })
+
+  describe('authorizer with payload format 2.0 with simple responses enabled and context identity source', () => {
+    ;[
+      {
+        description: 'should respond with Allow policy',
+        expected: {
+          status: 'Authorized',
+        },
+        path: '/user2simple-context',
+        status: 200,
+      },
+    ].forEach(doTest)
+  })
+
+  describe('authorizer with payload format 2.0 with simple responses enabled and mixed identity sources', () => {
+    ;[
+      {
+        description:
+          'should fail with an Unauthorized error when authorization identity source is not present on the request',
+        expected: {
+          error: 'Unauthorized',
+          message: 'User is not authorized to access this resource',
+          statusCode: 401,
+        },
+        options: {},
+        path: '/user2simple-mixed?query1=fc3e55ea-e6ec-4bf2-94d2-06ae6efe6e5a',
+        status: 401,
+      },
+
+      {
+        description:
+          'should fail with an Unauthorized error when queryString identity source is not present on the request',
+        expected: {
+          error: 'Unauthorized',
+          message: 'User is not authorized to access this resource',
+          statusCode: 401,
+        },
+        options: {
+          headers: {
+            Authorization: 'Bearer fc3e55ea-e6ec-4bf2-94d2-06ae6efe6e5a',
+          },
+        },
+        path: '/user2simple-mixed',
+        status: 401,
+      },
+
+      {
+        description:
+          'should fail with an Unauthorized error when neither queryString or authorization identity source is not present on the request',
+        expected: {
+          error: 'Unauthorized',
+          message: 'User is not authorized to access this resource',
+          statusCode: 401,
+        },
+        options: {},
+        path: '/user2simple-mixed',
         status: 401,
       },
     ].forEach(doTest)

--- a/tests/integration/request-authorizer/serverless.yml
+++ b/tests/integration/request-authorizer/serverless.yml
@@ -48,6 +48,44 @@ provider:
         identitySource: $request.querystring.query2simple
         payloadVersion: '2.0'
         type: request
+
+      requestAuthorizer1FormatContext:
+        functionName: requestAuthorizer1FormatContext
+        identitySource: $context.accountId
+        payloadVersion: '1.0'
+        type: request
+
+      requestAuthorizer2FormatContext:
+        functionName: requestAuthorizer2FormatContext
+        identitySource: $context.accountId
+        payloadVersion: '2.0'
+        type: request
+
+      requestAuthorizer2FormatSimpleContext:
+        enableSimpleResponses: true
+        functionName: requestAuthorizer2FormatSimpleContext
+        identitySource: $context.accountId
+        payloadVersion: '2.0'
+        type: request
+
+      requestAuthorizer1FormatMixed:
+        functionName: requestAuthorizer1FormatMixed
+        identitySource: $request.header.Authorization, $request.querystring.query1, $context.accountId
+        payloadVersion: '1.0'
+        type: request
+
+      requestAuthorizer2FormatMixed:
+        functionName: requestAuthorizer2FormatMixed
+        identitySource: $request.header.Authorization, $request.querystring.query1, $context.accountId
+        payloadVersion: '2.0'
+        type: request
+
+      requestAuthorizer2FormatSimpleMixed:
+        enableSimpleResponses: true
+        functionName: requestAuthorizer2FormatSimpleMixed
+        identitySource: $request.header.Authorization, $request.querystring.query1, $context.accountId
+        payloadVersion: '2.0'
+        type: request
   memorySize: 1024
   name: aws
   region: us-east-1 # default
@@ -110,6 +148,60 @@ functions:
           path: /user2simple-querystring
     handler: src/handler.user
 
+  user1WithContext:
+    events:
+      - httpApi:
+          authorizer:
+            name: requestAuthorizer1FormatContext
+          method: get
+          path: /user1-context
+    handler: src/handler.user
+
+  user2WithContext:
+    events:
+      - httpApi:
+          authorizer:
+            name: requestAuthorizer2FormatContext
+          method: get
+          path: /user2-context
+    handler: src/handler.user
+
+  user2simpleWithContext:
+    events:
+      - httpApi:
+          authorizer:
+            name: requestAuthorizer2FormatSimpleContext
+          method: get
+          path: /user2simple-context
+    handler: src/handler.user
+
+  user1WithMixed:
+    events:
+      - httpApi:
+          authorizer:
+            name: requestAuthorizer1FormatMixed
+          method: get
+          path: /user1-mixed
+    handler: src/handler.user
+
+  user2WithMixed:
+    events:
+      - httpApi:
+          authorizer:
+            name: requestAuthorizer2FormatMixed
+          method: get
+          path: /user2-mixed
+    handler: src/handler.user
+
+  user2simpleWithMixed:
+    events:
+      - httpApi:
+          authorizer:
+            name: requestAuthorizer2FormatSimpleMixed
+          method: get
+          path: /user2simple-mixed
+    handler: src/handler.user
+
   requestAuthorizer1FormatHeader:
     handler: src/authorizer.requestAuthorizer1Format
 
@@ -126,4 +218,22 @@ functions:
     handler: src/authorizer.requestAuthorizer2Format
 
   requestAuthorizer2FormatSimpleQueryString:
+    handler: src/authorizer.requestAuthorizer2FormatSimple
+
+  requestAuthorizer1FormatContext:
+    handler: src/authorizer.requestAuthorizer1Format
+
+  requestAuthorizer2FormatContext:
+    handler: src/authorizer.requestAuthorizer2Format
+
+  requestAuthorizer2FormatSimpleContext:
+    handler: src/authorizer.requestAuthorizer2FormatSimple
+
+  requestAuthorizer1FormatMixed:
+    handler: src/authorizer.requestAuthorizer1Format
+
+  requestAuthorizer2FormatMixed:
+    handler: src/authorizer.requestAuthorizer2Format
+
+  requestAuthorizer2FormatSimpleMixed:
     handler: src/authorizer.requestAuthorizer2FormatSimple

--- a/tests/integration/request-authorizer/src/authorizer.js
+++ b/tests/integration/request-authorizer/src/authorizer.js
@@ -66,7 +66,7 @@ export async function requestAuthorizer2Format(event) {
   }
 
   if (credential === 'random-account-id') {
-    return generatePolicy('user123', 'Allow', event.methodArn)
+    return generatePolicy('user123', 'Allow', event.routeArn)
   }
 
   throw new Error('Unauthorized')

--- a/tests/integration/request-authorizer/src/authorizer.js
+++ b/tests/integration/request-authorizer/src/authorizer.js
@@ -24,18 +24,19 @@ function generateSimpleResponse(authorizedValue) {
   }
 }
 
-function parseIdentitySourceToken(source) {
-  if (source.includes('Bearer')) {
-    const [, credential] = source.split(' ')
-    return credential
+function parseIdentitySourceToken(sources) {
+  for (const source in sources) {
+    if (source.includes('Bearer')) {
+      const [, credential] = source.split(' ')
+      return credential
+    }
   }
-
-  return source
+  return sources[0]
 }
 
 // On version 1.0, identitySource is a string
 export async function requestAuthorizer1Format(event) {
-  const credential = parseIdentitySourceToken(event.identitySource)
+  const credential = parseIdentitySourceToken(event.identitySource.split(','))
 
   if (credential === 'fc3e55ea-e6ec-4bf2-94d2-06ae6efe6e5a') {
     return generatePolicy('user123', 'Allow', event.methodArn)
@@ -50,7 +51,7 @@ export async function requestAuthorizer1Format(event) {
 
 // On version 2.0, identitySource is a string array
 export async function requestAuthorizer2Format(event) {
-  const credential = parseIdentitySourceToken(event.identitySource[0])
+  const credential = parseIdentitySourceToken(event.identitySource)
 
   if (credential === 'fc3e55ea-e6ec-4bf2-94d2-06ae6efe6e5a') {
     return generatePolicy('user123', 'Allow', event.routeArn)
@@ -67,7 +68,7 @@ export async function requestAuthorizer2Format(event) {
 // https://docs.aws.amazon.com/apigateway/latest/developerguide/http-api-lambda-authorizer.html
 // In this case, AWS doesn't care about the principal.
 export async function requestAuthorizer2FormatSimple(event) {
-  const credential = parseIdentitySourceToken(event.identitySource[0])
+  const credential = parseIdentitySourceToken(event.identitySource)
 
   if (credential === 'fc3e55ea-e6ec-4bf2-94d2-06ae6efe6e5a') {
     return generateSimpleResponse(true)

--- a/tests/integration/request-authorizer/src/authorizer.js
+++ b/tests/integration/request-authorizer/src/authorizer.js
@@ -25,7 +25,7 @@ function generateSimpleResponse(authorizedValue) {
 }
 
 function parseIdentitySourceToken(sources) {
-  for (const source in sources) {
+  for (const source of sources) {
     if (source.includes('Bearer')) {
       const [, credential] = source.split(' ')
       return credential
@@ -46,6 +46,10 @@ export async function requestAuthorizer1Format(event) {
     return generatePolicy('user123', 'Deny', event.methodArn)
   }
 
+  if (credential === 'random-account-id') {
+    return generatePolicy('user123', 'Allow', event.methodArn)
+  }
+
   throw new Error('Unauthorized')
 }
 
@@ -59,6 +63,10 @@ export async function requestAuthorizer2Format(event) {
 
   if (credential === 'fc3e55ea-e6ec-4bf2-94d2-06ae6efe6e5b') {
     return generatePolicy('user123', 'Deny', event.routeArn)
+  }
+
+  if (credential === 'random-account-id') {
+    return generatePolicy('user123', 'Allow', event.methodArn)
   }
 
   throw new Error('Unauthorized')
@@ -76,6 +84,10 @@ export async function requestAuthorizer2FormatSimple(event) {
 
   if (credential === 'fc3e55ea-e6ec-4bf2-94d2-06ae6efe6e5b') {
     return generateSimpleResponse(false)
+  }
+
+  if (credential === 'random-account-id') {
+    return generateSimpleResponse(true)
   }
 
   throw new Error('Unauthorized')


### PR DESCRIPTION
## Description
This PR adds support for request authorizers to handle context based identity sources. But seeing as context is set by us, I am not throwing an error if context required is not set.
Also added support for request authorizers to handle multiple identity sources, all of them are now check and required for the authorization function to be called.

## Motivation and Context

Following on from https://github.com/dherault/serverless-offline/pull/1610, my personal project requires a request authorizer which use a context identity source along with a header identity source. AWS supports this by defining the identity sources as a list of comma separated strings `XXX, YYY, ZZZ`.

## How Has This Been Tested?

Ran locally with my Serverless Project which has a request authorizer which requires context and header identity sources.
Added some integration tests for checking the new `mixed` case.

## Screenshots (if appropriate):
