### PR TITLE
feat: Adding handling for multiple identitySource headers in the REST API.

### DIFF
--- a/src/events/http/createAuthScheme.js
+++ b/src/events/http/createAuthScheme.js
@@ -270,7 +270,8 @@ export default function createAuthScheme(authorizerOptions, provider, lambda) {
     authorizerOptions.type !== 'request' ||
     authorizerOptions.identitySource
   ) {
-    const headerRegExp = /^(method.|\$)request.header.((?:\w+-?)+\w+)$/
+    // Only validate the first of N possible headers.
+    const headerRegExp = /^(method.|\$)request.header.((?:\w+-?)+\w+).*$/
     const queryStringRegExp =
       /^(method.|\$)request.querystring.((?:\w+-?)+\w+)$/
 

--- a/tests/integration/restApi-authorizers/restApi-authorizers.test.js
+++ b/tests/integration/restApi-authorizers/restApi-authorizers.test.js
@@ -1,0 +1,79 @@
+// tests based on:
+// https://dev.to/piczmar_0/serverless-authorizers---custom-rest-authorizer-16
+
+import assert from 'node:assert'
+import { join } from 'desm'
+import { setup, teardown } from '../../_testHelpers/index.js'
+import { BASE_URL } from '../../config.js'
+
+describe('RestApi Authorizers Tests', function desc() {
+  beforeEach(() =>
+    setup({
+      servicePath: join(import.meta.url),
+    }),
+  )
+
+  afterEach(() => teardown())
+
+  it('should handle configuration with a single header in method.request format', async () => {
+    const url = new URL('/dev/single-header-method', BASE_URL)
+    const options = {
+      headers: {
+        Authorization: 'Bearer abc123',
+        'Content-Type': 'application/json',
+      },
+      method: 'get',
+    }
+
+    const response = await fetch(url, options)
+
+    assert.equal(response.status, 200)
+  })
+
+  it('should handle configuration with a multi header in method.request format', async () => {
+    const url = new URL('/dev/multi-header-method', BASE_URL)
+    const options = {
+      headers: {
+        Authorization: 'Bearer abc123',
+        'Content-Type': 'application/json',
+        UserId: 'xxx',
+      },
+      method: 'get',
+    }
+
+    const response = await fetch(url, options)
+
+    assert.equal(response.status, 200)
+  })
+
+  it('should handle configuration with a single header in $request format', async () => {
+    const url = new URL('/dev/single-header-dollar', BASE_URL)
+    const options = {
+      headers: {
+        Authorization: 'Bearer abc123',
+        'Content-Type': 'application/json',
+      },
+      method: 'get',
+    }
+
+    const response = await fetch(url, options)
+
+    assert.equal(response.status, 200)
+  })
+
+  it('should handle configuration with a multi header in $request format', async () => {
+    const url = new URL('/dev/multi-header-dollar', BASE_URL)
+    const options = {
+      headers: {
+        Authorization: 'Bearer abc123',
+        'Content-Type': 'application/json',
+        UserId: 'xxx',
+      },
+      method: 'get',
+    }
+
+    const response = await fetch(url, options)
+
+    assert.equal(response.status, 200)
+  })
+})

--- a/tests/integration/restApi-authorizers/serverless.yml
+++ b/tests/integration/restApi-authorizers/serverless.yml
@@ -1,0 +1,62 @@
+service: restapi-authorizers
+
+configValidationMode: error
+deprecationNotificationMode: error
+
+plugins:
+  - ../../../src/index.js
+
+provider:
+  architecture: arm64
+  deploymentMethod: direct
+  memorySize: 1024
+  name: aws
+  region: us-east-1
+  runtime: nodejs18.x
+  stage: dev
+  versionFunctions: false
+
+functions:
+  restapi-authorizers:
+    events:
+      - http:
+          integration: lambda
+          method: get
+          path: single-header-method
+          authorizer:
+            name: authorizer-single-header
+            type: request
+            resultTtlInSeconds: 3600
+            identitySource: method.request.header.Authorization
+      - http:
+          integration: lambda
+          method: get
+          path: multi-header-method
+          authorizer:
+            name: authorizer-multi-header
+            type: request
+            resultTtlInSeconds: 3600
+            identitySource: method.request.header.Authorization, method.request.header.UserId
+      - http:
+          integration: lambda
+          method: get
+          path: single-header-dollar
+          authorizer:
+            name: authorizer-single-header
+            type: request
+            resultTtlInSeconds: 3600
+            identitySource: $request.header.Authorization
+      - http:
+          integration: lambda
+          method: get
+          path: multi-header-dollar
+          authorizer:
+            name: authorizer-multi-header
+            type: request
+            resultTtlInSeconds: 3600
+            identitySource: $request.header.Authorization, $request.header.UserId
+    handler: src/handler.test
+  authorizer-single-header:
+    handler: src/handler.authorizerSingle
+  authorizer-multi-header:
+    handler: src/handler.authorizerMulti

--- a/tests/integration/restApi-authorizers/src/handler.js
+++ b/tests/integration/restApi-authorizers/src/handler.js
@@ -1,0 +1,41 @@
+const { stringify } = JSON
+
+export const test = async () => {
+  return {
+    body: stringify({
+      foo: 'bar',
+    }),
+    statusCode: 200,
+  }
+}
+
+function generatePolicy(principalId, effect, resource, context) {
+  const authResponse = {
+    context,
+    principalId,
+  }
+
+  if (effect && resource) {
+    const policyDocument = {
+      Statement: [
+        {
+          Action: 'execute-api:Invoke',
+          Effect: effect,
+          Resource: resource,
+        },
+      ],
+      Version: '2012-10-17',
+    }
+
+    authResponse.policyDocument = policyDocument
+  }
+  return authResponse
+}
+
+export const authorizerSingle = async (event) => {
+  return generatePolicy('user123', 'Allow', event.methodArn, {})
+}
+
+export const authorizerMulti = async (event) => {
+  return generatePolicy('user123', 'Allow', event.methodArn, {})
+}

--- a/tests/integration/restApi-authorizers/src/package.json
+++ b/tests/integration/restApi-authorizers/src/package.json
@@ -1,0 +1,3 @@
+{
+  "type": "module"
+}


### PR DESCRIPTION
## Description

From https://github.com/dherault/serverless-offline/issues/1674

According to [the REST API docs](https://www.serverless.com/framework/docs/providers/aws/events/apigateway):
> In this case, your identitySource could contain multiple entries for your policy cache.

Currently on startup `createAuthScheme()` only allows for one header when validating the `identitySource` entry.

## Motivation and Context

This is preventing us from running serverless offline with our production configuration of using multiple headers to cache auth.

## How Has This Been Tested?

Tested locally and added integration tests.

## Screenshots (if appropriate):
