### PR TITLE
fix: Allow string values in provider.apiGateway.apiKeys

### DIFF
--- a/src/utils/__tests__/getApiKeysValues.test.js
+++ b/src/utils/__tests__/getApiKeysValues.test.js
@@ -1,0 +1,18 @@
+import assert from 'node:assert'
+import getApiKeysValues from '../getApiKeysValues.js'
+
+describe('getApiKeysValues', () => {
+  it('should handle objects and strings', () => {
+    const result = getApiKeysValues([
+      {
+        name: 'MY_FIRST_KEY_NAME',
+        value: 'MY_FIRST_KEY_VALUE',
+      },
+      'MY_SECOND_KEY_VALUE',
+    ])
+    assert.deepEqual(
+      result,
+      new Set(['MY_FIRST_KEY_VALUE', 'MY_SECOND_KEY_VALUE']),
+    )
+  })
+})

--- a/src/utils/getApiKeysValues.js
+++ b/src/utils/getApiKeysValues.js
@@ -1,7 +1,15 @@
 export default function getApiKeysValues(apiKeys) {
   return new Set(
     apiKeys
-      .filter((apiKey) => typeof apiKey === 'object' && apiKey.value != null)
-      .map(({ value }) => value),
+      .map((apiKey) => {
+        if (typeof apiKey === 'object' && apiKey.value != null) {
+          return apiKey.value
+        }
+        if (typeof apiKey === 'string') {
+          return apiKey
+        }
+        return undefined
+      })
+      .filter((apiKey) => !!apiKey),
   )
 }


### PR DESCRIPTION
## Description

Fixes the problem where `getApiKeysValues` would only allow `FIRST_API_KEY` in the following config, and not `SECOND_API_KEY` because it's not an object.

```yaml
provider:
  name: aws
  apiGateway:
    apiKeys:
      - name: FIRST_API_KEY_NAME
        value: FIRST_API_KEY
      - SECOND_API_KEY
```

Strings are supported, according to the serverless (docs)[https://www.serverless.com/framework/docs/providers/aws/guide/serverless.yml#api-gateway-v1-rest-api].

## Motivation and Context

- Allows using standard serverless syntax

Fixes https://github.com/dherault/serverless-offline/issues/1661

## How Has This Been Tested?

Tested with unit tests with both types of input