### PR TITLE
feat: Go replace

### DIFF
--- a/src/config/commandOptions.js
+++ b/src/config/commandOptions.js
@@ -135,4 +135,8 @@ export default {
     type: 'string',
     usage: 'Websocket port to listen on. Default: 3001.',
   },
+  goReplace: {
+    type: 'string',
+    usage: 'Replace rule for golang. e.g. use --goReplace bin=cmd replace bin/hello to cmd/hello/main.go',
+  }
 }

--- a/src/config/defaultOptions.js
+++ b/src/config/defaultOptions.js
@@ -28,4 +28,5 @@ export default {
   webSocketHardTimeout: 7200,
   webSocketIdleTimeout: 600,
   websocketPort: 3001,
+  goReplace: null,
 }

--- a/src/lambda/handler-runner/HandlerRunner.js
+++ b/src/lambda/handler-runner/HandlerRunner.js
@@ -68,8 +68,11 @@ export default class HandlerRunner {
 
     if (supportedGo.has(runtime)) {
       const { default: GoRunner } = await import('./go-runner/index.js')
-
-      return new GoRunner(this.#funOptions, this.#env)
+      
+      const goOptions = {
+        replace: this.#options.goReplace,
+      }
+      return new GoRunner(this.#funOptions, this.#env, goOptions)
     }
 
     if (supportedPython.has(runtime)) {

--- a/src/lambda/handler-runner/go-runner/GoRunner.js
+++ b/src/lambda/handler-runner/go-runner/GoRunner.js
@@ -23,8 +23,13 @@ export default class GoRunner {
 
   #tmpPath = null
 
-  constructor(funOptions, env) {
-    const { handler, codeDir } = funOptions
+  constructor(funOptions, env, goOptions) {
+    let { handler, codeDir } = funOptions
+    if (goOptions.replace !== null) {
+      const rule = goOptions.replace.split('=')
+      handler = handler.replace(rule[0], rule[1]) + '/main.go'
+    }
+
     const [handlerPath] = splitHandlerPathAndName(handler)
 
     this.#codeDir = codeDir


### PR DESCRIPTION
## Description

Add a new option for Golang runner to fix the incompatibility between local running and AWS.

You can use `sls offline start --stage local --goReplace bin=cmd`  to tell the runner how to find source files.

How to work?
```
functions:
  hello:
    handler: bin/hello  # <------- it will automatically replace here with cmd/hello/main.go
    events:
      - httpApi:
          path: /hello
          method: get
```

#1644 #1358 


