### PR TITLE
Upgrade aws-sdk/client-lambda

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "12.0.4",
       "license": "MIT",
       "dependencies": {
-        "@aws-sdk/client-lambda": "^3.241.0",
+        "@aws-sdk/client-lambda": "^3.352.0",
         "@hapi/boom": "^10.0.0",
         "@hapi/h2o2": "^10.0.0",
         "@hapi/hapi": "^21.1.0",
@@ -74,10 +74,25 @@
         "node": ">=6.0.0"
       }
     },
+    "node_modules/@aws-crypto/crc32": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/crc32/-/crc32-3.0.0.tgz",
+      "integrity": "sha512-IzSgsrxUcsrejQbPVilIKy16kAT52EwB6zSaI+M3xxIhKh5+aldEyvI+z6erM7TCLB2BJsFrtHjp6/4/sr+3dA==",
+      "dependencies": {
+        "@aws-crypto/util": "^3.0.0",
+        "@aws-sdk/types": "^3.222.0",
+        "tslib": "^1.11.1"
+      }
+    },
+    "node_modules/@aws-crypto/crc32/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+    },
     "node_modules/@aws-crypto/ie11-detection": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/ie11-detection/-/ie11-detection-2.0.2.tgz",
-      "integrity": "sha512-5XDMQY98gMAf/WRTic5G++jfmS/VLM0rwpiOpaainKi4L0nqWMSB1SzsrEG5rjFZGYN6ZAefO+/Yta2dFM0kMw==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/ie11-detection/-/ie11-detection-3.0.0.tgz",
+      "integrity": "sha512-341lBBkiY1DfDNKai/wXM3aujNBkXR7tq1URPQDL9wi3AUbI80NR74uF1TXHMm7po1AcnFk8iu2S2IeU/+/A+Q==",
       "dependencies": {
         "tslib": "^1.11.1"
       }
@@ -88,15 +103,15 @@
       "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
     },
     "node_modules/@aws-crypto/sha256-browser": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-2.0.0.tgz",
-      "integrity": "sha512-rYXOQ8BFOaqMEHJrLHul/25ckWH6GTJtdLSajhlqGMx0PmSueAuvboCuZCTqEKlxR8CQOwRarxYMZZSYlhRA1A==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-3.0.0.tgz",
+      "integrity": "sha512-8VLmW2B+gjFbU5uMeqtQM6Nj0/F1bro80xQXCW6CQBWgosFWXTx77aeOF5CAIAmbOK64SdMBJdNr6J41yP5mvQ==",
       "dependencies": {
-        "@aws-crypto/ie11-detection": "^2.0.0",
-        "@aws-crypto/sha256-js": "^2.0.0",
-        "@aws-crypto/supports-web-crypto": "^2.0.0",
-        "@aws-crypto/util": "^2.0.0",
-        "@aws-sdk/types": "^3.1.0",
+        "@aws-crypto/ie11-detection": "^3.0.0",
+        "@aws-crypto/sha256-js": "^3.0.0",
+        "@aws-crypto/supports-web-crypto": "^3.0.0",
+        "@aws-crypto/util": "^3.0.0",
+        "@aws-sdk/types": "^3.222.0",
         "@aws-sdk/util-locate-window": "^3.0.0",
         "@aws-sdk/util-utf8-browser": "^3.0.0",
         "tslib": "^1.11.1"
@@ -108,12 +123,12 @@
       "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
     },
     "node_modules/@aws-crypto/sha256-js": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-2.0.0.tgz",
-      "integrity": "sha512-VZY+mCY4Nmrs5WGfitmNqXzaE873fcIZDu54cbaDaaamsaTOP1DBImV9F4pICc3EHjQXujyE8jig+PFCaew9ig==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-3.0.0.tgz",
+      "integrity": "sha512-PnNN7os0+yd1XvXAy23CFOmTbMaDxgxXtTKHybrJ39Y8kGzBATgBFibWJKH6BhytLI/Zyszs87xCOBNyBig6vQ==",
       "dependencies": {
-        "@aws-crypto/util": "^2.0.0",
-        "@aws-sdk/types": "^3.1.0",
+        "@aws-crypto/util": "^3.0.0",
+        "@aws-sdk/types": "^3.222.0",
         "tslib": "^1.11.1"
       }
     },
@@ -123,9 +138,9 @@
       "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
     },
     "node_modules/@aws-crypto/supports-web-crypto": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-2.0.2.tgz",
-      "integrity": "sha512-6mbSsLHwZ99CTOOswvCRP3C+VCWnzBf+1SnbWxzzJ9lR0mA0JnY2JEAhp8rqmTE0GPFy88rrM27ffgp62oErMQ==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-3.0.0.tgz",
+      "integrity": "sha512-06hBdMwUAb2WFTuGG73LSC0wfPu93xWwo5vL2et9eymgmu3Id5vFAHBbajVWiGhPO37qcsdCap/FqXvJGJWPIg==",
       "dependencies": {
         "tslib": "^1.11.1"
       }
@@ -136,11 +151,11 @@
       "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
     },
     "node_modules/@aws-crypto/util": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-2.0.2.tgz",
-      "integrity": "sha512-Lgu5v/0e/BcrZ5m/IWqzPUf3UYFTy/PpeED+uc9SWUR1iZQL8XXbGQg10UfllwwBryO3hFF5dizK+78aoXC1eA==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-3.0.0.tgz",
+      "integrity": "sha512-2OJlpeJpCR48CC8r+uKVChzs9Iungj9wkZrl8Z041DWEWvyIHILYKCPNzJghKsivj+S3mLo6BVc7mBNzdxA46w==",
       "dependencies": {
-        "@aws-sdk/types": "^3.110.0",
+        "@aws-sdk/types": "^3.222.0",
         "@aws-sdk/util-utf8-browser": "^3.0.0",
         "tslib": "^1.11.1"
       }
@@ -151,447 +166,509 @@
       "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
     },
     "node_modules/@aws-sdk/abort-controller": {
-      "version": "3.226.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/abort-controller/-/abort-controller-3.226.0.tgz",
-      "integrity": "sha512-cJVzr1xxPBd08voknXvR0RLgtZKGKt6WyDpH/BaPCu3rfSqWCDZKzwqe940eqosjmKrxC6pUZNKASIqHOQ8xxQ==",
+      "version": "3.347.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/abort-controller/-/abort-controller-3.347.0.tgz",
+      "integrity": "sha512-P/2qE6ntYEmYG4Ez535nJWZbXqgbkJx8CMz7ChEuEg3Gp3dvVYEKg+iEUEvlqQ2U5dWP5J3ehw5po9t86IsVPQ==",
       "dependencies": {
-        "@aws-sdk/types": "3.226.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/types": "3.347.0",
+        "tslib": "^2.5.0"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/client-lambda": {
-      "version": "3.241.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-lambda/-/client-lambda-3.241.0.tgz",
-      "integrity": "sha512-Hb2/SE9nVEjTaLFitz36vU4/c0HhPNw/clQNQW4soVJjxBadQ8Yce03QjdEvphCFk3rQWSebhc9L+UZ3qw7Qdw==",
+      "version": "3.352.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-lambda/-/client-lambda-3.352.0.tgz",
+      "integrity": "sha512-n5pjqxeSTu85HFq/t+2voZJFC93iExQj+VJLytK0ZM9yhATK2n4aRGkSZttVeq6rX023QRYOh1E2VMGTToIdxA==",
       "dependencies": {
-        "@aws-crypto/sha256-browser": "2.0.0",
-        "@aws-crypto/sha256-js": "2.0.0",
-        "@aws-sdk/client-sts": "3.241.0",
-        "@aws-sdk/config-resolver": "3.234.0",
-        "@aws-sdk/credential-provider-node": "3.241.0",
-        "@aws-sdk/fetch-http-handler": "3.226.0",
-        "@aws-sdk/hash-node": "3.226.0",
-        "@aws-sdk/invalid-dependency": "3.226.0",
-        "@aws-sdk/middleware-content-length": "3.226.0",
-        "@aws-sdk/middleware-endpoint": "3.226.0",
-        "@aws-sdk/middleware-host-header": "3.226.0",
-        "@aws-sdk/middleware-logger": "3.226.0",
-        "@aws-sdk/middleware-recursion-detection": "3.226.0",
-        "@aws-sdk/middleware-retry": "3.235.0",
-        "@aws-sdk/middleware-serde": "3.226.0",
-        "@aws-sdk/middleware-signing": "3.226.0",
-        "@aws-sdk/middleware-stack": "3.226.0",
-        "@aws-sdk/middleware-user-agent": "3.226.0",
-        "@aws-sdk/node-config-provider": "3.226.0",
-        "@aws-sdk/node-http-handler": "3.226.0",
-        "@aws-sdk/protocol-http": "3.226.0",
-        "@aws-sdk/smithy-client": "3.234.0",
-        "@aws-sdk/types": "3.226.0",
-        "@aws-sdk/url-parser": "3.226.0",
-        "@aws-sdk/util-base64": "3.208.0",
-        "@aws-sdk/util-body-length-browser": "3.188.0",
-        "@aws-sdk/util-body-length-node": "3.208.0",
-        "@aws-sdk/util-defaults-mode-browser": "3.234.0",
-        "@aws-sdk/util-defaults-mode-node": "3.234.0",
-        "@aws-sdk/util-endpoints": "3.241.0",
-        "@aws-sdk/util-retry": "3.229.0",
-        "@aws-sdk/util-user-agent-browser": "3.226.0",
-        "@aws-sdk/util-user-agent-node": "3.226.0",
-        "@aws-sdk/util-utf8-browser": "3.188.0",
-        "@aws-sdk/util-utf8-node": "3.208.0",
-        "@aws-sdk/util-waiter": "3.226.0",
-        "tslib": "^2.3.1"
+        "@aws-crypto/sha256-browser": "3.0.0",
+        "@aws-crypto/sha256-js": "3.0.0",
+        "@aws-sdk/client-sts": "3.352.0",
+        "@aws-sdk/config-resolver": "3.347.0",
+        "@aws-sdk/credential-provider-node": "3.352.0",
+        "@aws-sdk/eventstream-serde-browser": "3.347.0",
+        "@aws-sdk/eventstream-serde-config-resolver": "3.347.0",
+        "@aws-sdk/eventstream-serde-node": "3.347.0",
+        "@aws-sdk/fetch-http-handler": "3.347.0",
+        "@aws-sdk/hash-node": "3.347.0",
+        "@aws-sdk/invalid-dependency": "3.347.0",
+        "@aws-sdk/middleware-content-length": "3.347.0",
+        "@aws-sdk/middleware-endpoint": "3.347.0",
+        "@aws-sdk/middleware-host-header": "3.347.0",
+        "@aws-sdk/middleware-logger": "3.347.0",
+        "@aws-sdk/middleware-recursion-detection": "3.347.0",
+        "@aws-sdk/middleware-retry": "3.347.0",
+        "@aws-sdk/middleware-serde": "3.347.0",
+        "@aws-sdk/middleware-signing": "3.347.0",
+        "@aws-sdk/middleware-stack": "3.347.0",
+        "@aws-sdk/middleware-user-agent": "3.352.0",
+        "@aws-sdk/node-config-provider": "3.347.0",
+        "@aws-sdk/node-http-handler": "3.350.0",
+        "@aws-sdk/smithy-client": "3.347.0",
+        "@aws-sdk/types": "3.347.0",
+        "@aws-sdk/url-parser": "3.347.0",
+        "@aws-sdk/util-base64": "3.310.0",
+        "@aws-sdk/util-body-length-browser": "3.310.0",
+        "@aws-sdk/util-body-length-node": "3.310.0",
+        "@aws-sdk/util-defaults-mode-browser": "3.347.0",
+        "@aws-sdk/util-defaults-mode-node": "3.347.0",
+        "@aws-sdk/util-endpoints": "3.352.0",
+        "@aws-sdk/util-retry": "3.347.0",
+        "@aws-sdk/util-user-agent-browser": "3.347.0",
+        "@aws-sdk/util-user-agent-node": "3.347.0",
+        "@aws-sdk/util-utf8": "3.310.0",
+        "@aws-sdk/util-waiter": "3.347.0",
+        "@smithy/protocol-http": "^1.0.1",
+        "@smithy/types": "^1.0.0",
+        "tslib": "^2.5.0"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/client-sso": {
-      "version": "3.241.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.241.0.tgz",
-      "integrity": "sha512-Jm4HR+RYAqKMEYZvvWaq0NYUKKonyInOeubObXH4BLXZpmUBSdYCSjjLdNJY3jkQoxbDVPVMIurVNh5zT5SMRw==",
+      "version": "3.352.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.352.0.tgz",
+      "integrity": "sha512-oeO36rvRvYbUlsgzYtLI2/BPwXdUK4KtYw+OFmirYeONUyX5uYx8kWXD66r3oXViIYMqhyHKN3fhkiFmFcVluQ==",
       "dependencies": {
-        "@aws-crypto/sha256-browser": "2.0.0",
-        "@aws-crypto/sha256-js": "2.0.0",
-        "@aws-sdk/config-resolver": "3.234.0",
-        "@aws-sdk/fetch-http-handler": "3.226.0",
-        "@aws-sdk/hash-node": "3.226.0",
-        "@aws-sdk/invalid-dependency": "3.226.0",
-        "@aws-sdk/middleware-content-length": "3.226.0",
-        "@aws-sdk/middleware-endpoint": "3.226.0",
-        "@aws-sdk/middleware-host-header": "3.226.0",
-        "@aws-sdk/middleware-logger": "3.226.0",
-        "@aws-sdk/middleware-recursion-detection": "3.226.0",
-        "@aws-sdk/middleware-retry": "3.235.0",
-        "@aws-sdk/middleware-serde": "3.226.0",
-        "@aws-sdk/middleware-stack": "3.226.0",
-        "@aws-sdk/middleware-user-agent": "3.226.0",
-        "@aws-sdk/node-config-provider": "3.226.0",
-        "@aws-sdk/node-http-handler": "3.226.0",
-        "@aws-sdk/protocol-http": "3.226.0",
-        "@aws-sdk/smithy-client": "3.234.0",
-        "@aws-sdk/types": "3.226.0",
-        "@aws-sdk/url-parser": "3.226.0",
-        "@aws-sdk/util-base64": "3.208.0",
-        "@aws-sdk/util-body-length-browser": "3.188.0",
-        "@aws-sdk/util-body-length-node": "3.208.0",
-        "@aws-sdk/util-defaults-mode-browser": "3.234.0",
-        "@aws-sdk/util-defaults-mode-node": "3.234.0",
-        "@aws-sdk/util-endpoints": "3.241.0",
-        "@aws-sdk/util-retry": "3.229.0",
-        "@aws-sdk/util-user-agent-browser": "3.226.0",
-        "@aws-sdk/util-user-agent-node": "3.226.0",
-        "@aws-sdk/util-utf8-browser": "3.188.0",
-        "@aws-sdk/util-utf8-node": "3.208.0",
-        "tslib": "^2.3.1"
+        "@aws-crypto/sha256-browser": "3.0.0",
+        "@aws-crypto/sha256-js": "3.0.0",
+        "@aws-sdk/config-resolver": "3.347.0",
+        "@aws-sdk/fetch-http-handler": "3.347.0",
+        "@aws-sdk/hash-node": "3.347.0",
+        "@aws-sdk/invalid-dependency": "3.347.0",
+        "@aws-sdk/middleware-content-length": "3.347.0",
+        "@aws-sdk/middleware-endpoint": "3.347.0",
+        "@aws-sdk/middleware-host-header": "3.347.0",
+        "@aws-sdk/middleware-logger": "3.347.0",
+        "@aws-sdk/middleware-recursion-detection": "3.347.0",
+        "@aws-sdk/middleware-retry": "3.347.0",
+        "@aws-sdk/middleware-serde": "3.347.0",
+        "@aws-sdk/middleware-stack": "3.347.0",
+        "@aws-sdk/middleware-user-agent": "3.352.0",
+        "@aws-sdk/node-config-provider": "3.347.0",
+        "@aws-sdk/node-http-handler": "3.350.0",
+        "@aws-sdk/smithy-client": "3.347.0",
+        "@aws-sdk/types": "3.347.0",
+        "@aws-sdk/url-parser": "3.347.0",
+        "@aws-sdk/util-base64": "3.310.0",
+        "@aws-sdk/util-body-length-browser": "3.310.0",
+        "@aws-sdk/util-body-length-node": "3.310.0",
+        "@aws-sdk/util-defaults-mode-browser": "3.347.0",
+        "@aws-sdk/util-defaults-mode-node": "3.347.0",
+        "@aws-sdk/util-endpoints": "3.352.0",
+        "@aws-sdk/util-retry": "3.347.0",
+        "@aws-sdk/util-user-agent-browser": "3.347.0",
+        "@aws-sdk/util-user-agent-node": "3.347.0",
+        "@aws-sdk/util-utf8": "3.310.0",
+        "@smithy/protocol-http": "^1.0.1",
+        "@smithy/types": "^1.0.0",
+        "tslib": "^2.5.0"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/client-sso-oidc": {
-      "version": "3.241.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.241.0.tgz",
-      "integrity": "sha512-/Ml2QBGpGfUEeBrPzBZhSTBkHuXFD2EAZEIHGCBH4tKaURDI6/FoGI8P1Rl4BzoFt+II/Cr91Eox6YT9EwChsQ==",
+      "version": "3.352.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.352.0.tgz",
+      "integrity": "sha512-PQdp0KOr478CaJNohASTgtt03W8Y/qINwsalLNguK01tWIGzellg2N3bA+IdyYXU8Oz3+Ab1oIJMKkUxtuNiGg==",
       "dependencies": {
-        "@aws-crypto/sha256-browser": "2.0.0",
-        "@aws-crypto/sha256-js": "2.0.0",
-        "@aws-sdk/config-resolver": "3.234.0",
-        "@aws-sdk/fetch-http-handler": "3.226.0",
-        "@aws-sdk/hash-node": "3.226.0",
-        "@aws-sdk/invalid-dependency": "3.226.0",
-        "@aws-sdk/middleware-content-length": "3.226.0",
-        "@aws-sdk/middleware-endpoint": "3.226.0",
-        "@aws-sdk/middleware-host-header": "3.226.0",
-        "@aws-sdk/middleware-logger": "3.226.0",
-        "@aws-sdk/middleware-recursion-detection": "3.226.0",
-        "@aws-sdk/middleware-retry": "3.235.0",
-        "@aws-sdk/middleware-serde": "3.226.0",
-        "@aws-sdk/middleware-stack": "3.226.0",
-        "@aws-sdk/middleware-user-agent": "3.226.0",
-        "@aws-sdk/node-config-provider": "3.226.0",
-        "@aws-sdk/node-http-handler": "3.226.0",
-        "@aws-sdk/protocol-http": "3.226.0",
-        "@aws-sdk/smithy-client": "3.234.0",
-        "@aws-sdk/types": "3.226.0",
-        "@aws-sdk/url-parser": "3.226.0",
-        "@aws-sdk/util-base64": "3.208.0",
-        "@aws-sdk/util-body-length-browser": "3.188.0",
-        "@aws-sdk/util-body-length-node": "3.208.0",
-        "@aws-sdk/util-defaults-mode-browser": "3.234.0",
-        "@aws-sdk/util-defaults-mode-node": "3.234.0",
-        "@aws-sdk/util-endpoints": "3.241.0",
-        "@aws-sdk/util-retry": "3.229.0",
-        "@aws-sdk/util-user-agent-browser": "3.226.0",
-        "@aws-sdk/util-user-agent-node": "3.226.0",
-        "@aws-sdk/util-utf8-browser": "3.188.0",
-        "@aws-sdk/util-utf8-node": "3.208.0",
-        "tslib": "^2.3.1"
+        "@aws-crypto/sha256-browser": "3.0.0",
+        "@aws-crypto/sha256-js": "3.0.0",
+        "@aws-sdk/config-resolver": "3.347.0",
+        "@aws-sdk/fetch-http-handler": "3.347.0",
+        "@aws-sdk/hash-node": "3.347.0",
+        "@aws-sdk/invalid-dependency": "3.347.0",
+        "@aws-sdk/middleware-content-length": "3.347.0",
+        "@aws-sdk/middleware-endpoint": "3.347.0",
+        "@aws-sdk/middleware-host-header": "3.347.0",
+        "@aws-sdk/middleware-logger": "3.347.0",
+        "@aws-sdk/middleware-recursion-detection": "3.347.0",
+        "@aws-sdk/middleware-retry": "3.347.0",
+        "@aws-sdk/middleware-serde": "3.347.0",
+        "@aws-sdk/middleware-stack": "3.347.0",
+        "@aws-sdk/middleware-user-agent": "3.352.0",
+        "@aws-sdk/node-config-provider": "3.347.0",
+        "@aws-sdk/node-http-handler": "3.350.0",
+        "@aws-sdk/smithy-client": "3.347.0",
+        "@aws-sdk/types": "3.347.0",
+        "@aws-sdk/url-parser": "3.347.0",
+        "@aws-sdk/util-base64": "3.310.0",
+        "@aws-sdk/util-body-length-browser": "3.310.0",
+        "@aws-sdk/util-body-length-node": "3.310.0",
+        "@aws-sdk/util-defaults-mode-browser": "3.347.0",
+        "@aws-sdk/util-defaults-mode-node": "3.347.0",
+        "@aws-sdk/util-endpoints": "3.352.0",
+        "@aws-sdk/util-retry": "3.347.0",
+        "@aws-sdk/util-user-agent-browser": "3.347.0",
+        "@aws-sdk/util-user-agent-node": "3.347.0",
+        "@aws-sdk/util-utf8": "3.310.0",
+        "@smithy/protocol-http": "^1.0.1",
+        "@smithy/types": "^1.0.0",
+        "tslib": "^2.5.0"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/client-sts": {
-      "version": "3.241.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.241.0.tgz",
-      "integrity": "sha512-vmlG8cJzRf8skCtTJbA2wBvD2c3NQ5gZryzJvTKDS06KzBzcEpnjlLseuTekcnOiRNekbFUX5hRu5Zj3N2ReLg==",
+      "version": "3.352.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.352.0.tgz",
+      "integrity": "sha512-Lt7uSdwgOrwYx8S6Bhz76ewOeoJNFiPD+Q7v8S/mJK8T7HUE/houjomXC3UnFaJjcecjWv273zEqV67FgP5l5g==",
       "dependencies": {
-        "@aws-crypto/sha256-browser": "2.0.0",
-        "@aws-crypto/sha256-js": "2.0.0",
-        "@aws-sdk/config-resolver": "3.234.0",
-        "@aws-sdk/credential-provider-node": "3.241.0",
-        "@aws-sdk/fetch-http-handler": "3.226.0",
-        "@aws-sdk/hash-node": "3.226.0",
-        "@aws-sdk/invalid-dependency": "3.226.0",
-        "@aws-sdk/middleware-content-length": "3.226.0",
-        "@aws-sdk/middleware-endpoint": "3.226.0",
-        "@aws-sdk/middleware-host-header": "3.226.0",
-        "@aws-sdk/middleware-logger": "3.226.0",
-        "@aws-sdk/middleware-recursion-detection": "3.226.0",
-        "@aws-sdk/middleware-retry": "3.235.0",
-        "@aws-sdk/middleware-sdk-sts": "3.226.0",
-        "@aws-sdk/middleware-serde": "3.226.0",
-        "@aws-sdk/middleware-signing": "3.226.0",
-        "@aws-sdk/middleware-stack": "3.226.0",
-        "@aws-sdk/middleware-user-agent": "3.226.0",
-        "@aws-sdk/node-config-provider": "3.226.0",
-        "@aws-sdk/node-http-handler": "3.226.0",
-        "@aws-sdk/protocol-http": "3.226.0",
-        "@aws-sdk/smithy-client": "3.234.0",
-        "@aws-sdk/types": "3.226.0",
-        "@aws-sdk/url-parser": "3.226.0",
-        "@aws-sdk/util-base64": "3.208.0",
-        "@aws-sdk/util-body-length-browser": "3.188.0",
-        "@aws-sdk/util-body-length-node": "3.208.0",
-        "@aws-sdk/util-defaults-mode-browser": "3.234.0",
-        "@aws-sdk/util-defaults-mode-node": "3.234.0",
-        "@aws-sdk/util-endpoints": "3.241.0",
-        "@aws-sdk/util-retry": "3.229.0",
-        "@aws-sdk/util-user-agent-browser": "3.226.0",
-        "@aws-sdk/util-user-agent-node": "3.226.0",
-        "@aws-sdk/util-utf8-browser": "3.188.0",
-        "@aws-sdk/util-utf8-node": "3.208.0",
-        "fast-xml-parser": "4.0.11",
-        "tslib": "^2.3.1"
+        "@aws-crypto/sha256-browser": "3.0.0",
+        "@aws-crypto/sha256-js": "3.0.0",
+        "@aws-sdk/config-resolver": "3.347.0",
+        "@aws-sdk/credential-provider-node": "3.352.0",
+        "@aws-sdk/fetch-http-handler": "3.347.0",
+        "@aws-sdk/hash-node": "3.347.0",
+        "@aws-sdk/invalid-dependency": "3.347.0",
+        "@aws-sdk/middleware-content-length": "3.347.0",
+        "@aws-sdk/middleware-endpoint": "3.347.0",
+        "@aws-sdk/middleware-host-header": "3.347.0",
+        "@aws-sdk/middleware-logger": "3.347.0",
+        "@aws-sdk/middleware-recursion-detection": "3.347.0",
+        "@aws-sdk/middleware-retry": "3.347.0",
+        "@aws-sdk/middleware-sdk-sts": "3.347.0",
+        "@aws-sdk/middleware-serde": "3.347.0",
+        "@aws-sdk/middleware-signing": "3.347.0",
+        "@aws-sdk/middleware-stack": "3.347.0",
+        "@aws-sdk/middleware-user-agent": "3.352.0",
+        "@aws-sdk/node-config-provider": "3.347.0",
+        "@aws-sdk/node-http-handler": "3.350.0",
+        "@aws-sdk/smithy-client": "3.347.0",
+        "@aws-sdk/types": "3.347.0",
+        "@aws-sdk/url-parser": "3.347.0",
+        "@aws-sdk/util-base64": "3.310.0",
+        "@aws-sdk/util-body-length-browser": "3.310.0",
+        "@aws-sdk/util-body-length-node": "3.310.0",
+        "@aws-sdk/util-defaults-mode-browser": "3.347.0",
+        "@aws-sdk/util-defaults-mode-node": "3.347.0",
+        "@aws-sdk/util-endpoints": "3.352.0",
+        "@aws-sdk/util-retry": "3.347.0",
+        "@aws-sdk/util-user-agent-browser": "3.347.0",
+        "@aws-sdk/util-user-agent-node": "3.347.0",
+        "@aws-sdk/util-utf8": "3.310.0",
+        "@smithy/protocol-http": "^1.0.1",
+        "@smithy/types": "^1.0.0",
+        "fast-xml-parser": "4.2.4",
+        "tslib": "^2.5.0"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/config-resolver": {
-      "version": "3.234.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/config-resolver/-/config-resolver-3.234.0.tgz",
-      "integrity": "sha512-uZxy4wzllfvgCQxVc+Iqhde0NGAnfmV2hWR6ejadJaAFTuYNvQiRg9IqJy3pkyDPqXySiJ8Bom5PoJfgn55J/A==",
+      "version": "3.347.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/config-resolver/-/config-resolver-3.347.0.tgz",
+      "integrity": "sha512-2ja+Sf/VnUO7IQ3nKbDQ5aumYKKJUaTm/BuVJ29wNho8wYHfuf7wHZV0pDTkB8RF5SH7IpHap7zpZAj39Iq+EA==",
       "dependencies": {
-        "@aws-sdk/signature-v4": "3.226.0",
-        "@aws-sdk/types": "3.226.0",
-        "@aws-sdk/util-config-provider": "3.208.0",
-        "@aws-sdk/util-middleware": "3.226.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/types": "3.347.0",
+        "@aws-sdk/util-config-provider": "3.310.0",
+        "@aws-sdk/util-middleware": "3.347.0",
+        "tslib": "^2.5.0"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/credential-provider-env": {
-      "version": "3.226.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.226.0.tgz",
-      "integrity": "sha512-sd8uK1ojbXxaZXlthzw/VXZwCPUtU3PjObOfr3Evj7MPIM2IH8h29foOlggx939MdLQGboJf9gKvLlvKDWtJRA==",
+      "version": "3.347.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.347.0.tgz",
+      "integrity": "sha512-UnEM+LKGpXKzw/1WvYEQsC6Wj9PupYZdQOE+e2Dgy2dqk/pVFy4WueRtFXYDT2B41ppv3drdXUuKZRIDVqIgNQ==",
       "dependencies": {
-        "@aws-sdk/property-provider": "3.226.0",
-        "@aws-sdk/types": "3.226.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/property-provider": "3.347.0",
+        "@aws-sdk/types": "3.347.0",
+        "tslib": "^2.5.0"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/credential-provider-imds": {
-      "version": "3.226.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-imds/-/credential-provider-imds-3.226.0.tgz",
-      "integrity": "sha512-//z/COQm2AjYFI1Lb0wKHTQSrvLFTyuKLFQGPJsKS7DPoxGOCKB7hmYerlbl01IDoCxTdyL//TyyPxbZEOQD5Q==",
+      "version": "3.347.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-imds/-/credential-provider-imds-3.347.0.tgz",
+      "integrity": "sha512-7scCy/DCDRLIhlqTxff97LQWDnRwRXji3bxxMg+xWOTTaJe7PWx+etGSbBWaL42vsBHFShQjSLvJryEgoBktpw==",
       "dependencies": {
-        "@aws-sdk/node-config-provider": "3.226.0",
-        "@aws-sdk/property-provider": "3.226.0",
-        "@aws-sdk/types": "3.226.0",
-        "@aws-sdk/url-parser": "3.226.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/node-config-provider": "3.347.0",
+        "@aws-sdk/property-provider": "3.347.0",
+        "@aws-sdk/types": "3.347.0",
+        "@aws-sdk/url-parser": "3.347.0",
+        "tslib": "^2.5.0"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/credential-provider-ini": {
-      "version": "3.241.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.241.0.tgz",
-      "integrity": "sha512-CI+mu6h74Kzmscw35TvNkc/wYHsHPGAwP7humSHoWw53H9mVw21Ggft/dT1iFQQZWQ8BNXkzuXlNo1IlqwMgOA==",
+      "version": "3.352.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.352.0.tgz",
+      "integrity": "sha512-lnQUJznvOhI2er1u/OVf99/2JIyDH7W+6tfWNXEoVgEi4WXtdyZ+GpPNoZsmCtHB2Jwlsh51IxmYdCj6b6SdwQ==",
       "dependencies": {
-        "@aws-sdk/credential-provider-env": "3.226.0",
-        "@aws-sdk/credential-provider-imds": "3.226.0",
-        "@aws-sdk/credential-provider-process": "3.226.0",
-        "@aws-sdk/credential-provider-sso": "3.241.0",
-        "@aws-sdk/credential-provider-web-identity": "3.226.0",
-        "@aws-sdk/property-provider": "3.226.0",
-        "@aws-sdk/shared-ini-file-loader": "3.226.0",
-        "@aws-sdk/types": "3.226.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/credential-provider-env": "3.347.0",
+        "@aws-sdk/credential-provider-imds": "3.347.0",
+        "@aws-sdk/credential-provider-process": "3.347.0",
+        "@aws-sdk/credential-provider-sso": "3.352.0",
+        "@aws-sdk/credential-provider-web-identity": "3.347.0",
+        "@aws-sdk/property-provider": "3.347.0",
+        "@aws-sdk/shared-ini-file-loader": "3.347.0",
+        "@aws-sdk/types": "3.347.0",
+        "tslib": "^2.5.0"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/credential-provider-node": {
-      "version": "3.241.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.241.0.tgz",
-      "integrity": "sha512-08zPQcD5o9brQmzEipWHeHgU85aQcEF8MWLfpeyjO6e1/l7ysQ35NsS+PYtv77nLpGCx/X+ZuW/KXWoRrbw77w==",
+      "version": "3.352.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.352.0.tgz",
+      "integrity": "sha512-8UZ5EQpoqHCh+XSGq2CdhzHZyKLOwF1taDw5A/gmV4O5lAWL0AGs0cPIEUORJyggU6Hv43zZOpLgK6dMgWOLgA==",
       "dependencies": {
-        "@aws-sdk/credential-provider-env": "3.226.0",
-        "@aws-sdk/credential-provider-imds": "3.226.0",
-        "@aws-sdk/credential-provider-ini": "3.241.0",
-        "@aws-sdk/credential-provider-process": "3.226.0",
-        "@aws-sdk/credential-provider-sso": "3.241.0",
-        "@aws-sdk/credential-provider-web-identity": "3.226.0",
-        "@aws-sdk/property-provider": "3.226.0",
-        "@aws-sdk/shared-ini-file-loader": "3.226.0",
-        "@aws-sdk/types": "3.226.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/credential-provider-env": "3.347.0",
+        "@aws-sdk/credential-provider-imds": "3.347.0",
+        "@aws-sdk/credential-provider-ini": "3.352.0",
+        "@aws-sdk/credential-provider-process": "3.347.0",
+        "@aws-sdk/credential-provider-sso": "3.352.0",
+        "@aws-sdk/credential-provider-web-identity": "3.347.0",
+        "@aws-sdk/property-provider": "3.347.0",
+        "@aws-sdk/shared-ini-file-loader": "3.347.0",
+        "@aws-sdk/types": "3.347.0",
+        "tslib": "^2.5.0"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/credential-provider-process": {
-      "version": "3.226.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.226.0.tgz",
-      "integrity": "sha512-iUDMdnrTvbvaCFhWwqyXrhvQ9+ojPqPqXhwZtY1X/Qaz+73S9gXBPJHZaZb2Ke0yKE1Ql3bJbKvmmxC/qLQMng==",
+      "version": "3.347.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.347.0.tgz",
+      "integrity": "sha512-yl1z4MsaBdXd4GQ2halIvYds23S67kElyOwz7g8kaQ4kHj+UoYWxz3JVW/DGusM6XmQ9/F67utBrUVA0uhQYyw==",
       "dependencies": {
-        "@aws-sdk/property-provider": "3.226.0",
-        "@aws-sdk/shared-ini-file-loader": "3.226.0",
-        "@aws-sdk/types": "3.226.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/property-provider": "3.347.0",
+        "@aws-sdk/shared-ini-file-loader": "3.347.0",
+        "@aws-sdk/types": "3.347.0",
+        "tslib": "^2.5.0"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/credential-provider-sso": {
-      "version": "3.241.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.241.0.tgz",
-      "integrity": "sha512-6Bjd6eEIrVomRTrPrM4dlxusQm+KMJ9hLYKECCpFkwDKIK+pTgZNLRtQdalHyzwneHJPdimrm8cOv1kUQ8hPoA==",
+      "version": "3.352.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.352.0.tgz",
+      "integrity": "sha512-YiooGNy9LYN1bFqKwO2wHC++1pYReiSqQDWBeluJfC3uZWpCyIUMdeYBR1X3XZDVtK6bl5KmhxldxJ3ntt/Q4w==",
       "dependencies": {
-        "@aws-sdk/client-sso": "3.241.0",
-        "@aws-sdk/property-provider": "3.226.0",
-        "@aws-sdk/shared-ini-file-loader": "3.226.0",
-        "@aws-sdk/token-providers": "3.241.0",
-        "@aws-sdk/types": "3.226.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/client-sso": "3.352.0",
+        "@aws-sdk/property-provider": "3.347.0",
+        "@aws-sdk/shared-ini-file-loader": "3.347.0",
+        "@aws-sdk/token-providers": "3.352.0",
+        "@aws-sdk/types": "3.347.0",
+        "tslib": "^2.5.0"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/credential-provider-web-identity": {
-      "version": "3.226.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.226.0.tgz",
-      "integrity": "sha512-CCpv847rLB0SFOHz2igvUMFAzeT2fD3YnY4C8jltuJoEkn0ITn1Hlgt13nTJ5BUuvyti2mvyXZHmNzhMIMrIlw==",
+      "version": "3.347.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.347.0.tgz",
+      "integrity": "sha512-DxoTlVK8lXjS1zVphtz/Ab+jkN/IZor9d6pP2GjJHNoAIIzXfRwwj5C8vr4eTayx/5VJ7GRP91J8GJ2cKly8Qw==",
       "dependencies": {
-        "@aws-sdk/property-provider": "3.226.0",
-        "@aws-sdk/types": "3.226.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/property-provider": "3.347.0",
+        "@aws-sdk/types": "3.347.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/eventstream-codec": {
+      "version": "3.347.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-codec/-/eventstream-codec-3.347.0.tgz",
+      "integrity": "sha512-61q+SyspjsaQ4sdgjizMyRgVph2CiW4aAtfpoH69EJFJfTxTR/OqnZ9Jx/3YiYi0ksrvDenJddYodfWWJqD8/w==",
+      "dependencies": {
+        "@aws-crypto/crc32": "3.0.0",
+        "@aws-sdk/types": "3.347.0",
+        "@aws-sdk/util-hex-encoding": "3.310.0",
+        "tslib": "^2.5.0"
+      }
+    },
+    "node_modules/@aws-sdk/eventstream-serde-browser": {
+      "version": "3.347.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-serde-browser/-/eventstream-serde-browser-3.347.0.tgz",
+      "integrity": "sha512-9BLVTHWgpiTo/hl+k7qt7E9iYu43zVwJN+4TEwA9ZZB3p12068t1Hay6HgCcgJC3+LWMtw/OhvypV6vQAG4UBg==",
+      "dependencies": {
+        "@aws-sdk/eventstream-serde-universal": "3.347.0",
+        "@aws-sdk/types": "3.347.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/eventstream-serde-config-resolver": {
+      "version": "3.347.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-serde-config-resolver/-/eventstream-serde-config-resolver-3.347.0.tgz",
+      "integrity": "sha512-RcXQbNVq0PFmDqfn6+MnjCUWbbobcYVxpimaF6pMDav04o6Mcle+G2Hrefp5NlFr/lZbHW2eUKYsp1sXPaxVlQ==",
+      "dependencies": {
+        "@aws-sdk/types": "3.347.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/eventstream-serde-node": {
+      "version": "3.347.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-serde-node/-/eventstream-serde-node-3.347.0.tgz",
+      "integrity": "sha512-pgQCWH0PkHjcHs04JE7FoGAD3Ww45ffV8Op0MSLUhg9OpGa6EDoO3EOpWi9l/TALtH4f0KRV35PVyUyHJ/wEkA==",
+      "dependencies": {
+        "@aws-sdk/eventstream-serde-universal": "3.347.0",
+        "@aws-sdk/types": "3.347.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/eventstream-serde-universal": {
+      "version": "3.347.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-serde-universal/-/eventstream-serde-universal-3.347.0.tgz",
+      "integrity": "sha512-4wWj6bz6lOyDIO/dCCjwaLwRz648xzQQnf89R29sLoEqvAPP5XOB7HL+uFaQ/f5tPNh49gL6huNFSVwDm62n4Q==",
+      "dependencies": {
+        "@aws-sdk/eventstream-codec": "3.347.0",
+        "@aws-sdk/types": "3.347.0",
+        "tslib": "^2.5.0"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/fetch-http-handler": {
-      "version": "3.226.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/fetch-http-handler/-/fetch-http-handler-3.226.0.tgz",
-      "integrity": "sha512-JewZPMNEBXfi1xVnRa7pVtK/zgZD8/lQ/YnD8pq79WuMa2cwyhDtr8oqCoqsPW+WJT5ScXoMtuHxN78l8eKWgg==",
+      "version": "3.347.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/fetch-http-handler/-/fetch-http-handler-3.347.0.tgz",
+      "integrity": "sha512-sQ5P7ivY8//7wdxfA76LT1sF6V2Tyyz1qF6xXf9sihPN5Q1Y65c+SKpMzXyFSPqWZ82+SQQuDliYZouVyS6kQQ==",
       "dependencies": {
-        "@aws-sdk/protocol-http": "3.226.0",
-        "@aws-sdk/querystring-builder": "3.226.0",
-        "@aws-sdk/types": "3.226.0",
-        "@aws-sdk/util-base64": "3.208.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/protocol-http": "3.347.0",
+        "@aws-sdk/querystring-builder": "3.347.0",
+        "@aws-sdk/types": "3.347.0",
+        "@aws-sdk/util-base64": "3.310.0",
+        "tslib": "^2.5.0"
       }
     },
     "node_modules/@aws-sdk/hash-node": {
-      "version": "3.226.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/hash-node/-/hash-node-3.226.0.tgz",
-      "integrity": "sha512-MdlJhJ9/Espwd0+gUXdZRsHuostB2WxEVAszWxobP0FTT9PnicqnfK7ExmW+DUAc0ywxtEbR3e0UND65rlSTVw==",
+      "version": "3.347.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/hash-node/-/hash-node-3.347.0.tgz",
+      "integrity": "sha512-96+ml/4EaUaVpzBdOLGOxdoXOjkPgkoJp/0i1fxOJEvl8wdAQSwc3IugVK9wZkCxy2DlENtgOe6DfIOhfffm/g==",
       "dependencies": {
-        "@aws-sdk/types": "3.226.0",
-        "@aws-sdk/util-buffer-from": "3.208.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/types": "3.347.0",
+        "@aws-sdk/util-buffer-from": "3.310.0",
+        "@aws-sdk/util-utf8": "3.310.0",
+        "tslib": "^2.5.0"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/invalid-dependency": {
-      "version": "3.226.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/invalid-dependency/-/invalid-dependency-3.226.0.tgz",
-      "integrity": "sha512-QXOYFmap8g9QzRjumcRCIo2GEZkdCwd7ePQW0OABWPhKHzlJ74vvBxywjU3s39EEBEluWXtZ7Iufg6GxZM4ifw==",
+      "version": "3.347.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/invalid-dependency/-/invalid-dependency-3.347.0.tgz",
+      "integrity": "sha512-8imQcwLwqZ/wTJXZqzXT9pGLIksTRckhGLZaXT60tiBOPKuerTsus2L59UstLs5LP8TKaVZKFFSsjRIn9dQdmQ==",
       "dependencies": {
-        "@aws-sdk/types": "3.226.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/types": "3.347.0",
+        "tslib": "^2.5.0"
       }
     },
     "node_modules/@aws-sdk/is-array-buffer": {
-      "version": "3.201.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/is-array-buffer/-/is-array-buffer-3.201.0.tgz",
-      "integrity": "sha512-UPez5qLh3dNgt0DYnPD/q0mVJY84rA17QE26hVNOW3fAji8W2wrwrxdacWOxyXvlxWsVRcKmr+lay1MDqpAMfg==",
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/is-array-buffer/-/is-array-buffer-3.310.0.tgz",
+      "integrity": "sha512-urnbcCR+h9NWUnmOtet/s4ghvzsidFmspfhYaHAmSRdy9yDjdjBJMFjjsn85A1ODUktztm+cVncXjQ38WCMjMQ==",
       "dependencies": {
-        "tslib": "^2.3.1"
+        "tslib": "^2.5.0"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/middleware-content-length": {
-      "version": "3.226.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-content-length/-/middleware-content-length-3.226.0.tgz",
-      "integrity": "sha512-ksUzlHJN2JMuyavjA46a4sctvnrnITqt2tbGGWWrAuXY1mel2j+VbgnmJUiwHKUO6bTFBBeft5Vd1TSOb4JmiA==",
+      "version": "3.347.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-content-length/-/middleware-content-length-3.347.0.tgz",
+      "integrity": "sha512-i4qtWTDImMaDUtwKQPbaZpXsReiwiBomM1cWymCU4bhz81HL01oIxOxOBuiM+3NlDoCSPr3KI6txZSz/8cqXCQ==",
       "dependencies": {
-        "@aws-sdk/protocol-http": "3.226.0",
-        "@aws-sdk/types": "3.226.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/protocol-http": "3.347.0",
+        "@aws-sdk/types": "3.347.0",
+        "tslib": "^2.5.0"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/middleware-endpoint": {
-      "version": "3.226.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-endpoint/-/middleware-endpoint-3.226.0.tgz",
-      "integrity": "sha512-EvLFafjtUxTT0AC9p3aBQu1/fjhWdIeK58jIXaNFONfZ3F8QbEYUPuF/SqZvJM6cWfOO9qwYKkRDbCSTYhprIg==",
+      "version": "3.347.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-endpoint/-/middleware-endpoint-3.347.0.tgz",
+      "integrity": "sha512-unF0c6dMaUL1ffU+37Ugty43DgMnzPWXr/Jup/8GbK5fzzWT5NQq6dj9KHPubMbWeEjQbmczvhv25JuJdK8gNQ==",
       "dependencies": {
-        "@aws-sdk/middleware-serde": "3.226.0",
-        "@aws-sdk/protocol-http": "3.226.0",
-        "@aws-sdk/signature-v4": "3.226.0",
-        "@aws-sdk/types": "3.226.0",
-        "@aws-sdk/url-parser": "3.226.0",
-        "@aws-sdk/util-config-provider": "3.208.0",
-        "@aws-sdk/util-middleware": "3.226.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/middleware-serde": "3.347.0",
+        "@aws-sdk/types": "3.347.0",
+        "@aws-sdk/url-parser": "3.347.0",
+        "@aws-sdk/util-middleware": "3.347.0",
+        "tslib": "^2.5.0"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/middleware-host-header": {
-      "version": "3.226.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.226.0.tgz",
-      "integrity": "sha512-haVkWVh6BUPwKgWwkL6sDvTkcZWvJjv8AgC8jiQuSl8GLZdzHTB8Qhi3IsfFta9HAuoLjxheWBE5Z/L0UrfhLA==",
+      "version": "3.347.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.347.0.tgz",
+      "integrity": "sha512-kpKmR9OvMlnReqp5sKcJkozbj1wmlblbVSbnQAIkzeQj2xD5dnVR3Nn2ogQKxSmU1Fv7dEroBtrruJ1o3fY38A==",
       "dependencies": {
-        "@aws-sdk/protocol-http": "3.226.0",
-        "@aws-sdk/types": "3.226.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/protocol-http": "3.347.0",
+        "@aws-sdk/types": "3.347.0",
+        "tslib": "^2.5.0"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/middleware-logger": {
-      "version": "3.226.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.226.0.tgz",
-      "integrity": "sha512-m9gtLrrYnpN6yckcQ09rV7ExWOLMuq8mMPF/K3DbL/YL0TuILu9i2T1W+JuxSX+K9FMG2HrLAKivE/kMLr55xA==",
+      "version": "3.347.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.347.0.tgz",
+      "integrity": "sha512-NYC+Id5UCkVn+3P1t/YtmHt75uED06vwaKyxDy0UmB2K66PZLVtwWbLpVWrhbroaw1bvUHYcRyQ9NIfnVcXQjA==",
       "dependencies": {
-        "@aws-sdk/types": "3.226.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/types": "3.347.0",
+        "tslib": "^2.5.0"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/middleware-recursion-detection": {
-      "version": "3.226.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.226.0.tgz",
-      "integrity": "sha512-mwRbdKEUeuNH5TEkyZ5FWxp6bL2UC1WbY+LDv6YjHxmSMKpAoOueEdtU34PqDOLrpXXxIGHDFmjeGeMfktyEcA==",
+      "version": "3.347.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.347.0.tgz",
+      "integrity": "sha512-qfnSvkFKCAMjMHR31NdsT0gv5Sq/ZHTUD4yQsSLpbVQ6iYAS834lrzXt41iyEHt57Y514uG7F/Xfvude3u4icQ==",
       "dependencies": {
-        "@aws-sdk/protocol-http": "3.226.0",
-        "@aws-sdk/types": "3.226.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/protocol-http": "3.347.0",
+        "@aws-sdk/types": "3.347.0",
+        "tslib": "^2.5.0"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/middleware-retry": {
-      "version": "3.235.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-retry/-/middleware-retry-3.235.0.tgz",
-      "integrity": "sha512-50WHbJGpD3SNp9763MAlHqIhXil++JdQbKejNpHg7HsJne/ao3ub+fDOfx//mMBjpzBV25BGd5UlfL6blrClSg==",
+      "version": "3.347.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-retry/-/middleware-retry-3.347.0.tgz",
+      "integrity": "sha512-CpdM+8dCSbX96agy4FCzOfzDmhNnGBM/pxrgIVLm5nkYTLuXp/d7ubpFEUHULr+4hCd5wakHotMt7yO29NFaVw==",
       "dependencies": {
-        "@aws-sdk/protocol-http": "3.226.0",
-        "@aws-sdk/service-error-classification": "3.229.0",
-        "@aws-sdk/types": "3.226.0",
-        "@aws-sdk/util-middleware": "3.226.0",
-        "@aws-sdk/util-retry": "3.229.0",
-        "tslib": "^2.3.1",
+        "@aws-sdk/protocol-http": "3.347.0",
+        "@aws-sdk/service-error-classification": "3.347.0",
+        "@aws-sdk/types": "3.347.0",
+        "@aws-sdk/util-middleware": "3.347.0",
+        "@aws-sdk/util-retry": "3.347.0",
+        "tslib": "^2.5.0",
         "uuid": "^8.3.2"
       },
       "engines": {
@@ -599,406 +676,406 @@
       }
     },
     "node_modules/@aws-sdk/middleware-sdk-sts": {
-      "version": "3.226.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sts/-/middleware-sdk-sts-3.226.0.tgz",
-      "integrity": "sha512-NN9T/qoSD1kZvAT+VLny3NnlqgylYQcsgV3rvi/8lYzw/G/2s8VS6sm/VTWGGZhx08wZRv20MWzYu3bftcyqUg==",
+      "version": "3.347.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sts/-/middleware-sdk-sts-3.347.0.tgz",
+      "integrity": "sha512-38LJ0bkIoVF3W97x6Jyyou72YV9Cfbml4OaDEdnrCOo0EssNZM5d7RhjMvQDwww7/3OBY/BzeOcZKfJlkYUXGw==",
       "dependencies": {
-        "@aws-sdk/middleware-signing": "3.226.0",
-        "@aws-sdk/property-provider": "3.226.0",
-        "@aws-sdk/protocol-http": "3.226.0",
-        "@aws-sdk/signature-v4": "3.226.0",
-        "@aws-sdk/types": "3.226.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/middleware-signing": "3.347.0",
+        "@aws-sdk/types": "3.347.0",
+        "tslib": "^2.5.0"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/middleware-serde": {
-      "version": "3.226.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-serde/-/middleware-serde-3.226.0.tgz",
-      "integrity": "sha512-nPuOOAkSfx9TxzdKFx0X2bDlinOxGrqD7iof926K/AEflxGD1DBdcaDdjlYlPDW2CVE8LV/rAgbYuLxh/E/1VA==",
+      "version": "3.347.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-serde/-/middleware-serde-3.347.0.tgz",
+      "integrity": "sha512-x5Foi7jRbVJXDu9bHfyCbhYDH5pKK+31MmsSJ3k8rY8keXLBxm2XEEg/AIoV9/TUF9EeVvZ7F1/RmMpJnWQsEg==",
       "dependencies": {
-        "@aws-sdk/types": "3.226.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/types": "3.347.0",
+        "tslib": "^2.5.0"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/middleware-signing": {
-      "version": "3.226.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.226.0.tgz",
-      "integrity": "sha512-E6HmtPcl+IjYDDzi1xI2HpCbBq2avNWcjvCriMZWuTAtRVpnA6XDDGW5GY85IfS3A8G8vuWqEVPr8JcYUcjfew==",
+      "version": "3.347.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.347.0.tgz",
+      "integrity": "sha512-zVBF/4MGKnvhAE/J+oAL/VAehiyv+trs2dqSQXwHou9j8eA8Vm8HS2NdOwpkZQchIxTuwFlqSusDuPEdYFbvGw==",
       "dependencies": {
-        "@aws-sdk/property-provider": "3.226.0",
-        "@aws-sdk/protocol-http": "3.226.0",
-        "@aws-sdk/signature-v4": "3.226.0",
-        "@aws-sdk/types": "3.226.0",
-        "@aws-sdk/util-middleware": "3.226.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/property-provider": "3.347.0",
+        "@aws-sdk/protocol-http": "3.347.0",
+        "@aws-sdk/signature-v4": "3.347.0",
+        "@aws-sdk/types": "3.347.0",
+        "@aws-sdk/util-middleware": "3.347.0",
+        "tslib": "^2.5.0"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/middleware-stack": {
-      "version": "3.226.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-stack/-/middleware-stack-3.226.0.tgz",
-      "integrity": "sha512-85wF29LvPvpoed60fZGDYLwv1Zpd/cM0C22WSSFPw1SSJeqO4gtFYyCg2squfT3KI6kF43IIkOCJ+L7GtryPug==",
+      "version": "3.347.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-stack/-/middleware-stack-3.347.0.tgz",
+      "integrity": "sha512-Izidg4rqtYMcKuvn2UzgEpPLSmyd8ub9+LQ2oIzG3mpIzCBITq7wp40jN1iNkMg+X6KEnX9vdMJIYZsPYMCYuQ==",
       "dependencies": {
-        "tslib": "^2.3.1"
+        "tslib": "^2.5.0"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/middleware-user-agent": {
-      "version": "3.226.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.226.0.tgz",
-      "integrity": "sha512-N1WnfzCW1Y5yWhVAphf8OPGTe8Df3vmV7/LdsoQfmpkCZgLZeK2o0xITkUQhRj1mbw7yp8tVFLFV3R2lMurdAQ==",
+      "version": "3.352.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.352.0.tgz",
+      "integrity": "sha512-QGqblMTsVDqeomy22KPm9LUW8PHZXBA2Hjk9Hcw8U1uFS8IKYJrewInG3ae2+9FAcTyug4LFWDf8CRr9YH2B3Q==",
       "dependencies": {
-        "@aws-sdk/protocol-http": "3.226.0",
-        "@aws-sdk/types": "3.226.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/protocol-http": "3.347.0",
+        "@aws-sdk/types": "3.347.0",
+        "@aws-sdk/util-endpoints": "3.352.0",
+        "tslib": "^2.5.0"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/node-config-provider": {
-      "version": "3.226.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/node-config-provider/-/node-config-provider-3.226.0.tgz",
-      "integrity": "sha512-B8lQDqiRk7X5izFEUMXmi8CZLOKCTWQJU9HQf3ako+sF0gexo4nHN3jhoRWyLtcgC5S3on/2jxpAcqtm7kuY3w==",
+      "version": "3.347.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/node-config-provider/-/node-config-provider-3.347.0.tgz",
+      "integrity": "sha512-faU93d3+5uTTUcotGgMXF+sJVFjrKh+ufW+CzYKT4yUHammyaIab/IbTPWy2hIolcEGtuPeVoxXw8TXbkh/tuw==",
       "dependencies": {
-        "@aws-sdk/property-provider": "3.226.0",
-        "@aws-sdk/shared-ini-file-loader": "3.226.0",
-        "@aws-sdk/types": "3.226.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/property-provider": "3.347.0",
+        "@aws-sdk/shared-ini-file-loader": "3.347.0",
+        "@aws-sdk/types": "3.347.0",
+        "tslib": "^2.5.0"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/node-http-handler": {
-      "version": "3.226.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/node-http-handler/-/node-http-handler-3.226.0.tgz",
-      "integrity": "sha512-xQCddnZNMiPmjr3W7HYM+f5ir4VfxgJh37eqZwX6EZmyItFpNNeVzKUgA920ka1VPz/ZUYB+2OFGiX3LCLkkaA==",
+      "version": "3.350.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/node-http-handler/-/node-http-handler-3.350.0.tgz",
+      "integrity": "sha512-oD96GAlmpzYilCdC8wwyURM5lNfNHZCjm/kxBkQulHKa2kRbIrnD9GfDqdCkWA5cTpjh1NzGLT4D6e6UFDjt9w==",
       "dependencies": {
-        "@aws-sdk/abort-controller": "3.226.0",
-        "@aws-sdk/protocol-http": "3.226.0",
-        "@aws-sdk/querystring-builder": "3.226.0",
-        "@aws-sdk/types": "3.226.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/abort-controller": "3.347.0",
+        "@aws-sdk/protocol-http": "3.347.0",
+        "@aws-sdk/querystring-builder": "3.347.0",
+        "@aws-sdk/types": "3.347.0",
+        "tslib": "^2.5.0"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/property-provider": {
-      "version": "3.226.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/property-provider/-/property-provider-3.226.0.tgz",
-      "integrity": "sha512-TsljjG+Sg0LmdgfiAlWohluWKnxB/k8xenjeozZfzOr5bHmNHtdbWv6BtNvD/R83hw7SFXxbJHlD5H4u9p2NFg==",
+      "version": "3.347.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/property-provider/-/property-provider-3.347.0.tgz",
+      "integrity": "sha512-t3nJ8CYPLKAF2v9nIHOHOlF0CviQbTvbFc2L4a+A+EVd/rM4PzL3+3n8ZJsr0h7f6uD04+b5YRFgKgnaqLXlEg==",
       "dependencies": {
-        "@aws-sdk/types": "3.226.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/types": "3.347.0",
+        "tslib": "^2.5.0"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/protocol-http": {
-      "version": "3.226.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.226.0.tgz",
-      "integrity": "sha512-zWkVqiTA9RXL6y0hhfZc9bcU4DX2NI6Hw9IhQmSPeM59mdbPjJlY4bLlMr5YxywqO3yQ/ylNoAfrEzrDjlOSRg==",
+      "version": "3.347.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.347.0.tgz",
+      "integrity": "sha512-2YdBhc02Wvy03YjhGwUxF0UQgrPWEy8Iq75pfS42N+/0B/+eWX1aQgfjFxIpLg7YSjT5eKtYOQGlYd4MFTgj9g==",
       "dependencies": {
-        "@aws-sdk/types": "3.226.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/types": "3.347.0",
+        "tslib": "^2.5.0"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/querystring-builder": {
-      "version": "3.226.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-builder/-/querystring-builder-3.226.0.tgz",
-      "integrity": "sha512-LVurypuNeotO4lmirKXRC4NYrZRAyMJXuwO0f2a5ZAUJCjauwYrifKue6yCfU7bls7gut7nfcR6B99WBYpHs3g==",
+      "version": "3.347.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-builder/-/querystring-builder-3.347.0.tgz",
+      "integrity": "sha512-phtKTe6FXoV02MoPkIVV6owXI8Mwr5IBN3bPoxhcPvJG2AjEmnetSIrhb8kwc4oNhlwfZwH6Jo5ARW/VEWbZtg==",
       "dependencies": {
-        "@aws-sdk/types": "3.226.0",
-        "@aws-sdk/util-uri-escape": "3.201.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/types": "3.347.0",
+        "@aws-sdk/util-uri-escape": "3.310.0",
+        "tslib": "^2.5.0"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/querystring-parser": {
-      "version": "3.226.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-parser/-/querystring-parser-3.226.0.tgz",
-      "integrity": "sha512-FzB+VrQ47KAFxiPt2YXrKZ8AOLZQqGTLCKHzx4bjxGmwgsjV8yIbtJiJhZLMcUQV4LtGeIY9ixIqQhGvnZHE4A==",
+      "version": "3.347.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-parser/-/querystring-parser-3.347.0.tgz",
+      "integrity": "sha512-5VXOhfZz78T2W7SuXf2avfjKglx1VZgZgp9Zfhrt/Rq+MTu2D+PZc5zmJHhYigD7x83jLSLogpuInQpFMA9LgA==",
       "dependencies": {
-        "@aws-sdk/types": "3.226.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/types": "3.347.0",
+        "tslib": "^2.5.0"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/service-error-classification": {
-      "version": "3.229.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/service-error-classification/-/service-error-classification-3.229.0.tgz",
-      "integrity": "sha512-dnzWWQ0/NoWMUZ5C0DW3dPm0wC1O76Y/SpKbuJzWPkx1EYy6r8p32Ly4D9vUzrKDbRGf48YHIF2kOkBmu21CLg==",
+      "version": "3.347.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/service-error-classification/-/service-error-classification-3.347.0.tgz",
+      "integrity": "sha512-xZ3MqSY81Oy2gh5g0fCtooAbahqh9VhsF8vcKjVX8+XPbGC8y+kej82+MsMg4gYL8gRFB9u4hgYbNgIS6JTAvg==",
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/shared-ini-file-loader": {
-      "version": "3.226.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/shared-ini-file-loader/-/shared-ini-file-loader-3.226.0.tgz",
-      "integrity": "sha512-661VQefsARxVyyV2FX9V61V+nNgImk7aN2hYlFKla6BCwZfMng+dEtD0xVGyg1PfRw0qvEv5LQyxMVgHcUSevA==",
+      "version": "3.347.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/shared-ini-file-loader/-/shared-ini-file-loader-3.347.0.tgz",
+      "integrity": "sha512-Xw+zAZQVLb+xMNHChXQ29tzzLqm3AEHsD8JJnlkeFjeMnWQtXdUfOARl5s8NzAppcKQNlVe2gPzjaKjoy2jz1Q==",
       "dependencies": {
-        "@aws-sdk/types": "3.226.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/types": "3.347.0",
+        "tslib": "^2.5.0"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/signature-v4": {
-      "version": "3.226.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4/-/signature-v4-3.226.0.tgz",
-      "integrity": "sha512-/R5q5agdPd7HJB68XMzpxrNPk158EHUvkFkuRu5Qf3kkkHebEzWEBlWoVpUe6ss4rP9Tqcue6xPuaftEmhjpYw==",
+      "version": "3.347.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4/-/signature-v4-3.347.0.tgz",
+      "integrity": "sha512-58Uq1do+VsTHYkP11dTK+DF53fguoNNJL9rHRWhzP+OcYv3/mBMLoS2WPz/x9FO5mBg4ESFsug0I6mXbd36tjw==",
       "dependencies": {
-        "@aws-sdk/is-array-buffer": "3.201.0",
-        "@aws-sdk/types": "3.226.0",
-        "@aws-sdk/util-hex-encoding": "3.201.0",
-        "@aws-sdk/util-middleware": "3.226.0",
-        "@aws-sdk/util-uri-escape": "3.201.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/eventstream-codec": "3.347.0",
+        "@aws-sdk/is-array-buffer": "3.310.0",
+        "@aws-sdk/types": "3.347.0",
+        "@aws-sdk/util-hex-encoding": "3.310.0",
+        "@aws-sdk/util-middleware": "3.347.0",
+        "@aws-sdk/util-uri-escape": "3.310.0",
+        "@aws-sdk/util-utf8": "3.310.0",
+        "tslib": "^2.5.0"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/smithy-client": {
-      "version": "3.234.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/smithy-client/-/smithy-client-3.234.0.tgz",
-      "integrity": "sha512-8AtR/k4vsFvjXeQbIzq/Wy7Nbk48Ou0wUEeVYPHWHPSU8QamFWORkOwmKtKMfHAyZvmqiAPeQqHFkq+UJhWyyQ==",
+      "version": "3.347.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/smithy-client/-/smithy-client-3.347.0.tgz",
+      "integrity": "sha512-PaGTDsJLGK0sTjA6YdYQzILRlPRN3uVFyqeBUkfltXssvUzkm8z2t1lz2H4VyJLAhwnG5ZuZTNEV/2mcWrU7JQ==",
       "dependencies": {
-        "@aws-sdk/middleware-stack": "3.226.0",
-        "@aws-sdk/types": "3.226.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/middleware-stack": "3.347.0",
+        "@aws-sdk/types": "3.347.0",
+        "tslib": "^2.5.0"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/token-providers": {
-      "version": "3.241.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.241.0.tgz",
-      "integrity": "sha512-79okvuOS7V559OIL/RalIPG98wzmWxeFOChFnbEjn2pKOyGQ6FJRwLPYZaVRtNdAtnkBNgRpmFq9dX843QxhtQ==",
+      "version": "3.352.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.352.0.tgz",
+      "integrity": "sha512-cmmAgieLP/aAl9WdPiBoaC0Abd6KncSLig/ElLPoNsADR10l3QgxQcVF3YMtdX0U0d917+/SeE1PdrPD2x15cw==",
       "dependencies": {
-        "@aws-sdk/client-sso-oidc": "3.241.0",
-        "@aws-sdk/property-provider": "3.226.0",
-        "@aws-sdk/shared-ini-file-loader": "3.226.0",
-        "@aws-sdk/types": "3.226.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/client-sso-oidc": "3.352.0",
+        "@aws-sdk/property-provider": "3.347.0",
+        "@aws-sdk/shared-ini-file-loader": "3.347.0",
+        "@aws-sdk/types": "3.347.0",
+        "tslib": "^2.5.0"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/types": {
-      "version": "3.226.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.226.0.tgz",
-      "integrity": "sha512-MmmNHrWeO4man7wpOwrAhXlevqtOV9ZLcH4RhnG5LmRce0RFOApx24HoKENfFCcOyCm5LQBlsXCqi0dZWDWU0A==",
+      "version": "3.347.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.347.0.tgz",
+      "integrity": "sha512-GkCMy79mdjU9OTIe5KT58fI/6uqdf8UmMdWqVHmFJ+UpEzOci7L/uw4sOXWo7xpPzLs6cJ7s5ouGZW4GRPmHFA==",
       "dependencies": {
-        "tslib": "^2.3.1"
+        "tslib": "^2.5.0"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/url-parser": {
-      "version": "3.226.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/url-parser/-/url-parser-3.226.0.tgz",
-      "integrity": "sha512-p5RLE0QWyP0OcTOLmFcLdVgUcUEzmEfmdrnOxyNzomcYb0p3vUagA5zfa1HVK2azsQJFBv28GfvMnba9bGhObg==",
+      "version": "3.347.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/url-parser/-/url-parser-3.347.0.tgz",
+      "integrity": "sha512-lhrnVjxdV7hl+yCnJfDZOaVLSqKjxN20MIOiijRiqaWGLGEAiSqBreMhL89X1WKCifxAs4zZf9YB9SbdziRpAA==",
       "dependencies": {
-        "@aws-sdk/querystring-parser": "3.226.0",
-        "@aws-sdk/types": "3.226.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/querystring-parser": "3.347.0",
+        "@aws-sdk/types": "3.347.0",
+        "tslib": "^2.5.0"
       }
     },
     "node_modules/@aws-sdk/util-base64": {
-      "version": "3.208.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-base64/-/util-base64-3.208.0.tgz",
-      "integrity": "sha512-PQniZph5A6N7uuEOQi+1hnMz/FSOK/8kMFyFO+4DgA1dZ5pcKcn5wiFwHkcTb/BsgVqQa3Jx0VHNnvhlS8JyTg==",
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-base64/-/util-base64-3.310.0.tgz",
+      "integrity": "sha512-v3+HBKQvqgdzcbL+pFswlx5HQsd9L6ZTlyPVL2LS9nNXnCcR3XgGz9jRskikRUuUvUXtkSG1J88GAOnJ/apTPg==",
       "dependencies": {
-        "@aws-sdk/util-buffer-from": "3.208.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/util-buffer-from": "3.310.0",
+        "tslib": "^2.5.0"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/util-body-length-browser": {
-      "version": "3.188.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-browser/-/util-body-length-browser-3.188.0.tgz",
-      "integrity": "sha512-8VpnwFWXhnZ/iRSl9mTf+VKOX9wDE8QtN4bj9pBfxwf90H1X7E8T6NkiZD3k+HubYf2J94e7DbeHs7fuCPW5Qg==",
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-browser/-/util-body-length-browser-3.310.0.tgz",
+      "integrity": "sha512-sxsC3lPBGfpHtNTUoGXMQXLwjmR0zVpx0rSvzTPAuoVILVsp5AU/w5FphNPxD5OVIjNbZv9KsKTuvNTiZjDp9g==",
       "dependencies": {
-        "tslib": "^2.3.1"
+        "tslib": "^2.5.0"
       }
     },
     "node_modules/@aws-sdk/util-body-length-node": {
-      "version": "3.208.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-node/-/util-body-length-node-3.208.0.tgz",
-      "integrity": "sha512-3zj50e5g7t/MQf53SsuuSf0hEELzMtD8RX8C76f12OSRo2Bca4FLLYHe0TZbxcfQHom8/hOaeZEyTyMogMglqg==",
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-node/-/util-body-length-node-3.310.0.tgz",
+      "integrity": "sha512-2tqGXdyKhyA6w4zz7UPoS8Ip+7sayOg9BwHNidiGm2ikbDxm1YrCfYXvCBdwaJxa4hJfRVz+aL9e+d3GqPI9pQ==",
       "dependencies": {
-        "tslib": "^2.3.1"
+        "tslib": "^2.5.0"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/util-buffer-from": {
-      "version": "3.208.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-buffer-from/-/util-buffer-from-3.208.0.tgz",
-      "integrity": "sha512-7L0XUixNEFcLUGPeBF35enCvB9Xl+K6SQsmbrPk1P3mlV9mguWSDQqbOBwY1Ir0OVbD6H/ZOQU7hI/9RtRI0Zw==",
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-buffer-from/-/util-buffer-from-3.310.0.tgz",
+      "integrity": "sha512-i6LVeXFtGih5Zs8enLrt+ExXY92QV25jtEnTKHsmlFqFAuL3VBeod6boeMXkN2p9lbSVVQ1sAOOYZOHYbYkntw==",
       "dependencies": {
-        "@aws-sdk/is-array-buffer": "3.201.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/is-array-buffer": "3.310.0",
+        "tslib": "^2.5.0"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/util-config-provider": {
-      "version": "3.208.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-config-provider/-/util-config-provider-3.208.0.tgz",
-      "integrity": "sha512-DSRqwrERUsT34ug+anlMBIFooBEGwM8GejC7q00Y/9IPrQy50KnG5PW2NiTjuLKNi7pdEOlwTSEocJE15eDZIg==",
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-config-provider/-/util-config-provider-3.310.0.tgz",
+      "integrity": "sha512-xIBaYo8dwiojCw8vnUcIL4Z5tyfb1v3yjqyJKJWV/dqKUFOOS0U591plmXbM+M/QkXyML3ypon1f8+BoaDExrg==",
       "dependencies": {
-        "tslib": "^2.3.1"
+        "tslib": "^2.5.0"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/util-defaults-mode-browser": {
-      "version": "3.234.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-browser/-/util-defaults-mode-browser-3.234.0.tgz",
-      "integrity": "sha512-IHMKXjTbOD8XMz5+2oCOsVP94BYb9YyjXdns0aAXr2NAo7k2+RCzXQ2DebJXppGda1F6opFutoKwyVSN0cmbMw==",
+      "version": "3.347.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-browser/-/util-defaults-mode-browser-3.347.0.tgz",
+      "integrity": "sha512-+JHFA4reWnW/nMWwrLKqL2Lm/biw/Dzi/Ix54DAkRZ08C462jMKVnUlzAI+TfxQE3YLm99EIa0G7jiEA+p81Qw==",
       "dependencies": {
-        "@aws-sdk/property-provider": "3.226.0",
-        "@aws-sdk/types": "3.226.0",
+        "@aws-sdk/property-provider": "3.347.0",
+        "@aws-sdk/types": "3.347.0",
         "bowser": "^2.11.0",
-        "tslib": "^2.3.1"
+        "tslib": "^2.5.0"
       },
       "engines": {
         "node": ">= 10.0.0"
       }
     },
     "node_modules/@aws-sdk/util-defaults-mode-node": {
-      "version": "3.234.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-node/-/util-defaults-mode-node-3.234.0.tgz",
-      "integrity": "sha512-UGjQ+OjBYYhxFVtUY+jtr0ZZgzZh6OHtYwRhFt8IHewJXFCfZTyfsbX20szBj5y1S4HRIUJ7cwBLIytTqMbI5w==",
+      "version": "3.347.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-node/-/util-defaults-mode-node-3.347.0.tgz",
+      "integrity": "sha512-A8BzIVhAAZE5WEukoAN2kYebzTc99ZgncbwOmgCCbvdaYlk5tzguR/s+uoT4G0JgQGol/4hAMuJEl7elNgU6RQ==",
       "dependencies": {
-        "@aws-sdk/config-resolver": "3.234.0",
-        "@aws-sdk/credential-provider-imds": "3.226.0",
-        "@aws-sdk/node-config-provider": "3.226.0",
-        "@aws-sdk/property-provider": "3.226.0",
-        "@aws-sdk/types": "3.226.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/config-resolver": "3.347.0",
+        "@aws-sdk/credential-provider-imds": "3.347.0",
+        "@aws-sdk/node-config-provider": "3.347.0",
+        "@aws-sdk/property-provider": "3.347.0",
+        "@aws-sdk/types": "3.347.0",
+        "tslib": "^2.5.0"
       },
       "engines": {
         "node": ">= 10.0.0"
       }
     },
     "node_modules/@aws-sdk/util-endpoints": {
-      "version": "3.241.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.241.0.tgz",
-      "integrity": "sha512-jVf8bKrN22Ey0xLmj75sL7EUvm5HFpuOMkXsZkuXycKhCwLBcEUWlvtJYtRjOU1zScPQv9GMJd2QXQglp34iOQ==",
+      "version": "3.352.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.352.0.tgz",
+      "integrity": "sha512-PjWMPdoIUWfBPgAWLyOrWFbdSS/3DJtc0OmFb/JrE8C8rKFYl+VGW5f1p0cVdRWiDR0xCGr0s67p8itAakVqjw==",
       "dependencies": {
-        "@aws-sdk/types": "3.226.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/types": "3.347.0",
+        "tslib": "^2.5.0"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/util-hex-encoding": {
-      "version": "3.201.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-hex-encoding/-/util-hex-encoding-3.201.0.tgz",
-      "integrity": "sha512-7t1vR1pVxKx0motd3X9rI3m/xNp78p3sHtP5yo4NP4ARpxyJ0fokBomY8ScaH2D/B+U5o9ARxldJUdMqyBlJcA==",
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-hex-encoding/-/util-hex-encoding-3.310.0.tgz",
+      "integrity": "sha512-sVN7mcCCDSJ67pI1ZMtk84SKGqyix6/0A1Ab163YKn+lFBQRMKexleZzpYzNGxYzmQS6VanP/cfU7NiLQOaSfA==",
       "dependencies": {
-        "tslib": "^2.3.1"
+        "tslib": "^2.5.0"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/util-locate-window": {
-      "version": "3.208.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.208.0.tgz",
-      "integrity": "sha512-iua1A2+P7JJEDHVgvXrRJSvsnzG7stYSGQnBVphIUlemwl6nN5D+QrgbjECtrbxRz8asYFHSzhdhECqN+tFiBg==",
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.310.0.tgz",
+      "integrity": "sha512-qo2t/vBTnoXpjKxlsC2e1gBrRm80M3bId27r0BRB2VniSSe7bL1mmzM+/HFtujm0iAxtPM+aLEflLJlJeDPg0w==",
       "dependencies": {
-        "tslib": "^2.3.1"
+        "tslib": "^2.5.0"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/util-middleware": {
-      "version": "3.226.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-middleware/-/util-middleware-3.226.0.tgz",
-      "integrity": "sha512-B96CQnwX4gRvQdaQkdUtqvDPkrptV5+va6FVeJOocU/DbSYMAScLxtR3peMS8cnlOT6nL1Eoa42OI9AfZz1VwQ==",
+      "version": "3.347.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-middleware/-/util-middleware-3.347.0.tgz",
+      "integrity": "sha512-8owqUA3ePufeYTUvlzdJ7Z0miLorTwx+rNol5lourGQZ9JXsVMo23+yGA7nOlFuXSGkoKpMOtn6S0BT2bcfeiw==",
       "dependencies": {
-        "tslib": "^2.3.1"
+        "tslib": "^2.5.0"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/util-retry": {
-      "version": "3.229.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-retry/-/util-retry-3.229.0.tgz",
-      "integrity": "sha512-0zKTqi0P1inD0LzIMuXRIYYQ/8c1lWMg/cfiqUcIAF1TpatlpZuN7umU0ierpBFud7S+zDgg0oemh+Nj8xliJw==",
+      "version": "3.347.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-retry/-/util-retry-3.347.0.tgz",
+      "integrity": "sha512-NxnQA0/FHFxriQAeEgBonA43Q9/VPFQa8cfJDuT2A1YZruMasgjcltoZszi1dvoIRWSZsFTW42eY2gdOd0nffQ==",
       "dependencies": {
-        "@aws-sdk/service-error-classification": "3.229.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/service-error-classification": "3.347.0",
+        "tslib": "^2.5.0"
       },
       "engines": {
         "node": ">= 14.0.0"
       }
     },
     "node_modules/@aws-sdk/util-uri-escape": {
-      "version": "3.201.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-uri-escape/-/util-uri-escape-3.201.0.tgz",
-      "integrity": "sha512-TeTWbGx4LU2c5rx0obHeDFeO9HvwYwQtMh1yniBz00pQb6Qt6YVOETVQikRZ+XRQwEyCg/dA375UplIpiy54mA==",
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-uri-escape/-/util-uri-escape-3.310.0.tgz",
+      "integrity": "sha512-drzt+aB2qo2LgtDoiy/3sVG8w63cgLkqFIa2NFlGpUgHFWTXkqtbgf4L5QdjRGKWhmZsnqkbtL7vkSWEcYDJ4Q==",
       "dependencies": {
-        "tslib": "^2.3.1"
+        "tslib": "^2.5.0"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/util-user-agent-browser": {
-      "version": "3.226.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.226.0.tgz",
-      "integrity": "sha512-PhBIu2h6sPJPcv2I7ELfFizdl5pNiL4LfxrasMCYXQkJvVnoXztHA1x+CQbXIdtZOIlpjC+6BjDcE0uhnpvfcA==",
+      "version": "3.347.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.347.0.tgz",
+      "integrity": "sha512-ydxtsKVtQefgbk1Dku1q7pMkjDYThauG9/8mQkZUAVik55OUZw71Zzr3XO8J8RKvQG8lmhPXuAQ0FKAyycc0RA==",
       "dependencies": {
-        "@aws-sdk/types": "3.226.0",
+        "@aws-sdk/types": "3.347.0",
         "bowser": "^2.11.0",
-        "tslib": "^2.3.1"
+        "tslib": "^2.5.0"
       }
     },
     "node_modules/@aws-sdk/util-user-agent-node": {
-      "version": "3.226.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.226.0.tgz",
-      "integrity": "sha512-othPc5Dz/pkYkxH+nZPhc1Al0HndQT8zHD4e9h+EZ+8lkd8n+IsnLfTS/mSJWrfiC6UlNRVw55cItstmJyMe/A==",
+      "version": "3.347.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.347.0.tgz",
+      "integrity": "sha512-6X0b9qGsbD1s80PmbaB6v1/ZtLfSx6fjRX8caM7NN0y/ObuLoX8LhYnW6WlB2f1+xb4EjaCNgpP/zCf98MXosw==",
       "dependencies": {
-        "@aws-sdk/node-config-provider": "3.226.0",
-        "@aws-sdk/types": "3.226.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/node-config-provider": "3.347.0",
+        "@aws-sdk/types": "3.347.0",
+        "tslib": "^2.5.0"
       },
       "engines": {
         "node": ">=14.0.0"
@@ -1012,34 +1089,34 @@
         }
       }
     },
-    "node_modules/@aws-sdk/util-utf8-browser": {
-      "version": "3.188.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-browser/-/util-utf8-browser-3.188.0.tgz",
-      "integrity": "sha512-jt627x0+jE+Ydr9NwkFstg3cUvgWh56qdaqAMDsqgRlKD21md/6G226z/Qxl7lb1VEW2LlmCx43ai/37Qwcj2Q==",
+    "node_modules/@aws-sdk/util-utf8": {
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8/-/util-utf8-3.310.0.tgz",
+      "integrity": "sha512-DnLfFT8uCO22uOJc0pt0DsSNau1GTisngBCDw8jQuWT5CqogMJu4b/uXmwEqfj8B3GX6Xsz8zOd6JpRlPftQoA==",
       "dependencies": {
-        "tslib": "^2.3.1"
-      }
-    },
-    "node_modules/@aws-sdk/util-utf8-node": {
-      "version": "3.208.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-node/-/util-utf8-node-3.208.0.tgz",
-      "integrity": "sha512-jKY87Acv0yWBdFxx6bveagy5FYjz+dtV8IPT7ay1E2WPWH1czoIdMAkc8tSInK31T6CRnHWkLZ1qYwCbgRfERQ==",
-      "dependencies": {
-        "@aws-sdk/util-buffer-from": "3.208.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/util-buffer-from": "3.310.0",
+        "tslib": "^2.5.0"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
-    "node_modules/@aws-sdk/util-waiter": {
-      "version": "3.226.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-waiter/-/util-waiter-3.226.0.tgz",
-      "integrity": "sha512-qYQMRxnu5k8qQihJXoIWMkBOj0+XkHHj/drLdbRnwL6ni6NcG8++cs9M3DSjIcxmxgF/7SLpDjn1H3sC7cYo4g==",
+    "node_modules/@aws-sdk/util-utf8-browser": {
+      "version": "3.259.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-browser/-/util-utf8-browser-3.259.0.tgz",
+      "integrity": "sha512-UvFa/vR+e19XookZF8RzFZBrw2EUkQWxiBW0yYQAhvk3C+QVGl0H3ouca8LDBlBfQKXwmW3huo/59H8rwb1wJw==",
       "dependencies": {
-        "@aws-sdk/abort-controller": "3.226.0",
-        "@aws-sdk/types": "3.226.0",
         "tslib": "^2.3.1"
+      }
+    },
+    "node_modules/@aws-sdk/util-waiter": {
+      "version": "3.347.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-waiter/-/util-waiter-3.347.0.tgz",
+      "integrity": "sha512-3ze/0PkwkzUzLncukx93tZgGL0JX9NaP8DxTi6WzflnL/TEul5Z63PCruRNK0om17iZYAWKrf8q2mFoHYb4grA==",
+      "dependencies": {
+        "@aws-sdk/abort-controller": "3.347.0",
+        "@aws-sdk/types": "3.347.0",
+        "tslib": "^2.5.0"
       },
       "engines": {
         "node": ">=14.0.0"
@@ -2320,6 +2397,29 @@
       },
       "funding": {
         "url": "https://github.com/sindresorhus/is?sponsor=1"
+      }
+    },
+    "node_modules/@smithy/protocol-http": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-1.0.1.tgz",
+      "integrity": "sha512-9OrEn0WfOVtBNYJUjUAn9AOiJ4lzERCJJ/JeZs8E6yajTGxBaFRxUnNBHiNqoDJVg076hY36UmEnPx7xXrvUSg==",
+      "dependencies": {
+        "@smithy/types": "^1.0.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/types": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-1.0.0.tgz",
+      "integrity": "sha512-kc1m5wPBHQCTixwuaOh9vnak/iJm21DrSf9UK6yDE5S3mQQ4u11pqAUiKWnlrZnYkeLfAI9UEHj9OaMT1v5Umg==",
+      "dependencies": {
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@szmarczak/http-timer": {
@@ -5858,18 +5958,24 @@
       "dev": true
     },
     "node_modules/fast-xml-parser": {
-      "version": "4.0.11",
-      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.0.11.tgz",
-      "integrity": "sha512-4aUg3aNRR/WjQAcpceODG1C3x3lFANXRo8+1biqfieHmg9pyMt7qB4lQV/Ta6sJCTbA5vfD8fnA8S54JATiFUA==",
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.2.4.tgz",
+      "integrity": "sha512-fbfMDvgBNIdDJLdLOwacjFAPYt67tr31H9ZhWSm45CDAxvd0I6WTlSOUo7K2P/K5sA5JgMKG64PI3DMcaFdWpQ==",
+      "funding": [
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/naturalintelligence"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
       "dependencies": {
         "strnum": "^1.0.5"
       },
       "bin": {
         "fxparser": "src/cli/cli.js"
-      },
-      "funding": {
-        "type": "paypal",
-        "url": "https://paypal.me/naturalintelligence"
       }
     },
     "node_modules/fastest-levenshtein": {
@@ -11909,9 +12015,9 @@
       }
     },
     "node_modules/tslib": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
-      "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="
+      "version": "2.5.3",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.3.tgz",
+      "integrity": "sha512-mSxlJJwl3BMEQCUNnxXBU9jP4JBktcEGhURcPR6VQVlnP0FdDEsIaz0C35dXNGLyRfrATNofF0F5p2KPxQgB+w=="
     },
     "node_modules/type": {
       "version": "2.7.2",

--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
     ]
   },
   "dependencies": {
-    "@aws-sdk/client-lambda": "^3.241.0",
+    "@aws-sdk/client-lambda": "^3.352.0",
     "@hapi/boom": "^10.0.0",
     "@hapi/h2o2": "^10.0.0",
     "@hapi/hapi": "^21.1.0",


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->
Fixes a security vulnerability issue caused by `fast-xml-parser` deprecated version by upgrading `aws-sdk/client-lambda` that is using it as a dependency
## Motivation and Context
Fixes [#1701](https://github.com/dherault/serverless-offline/issues/1701)

## How Has This Been Tested?
- Tested locally in my project
