### PR TITLE
doc: Fix customAuthenticationProvider documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -524,9 +524,16 @@ only enabled with the `--ignoreJWTSignature` flag. Make sure to only set this fl
 
 ### Serverless plugin authorizers
 
-If your authentication needs are custom and not satisfied by the existing capabilities of the Serverless offline project, you can inject your own authentication strategy. To inject a custom strategy for Lambda invocation, you define a custom variable under `serverless-offline` called `authenticationProvider` in the serverless.yml file. The value of the custom variable will be used to `require(your authenticationProvider value)` where the location is expected to return a function with the following signature.
+If your authentication needs are custom and not satisfied by the existing capabilities of the Serverless offline project, you can inject your own authentication strategy. To inject a custom strategy for Lambda invocation, you define a custom variable under `offline` called `customAuthenticationProvider` in the serverless.yml file. The value of the custom variable will be used to `require(your customAuthenticationProvider value)` where the location is expected to return a function with the following signature.
+
+```yaml
+  offline:
+    customAuthenticationProvider: ./path/to/custom-authentication-provider
+```
 
 ```js
+// ./path/to/customer-authentication-provider.js
+
 module.exports = function (endpoint, functionKey, method, path) {
   return {
     getAuthenticateFunction() {
@@ -543,7 +550,7 @@ module.exports = function (endpoint, functionKey, method, path) {
 }
 ```
 
-A working example of injecting a custom authorization provider can be found in the projects integration tests under the folder `custom-authentication`.
+A working example of injecting a custom authorization provider can be found in the projects integration tests under the folder [`custom-authentication`](./tests/integration/custom-authentication).
 
 ## Custom headers
 


### PR DESCRIPTION

## Description

This PR fixes the description for enabling custom authentication providers in serverless.yml files. In addition to using the correct keys, I added an usage example and direct linked the referenced integration test example.

Related to #1311

## Motivation and Context

The documentation was wrong and hard to follow. Correct solution was pointed out in https://github.com/dherault/serverless-offline/issues/1311#issuecomment-1176860248 by @rion18.

## How Has This Been Tested?

Implemented the custom provider in my own project. Additionally I tested that the key `serverless-offline` and `authenticationProvider` mentioned in the README are no-ops and that the implementation in https://github.com/dherault/serverless-offline/tree/master/tests/integration/custom-authentication is in fact correct. 