### PR TITLE
Add pathParameters and queryStringParameters to payload version 2.0

### DIFF
--- a/src/events/http/createAuthScheme.js
+++ b/src/events/http/createAuthScheme.js
@@ -143,6 +143,8 @@ export default function createAuthScheme(authorizerOptions, provider, lambda) {
             },
             routeArn: methodArn,
             routeKey: resourceId,
+            pathParameters: nullIfEmpty(pathParams),
+            queryStringParameters: parseQueryStringParameters(url),
           }
         }
 


### PR DESCRIPTION
## Description

As per, https://docs.aws.amazon.com/apigateway/latest/developerguide/http-api-lambda-authorizer.html#http-api-lambda-authorizer.payload-format Events with payload version 2.0 for HTTP APIs include path parameters and query string parameters

## Motivation and Context

Sometimes, path parameters need to be used in an authorizer

## How Has This Been Tested?

Yes, locally. Changes are trivial.