### PR TITLE
Python handle base64 encoded binary response from aws lambda function

### DIFF
--- a/src/lambda/handler-runner/python-runner/invoke.py
+++ b/src/lambda/handler-runner/python-runner/invoke.py
@@ -1,6 +1,7 @@
 # copy/pasted entirely as is from:
 # https://github.com/serverless/serverless/blob/v1.50.0/lib/plugins/aws/invokeLocal/invoke.py
 
+import base64
 import subprocess
 import argparse
 import json
@@ -9,6 +10,7 @@ import sys
 import os
 from time import strftime, time
 from importlib import import_module
+
 
 class FakeLambdaContext(object):
     def __init__(self, name='Fake', version='LATEST', timeout=6, **kwargs):
@@ -101,6 +103,10 @@ if __name__ == '__main__':
             # interesting data (result) and stdout/print
             '__offline_payload__': result
         }
+
+        if isinstance(result['body'], bytes):
+            data['__offline_payload__']['body'] = base64.b64encode(result['body']).decode('utf-8')
+            data['isBase64Encoded'] = True
 
         sys.stdout.write(json.dumps(data))
         sys.stdout.write('\n')


### PR DESCRIPTION
## Description

Add support of base64 encoded binary response from aws python lambda function

## Motivation and Context
API Gateway will treat lambda-proxy responses with isBase64Encoded set  
to true as binary as long as the mime-type matches one of the allowed  binary types.
We need Python lambdas to support base64 handling. At this point serverless-offline contains Base64 handling for JavaScript lambdas only.


## Screenshots (if appropriate):
