### PR TITLE
Fix error: cannot find module 'node:url'

### DIFF
--- a/src/lambda/handler-runner/in-process-runner/aws-lambda-ric/UserFunction.js
+++ b/src/lambda/handler-runner/in-process-runner/aws-lambda-ric/UserFunction.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const { pathToFileURL } = require('node:url')
+const { pathToFileURL } = import('node:url')
 
 // node_modules/lambda-runtime/dist/node16/UserFunction.js
 ;(function () {


### PR DESCRIPTION
Environment:
- node 14.17.5
- serverless framework 3.27.0 (local)
- plugin 12.0.4

Error:
Error: Cannot find module 'node:url'

Fix:
I changed require to import to make it work.

## Description

Same issue posted here https://stackoverflow.com/questions/73821950/serverless-framework-serverless-offline-start-error-on-get-request-cannot-find-m

<!--- Describe your changes in detail -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

#### Package.json:
![image](https://user-images.githubusercontent.com/37496018/215079938-3c99e519-cfab-448d-a975-c895a498664a.png)

#### Error:
![image](https://user-images.githubusercontent.com/37496018/215079843-888b8cb0-d907-4cd7-a113-1a160ef0da67.png)
