### PR TITLE
fix: Support alb with no method conditions

### DIFF
--- a/src/events/alb/HttpServer.js
+++ b/src/events/alb/HttpServer.js
@@ -296,7 +296,11 @@ export default class HttpServer {
   }
 
   createRoutes(functionKey, albEvent) {
-    const method = albEvent.conditions.method[0].toUpperCase()
+    let method = 'ANY'
+    if ((albEvent.conditions.method || []).length > 0) {
+      method = albEvent.conditions.method[0].toUpperCase()
+    }
+
     const path = albEvent.conditions.path[0]
     const hapiPath = generateAlbHapiPath(path, this.#options, this.#serverless)
 

--- a/tests/integration/alb-handler/handlerPayload.test.js
+++ b/tests/integration/alb-handler/handlerPayload.test.js
@@ -296,12 +296,25 @@ describe('ALB handler payload tests with prepend off', function desc() {
       path: '/test-query-parameters?foo=anything&bar=50',
       status: 200,
     },
-  ].forEach(({ description, expected, path, status }) => {
+    {
+      description: 'test POST when no method condition',
+      expected: 'POST',
+      method: 'POST',
+      path: '/test-no-method-conditions',
+      status: 200,
+    },
+    {
+      description: 'test GET when no method condition',
+      expected: 'GET',
+      path: '/test-no-method-conditions',
+      status: 200,
+    },
+  ].forEach(({ description, expected, path, status, method }) => {
     it(description, async () => {
       const url = new URL(path, BASE_URL)
       url.port = url.port ? '3003' : url.port
 
-      const response = await fetch(url)
+      const response = await fetch(url, { method })
       assert.equal(response.status, status)
 
       if (expected) {

--- a/tests/integration/alb-handler/serverless.yml
+++ b/tests/integration/alb-handler/serverless.yml
@@ -223,3 +223,12 @@ functions:
             method: GET
             path: /test-query-parameters
     handler: src/handler.TestQueryParameters
+
+  TestNoMethodCondition:
+    events:
+      - alb:
+          listenerArn: arn:aws:elasticloadbalancing:us-east-1:12345:listener/app/my-load-balancer/50dc6c495c0c9188/50dc6c495c0c9188
+          priority: 1
+          conditions:
+            path: /test-no-method-conditions
+    handler: src/handler.TestNoMethodConditions

--- a/tests/integration/alb-handler/src/handler.js
+++ b/tests/integration/alb-handler/src/handler.js
@@ -189,3 +189,10 @@ export const TestQueryParameters = (event, context, callback) => {
     statusCode: 200,
   })
 }
+
+export const TestNoMethodConditions = (event, context, callback) => {
+  callback(null, {
+    body: stringify(event.httpMethod),
+    statusCode: 200,
+  })
+}


### PR DESCRIPTION
## Description

The method conditions in alb event is optional, allow any request method to be routed
to alb event handler if no method conditions are specified

Fixes: https://github.com/dherault/serverless-offline/issues/1623

## How Has This Been Tested?

Added integration tests to verify that method condition is no longer required and
any method is routed to the event handler
