### PR TITLE
feat: add support for runtime python3.10

### DIFF
--- a/src/config/supportedRuntimes.js
+++ b/src/config/supportedRuntimes.js
@@ -30,6 +30,7 @@ export const supportedPython = new Set([
   'python3.7',
   'python3.8',
   'python3.9',
+  'python3.10',
 ])
 
 // RUBY


### PR DESCRIPTION
## Description

AWS recently released support for Python 3.10:
https://aws.amazon.com/blogs/compute/python-3-10-runtime-now-available-in-aws-lambda/

This makes it possible to use the runtime with serverless-offline.

## Motivation and Context

To use Python 3.10.

## How Has This Been Tested?

I tested running my project with serverless-offline and Python 3.10 and it works fine when it's added to supported runtimes.