### PR TITLE
feat: add support for java17 runtime

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -51,7 +51,7 @@
         "mocha": "^10.2.0",
         "nyc": "^15.1.0",
         "prettier": "^2.8.1",
-        "serverless": "^3.26.0",
+        "serverless": "^3.31.0",
         "standard-version": "^9.5.0"
       },
       "engines": {
@@ -1983,29 +1983,29 @@
       }
     },
     "node_modules/@serverless/dashboard-plugin": {
-      "version": "6.2.2",
-      "resolved": "https://registry.npmjs.org/@serverless/dashboard-plugin/-/dashboard-plugin-6.2.2.tgz",
-      "integrity": "sha512-h3zOprpuWZCdAP7qoOKT2nboB+AaxMkGoSzOD0jIBpt9s0cXqLE2VFjR2vKn8Cvam47Qa3XYnT2/XN6tR6rZgQ==",
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/@serverless/dashboard-plugin/-/dashboard-plugin-6.2.3.tgz",
+      "integrity": "sha512-iTZhpZbiVl6G2AyfgoqxemqqpG4pUceWys3GsyZtjimnfnGd2UFBOMVUMTavLhYia7lQc4kQVuXQ+afLlkg+pQ==",
       "dev": true,
       "dependencies": {
         "@serverless/event-mocks": "^1.1.1",
         "@serverless/platform-client": "^4.3.2",
-        "@serverless/utils": "^6.0.3",
+        "@serverless/utils": "^6.8.2",
         "child-process-ext": "^2.1.1",
         "chokidar": "^3.5.3",
         "flat": "^5.0.2",
         "fs-extra": "^9.1.0",
         "js-yaml": "^4.1.0",
-        "jszip": "^3.9.1",
+        "jszip": "^3.10.1",
         "lodash": "^4.17.21",
         "memoizee": "^0.4.15",
-        "ncjsm": "^4.3.0",
+        "ncjsm": "^4.3.2",
         "node-dir": "^0.1.17",
-        "node-fetch": "^2.6.7",
+        "node-fetch": "^2.6.8",
         "open": "^7.4.2",
-        "semver": "^7.3.7",
-        "simple-git": "^3.7.0",
-        "type": "^2.6.0",
+        "semver": "^7.3.8",
+        "simple-git": "^3.16.0",
+        "type": "^2.7.2",
         "uuid": "^8.3.2",
         "yamljs": "^0.3.0"
       },
@@ -2059,9 +2059,9 @@
       }
     },
     "node_modules/@serverless/dashboard-plugin/node_modules/node-fetch": {
-      "version": "2.6.7",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
-      "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
+      "version": "2.6.12",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.12.tgz",
+      "integrity": "sha512-C/fGU2E8ToujUivIO0H+tpQ6HWo4eEmchoPIoXtxCrVghxdKq+QOHqEZW7tuP3KlV3bC8FRMO5nMCC7Zm1VP6g==",
       "dev": true,
       "dependencies": {
         "whatwg-url": "^5.0.0"
@@ -2095,9 +2095,9 @@
       }
     },
     "node_modules/@serverless/dashboard-plugin/node_modules/semver": {
-      "version": "7.3.8",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
-      "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
+      "version": "7.5.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+      "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
       "dev": true,
       "dependencies": {
         "lru-cache": "^6.0.0"
@@ -2179,13 +2179,13 @@
       }
     },
     "node_modules/@serverless/utils": {
-      "version": "6.8.2",
-      "resolved": "https://registry.npmjs.org/@serverless/utils/-/utils-6.8.2.tgz",
-      "integrity": "sha512-FW8zdG8OPoF6qgyutiMhz4m/5SxbQjoQdbaGcW3wU6xe3QzQh41Hif7I3Xuu4J62CvxiWuz19sxNDJz2mTcskw==",
+      "version": "6.11.2",
+      "resolved": "https://registry.npmjs.org/@serverless/utils/-/utils-6.11.2.tgz",
+      "integrity": "sha512-Uww5DM78K+bHmukNgVX3Yieu7CVnOKvpUhxxRe+5WiYBV7mNrLiZr9bNAtUSNOYFS4tU5Ig5YlMCCForCCYxEw==",
       "dependencies": {
         "archive-type": "^4.0.0",
         "chalk": "^4.1.2",
-        "ci-info": "^3.5.0",
+        "ci-info": "^3.8.0",
         "cli-progress-footer": "^2.3.2",
         "content-disposition": "^0.5.4",
         "d": "^1.0.1",
@@ -2196,7 +2196,7 @@
         "file-type": "^16.5.4",
         "filenamify": "^4.3.0",
         "get-stream": "^6.0.1",
-        "got": "^11.8.5",
+        "got": "^11.8.6",
         "inquirer": "^8.2.5",
         "js-yaml": "^4.1.0",
         "jwt-decode": "^3.1.2",
@@ -2205,9 +2205,10 @@
         "log-node": "^8.0.3",
         "make-dir": "^3.1.0",
         "memoizee": "^0.4.15",
-        "ncjsm": "^4.3.1",
-        "node-fetch": "^2.6.7",
-        "open": "^8.4.0",
+        "ms": "^2.1.3",
+        "ncjsm": "^4.3.2",
+        "node-fetch": "^2.6.11",
+        "open": "^8.4.2",
         "p-event": "^4.2.0",
         "supports-color": "^8.1.1",
         "timers-ext": "^0.1.7",
@@ -2292,10 +2293,15 @@
         "js-yaml": "bin/js-yaml.js"
       }
     },
+    "node_modules/@serverless/utils/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
+    },
     "node_modules/@serverless/utils/node_modules/node-fetch": {
-      "version": "2.6.7",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
-      "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
+      "version": "2.6.12",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.12.tgz",
+      "integrity": "sha512-C/fGU2E8ToujUivIO0H+tpQ6HWo4eEmchoPIoXtxCrVghxdKq+QOHqEZW7tuP3KlV3bC8FRMO5nMCC7Zm1VP6g==",
       "dependencies": {
         "whatwg-url": "^5.0.0"
       },
@@ -2369,9 +2375,9 @@
       }
     },
     "node_modules/@types/lodash": {
-      "version": "4.14.191",
-      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.191.tgz",
-      "integrity": "sha512-BdZ5BCCvho3EIXw6wUCXHe7rS53AIDPLE+JzwgT+OsJk53oBfbSmZZ7CX4VaRoN78N+TJpFi9QPlfIVNmJYWxQ==",
+      "version": "4.14.195",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.195.tgz",
+      "integrity": "sha512-Hwx9EUgdwf2GLarOjQp5ZH8ZmblzcbTBC2wtQWNKARBSxM9ezRIAUpeDTgoQRAFB0+8CNWXVA9+MaSOzOF3nPg==",
       "dev": true
     },
     "node_modules/@types/minimist": {
@@ -2863,9 +2869,9 @@
       }
     },
     "node_modules/aws-sdk": {
-      "version": "2.1287.0",
-      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.1287.0.tgz",
-      "integrity": "sha512-mtfDstUdFNn8FnBaXs2KAaQ0cgDIiwlqwC2UptUKWWrugjZHAoRacfD/6bnah1Kwhu43F9CDEe5QLHnQtymNkw==",
+      "version": "2.1413.0",
+      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.1413.0.tgz",
+      "integrity": "sha512-vKpjC7iRwOhgv7P0xw90mVGO//2rqVPJKyYIs7uxLzSV0JzriVD+yqktOu/Hz6/phOmAd1cMIeFgpEC9ynrppg==",
       "dev": true,
       "dependencies": {
         "buffer": "4.9.2",
@@ -2877,7 +2883,7 @@
         "url": "0.10.3",
         "util": "^0.12.4",
         "uuid": "8.0.0",
-        "xml2js": "0.4.19"
+        "xml2js": "0.5.0"
       },
       "engines": {
         "node": ">= 10.0.0"
@@ -3452,9 +3458,9 @@
       }
     },
     "node_modules/ci-info": {
-      "version": "3.7.1",
-      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.7.1.tgz",
-      "integrity": "sha512-4jYS4MOAaCIStSRwiuxc4B8MYhIe676yO1sYGzARnjXkWpmzZMMYxY6zu8WYWDhSuth5zhrQ1rhNSibyyvv4/w==",
+      "version": "3.8.0",
+      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.8.0.tgz",
+      "integrity": "sha512-eXTggHWSooYhq49F2opQhuHWgzucfF2YgODK4e1566GQs5BIfP30B0oenwBJHfWxAs2fyPB1s7Mg949zLf61Yw==",
       "funding": [
         {
           "type": "github",
@@ -4413,9 +4419,9 @@
       }
     },
     "node_modules/dayjs": {
-      "version": "1.11.7",
-      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.7.tgz",
-      "integrity": "sha512-+Yw9U6YO5TQohxLcIkrXBeY73WP3ejHWVvx8XCk3gxvQDCTEmS48ZrSZCKciI7Bhl/uCMyxYtE9UqRILmFphkQ==",
+      "version": "1.11.9",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.9.tgz",
+      "integrity": "sha512-QvzAURSbQ0pKdIye2txOzNaHmxtUBXerpY0FJsFXUMKbIZeFm5ht1LS/jFsrncjnmtv8HsG0W2g6c0zUjZWmpA==",
       "dev": true
     },
     "node_modules/debug": {
@@ -4845,18 +4851,21 @@
       }
     },
     "node_modules/dotenv": {
-      "version": "16.0.3",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.0.3.tgz",
-      "integrity": "sha512-7GO6HghkA5fYG9TYnNxi14/7K9f5occMlp3zXAuSxn7CKCxt9xbNWG7yF8hTCSUchlfWSe3uLmlPfigevRItzQ==",
+      "version": "16.3.1",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.3.1.tgz",
+      "integrity": "sha512-IPzF4w4/Rd94bA9imS68tZBaYyBWSCE47V1RGuMrB94iyTOIEwRmVL2x/4An+6mETpLrKJ5hQkB8W4kFAadeIQ==",
       "dev": true,
       "engines": {
         "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/motdotla/dotenv?sponsor=1"
       }
     },
     "node_modules/dotenv-expand": {
-      "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/dotenv-expand/-/dotenv-expand-9.0.0.tgz",
-      "integrity": "sha512-uW8Hrhp5ammm9x7kBLR6jDfujgaDarNA02tprvZdyrJ7MpdzD1KyrIHG4l+YoC2fJ2UcdFdNWNWIjt+sexBHJw==",
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/dotenv-expand/-/dotenv-expand-10.0.0.tgz",
+      "integrity": "sha512-GopVGCpVS1UKH75VKHGuQFqS1Gusej0z4FyQkPdwjil2gNIv+LNsqBlboOzpJFZKVT95GkCyWJbBSdFEFUWI2A==",
       "dev": true,
       "engines": {
         "node": ">=12"
@@ -5995,9 +6004,9 @@
       }
     },
     "node_modules/filesize": {
-      "version": "10.0.6",
-      "resolved": "https://registry.npmjs.org/filesize/-/filesize-10.0.6.tgz",
-      "integrity": "sha512-rzpOZ4C9vMFDqOa6dNpog92CoLYjD79dnjLk2TYDDtImRIyLTOzqojCb05Opd1WuiWjs+fshhCgTd8cl7y5t+g==",
+      "version": "10.0.7",
+      "resolved": "https://registry.npmjs.org/filesize/-/filesize-10.0.7.tgz",
+      "integrity": "sha512-iMRG7Qo9nayLoU3PNCiLizYtsy4W1ClrapeCwEgtiQelOAOuRJiw4QaLI+sSr8xr901dgHv+EYP2bCusGZgoiA==",
       "dev": true,
       "engines": {
         "node": ">= 10.4.0"
@@ -6639,9 +6648,9 @@
       }
     },
     "node_modules/graceful-fs": {
-      "version": "4.2.10",
-      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.10.tgz",
-      "integrity": "sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA=="
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ=="
     },
     "node_modules/grapheme-splitter": {
       "version": "1.0.4",
@@ -7738,10 +7747,76 @@
       "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
       "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ=="
     },
+    "node_modules/json-colorizer": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/json-colorizer/-/json-colorizer-2.2.2.tgz",
+      "integrity": "sha512-56oZtwV1piXrQnRNTtJeqRv+B9Y/dXAYLqBBaYl/COcUdoZxgLBLAO88+CnkbT6MxNs0c5E9mPBIb2sFcNz3vw==",
+      "dev": true,
+      "dependencies": {
+        "chalk": "^2.4.1",
+        "lodash.get": "^4.4.2"
+      }
+    },
+    "node_modules/json-colorizer/node_modules/ansi-styles": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+      "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+      "dev": true,
+      "dependencies": {
+        "color-convert": "^1.9.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/json-colorizer/node_modules/chalk": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+      "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^3.2.1",
+        "escape-string-regexp": "^1.0.5",
+        "supports-color": "^5.3.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/json-colorizer/node_modules/escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/json-colorizer/node_modules/has-flag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+      "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/json-colorizer/node_modules/supports-color": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+      "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/json-cycle": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/json-cycle/-/json-cycle-1.3.0.tgz",
-      "integrity": "sha512-FD/SedD78LCdSvJaOUQAXseT8oQBb5z6IVYaQaCrVUlu9zOAr1BDdKyVYQaSD/GDsAMrXpKcOyBD4LIl8nfjHw==",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/json-cycle/-/json-cycle-1.5.0.tgz",
+      "integrity": "sha512-GOehvd5PO2FeZ5T4c+RxobeT5a1PiGpF4u9/3+UvrMU4bhnVqzJY7hm39wg8PDCqkU91fWGH8qjWR4bn+wgq9w==",
       "dev": true,
       "engines": {
         "node": ">= 4"
@@ -8261,6 +8336,12 @@
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/lodash.flattendeep/-/lodash.flattendeep-4.4.0.tgz",
       "integrity": "sha512-uHaJFihxmJcEX3kT4I23ABqKKalJ/zDrDg0lsFtc1h+3uw49SIJ5beyhx5ExVRti3AvKoOJngIj7xz3oylPdWQ==",
+      "dev": true
+    },
+    "node_modules/lodash.get": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
+      "integrity": "sha512-z+Uw/vLuy6gQe8cfaFWD7p0wVv8fJl3mbzXh33RS+0oW2wvUqiRXiQ69gLWSLpgB5/6sU+r6BlQR0MBILadqTQ==",
       "dev": true
     },
     "node_modules/lodash.ismatch": {
@@ -8812,22 +8893,13 @@
       }
     },
     "node_modules/minipass": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/minipass/-/minipass-4.0.0.tgz",
-      "integrity": "sha512-g2Uuh2jEKoht+zvO6vJqXmYpflPqzRBT+Th2h01DKh5z7wbY/AZ2gCQ78cP70YoHPyFdY30YBV5WxgLOEwOykw==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-5.0.0.tgz",
+      "integrity": "sha512-3FnjYuehv9k6ovOEbyOswadCDPX1piCfhV8ncmYtHOjuPwylVWsghTLo7rabjC3Rx5xD4HDx8Wm1xnMF7S5qFQ==",
       "dev": true,
-      "dependencies": {
-        "yallist": "^4.0.0"
-      },
       "engines": {
         "node": ">=8"
       }
-    },
-    "node_modules/minipass/node_modules/yallist": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-      "dev": true
     },
     "node_modules/minizlib": {
       "version": "2.1.2",
@@ -9094,18 +9166,18 @@
       "dev": true
     },
     "node_modules/ncjsm": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/ncjsm/-/ncjsm-4.3.1.tgz",
-      "integrity": "sha512-5hy/Mr7KKLS/AFyY4Be8q0aXz8wYd2PN3cSSMBeQHfcrK6Sbd0EGoQxiNrUoKMAYhl67v4A975f6Gy1oEqfJlA==",
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/ncjsm/-/ncjsm-4.3.2.tgz",
+      "integrity": "sha512-6d1VWA7FY31CpI4Ki97Fpm36jfURkVbpktizp8aoVViTZRQgr/0ddmlKerALSSlzfwQRBeSq1qwwVcBJK4Sk7Q==",
       "dependencies": {
         "builtin-modules": "^3.3.0",
         "deferred": "^0.7.11",
-        "es5-ext": "^0.10.61",
-        "es6-set": "^0.1.5",
-        "ext": "^1.6.0",
+        "es5-ext": "^0.10.62",
+        "es6-set": "^0.1.6",
+        "ext": "^1.7.0",
         "find-requires": "^1.0.0",
         "fs2": "^0.3.9",
-        "type": "^2.6.0"
+        "type": "^2.7.2"
       }
     },
     "node_modules/neo-async": {
@@ -9652,9 +9724,9 @@
       }
     },
     "node_modules/open": {
-      "version": "8.4.0",
-      "resolved": "https://registry.npmjs.org/open/-/open-8.4.0.tgz",
-      "integrity": "sha512-XgFPPM+B28FtCCgSb9I+s9szOC1vZRSwgWsRUA5ylIxRTgKozqjOCrVOqGsYABPYK5qnfqClxZTFBa8PKt2v6Q==",
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/open/-/open-8.4.2.tgz",
+      "integrity": "sha512-7x81NCL719oNbsq/3mh+hVrAWmFuEYUqrq/Iw3kUzH8ReypT9QQ0BLoJS7/G9k6N81XjW4qHWtjWwe/9eLy1EQ==",
       "dependencies": {
         "define-lazy-prop": "^2.0.0",
         "is-docker": "^2.1.1",
@@ -10765,64 +10837,67 @@
       }
     },
     "node_modules/serverless": {
-      "version": "3.26.0",
-      "resolved": "https://registry.npmjs.org/serverless/-/serverless-3.26.0.tgz",
-      "integrity": "sha512-drVr4akkQwm2Pj7ZN9boh5PoI2nKvlXmy+Cb8Hh1Zv8ybsf47ZUQE6t7dakGA4irYf4SQCbVc72nKqISfarMCQ==",
+      "version": "3.33.0",
+      "resolved": "https://registry.npmjs.org/serverless/-/serverless-3.33.0.tgz",
+      "integrity": "sha512-qmG0RMelsWmnS5Smxoy0CbjpecgnJlM89wzSIgJqfkGlmOo2nJdd8y0/E6KlaTsaozlPKkjUBDzis2nF8VNO2g==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
-        "@serverless/dashboard-plugin": "^6.2.2",
+        "@serverless/dashboard-plugin": "^6.2.3",
         "@serverless/platform-client": "^4.3.2",
-        "@serverless/utils": "^6.8.2",
-        "ajv": "^8.11.2",
+        "@serverless/utils": "^6.11.1",
+        "ajv": "^8.12.0",
         "ajv-formats": "^2.1.1",
         "archiver": "^5.3.1",
-        "aws-sdk": "^2.1280.0",
+        "aws-sdk": "^2.1404.0",
         "bluebird": "^3.7.2",
         "cachedir": "^2.3.0",
         "chalk": "^4.1.2",
         "child-process-ext": "^2.1.1",
-        "ci-info": "^3.7.0",
+        "ci-info": "^3.8.0",
         "cli-progress-footer": "^2.3.2",
         "d": "^1.0.1",
-        "dayjs": "^1.11.7",
+        "dayjs": "^1.11.8",
         "decompress": "^4.2.1",
-        "dotenv": "^16.0.3",
-        "dotenv-expand": "^9.0.0",
+        "dotenv": "^16.3.1",
+        "dotenv-expand": "^10.0.0",
         "essentials": "^1.2.0",
         "ext": "^1.7.0",
         "fastest-levenshtein": "^1.0.16",
-        "filesize": "^10.0.6",
+        "filesize": "^10.0.7",
         "fs-extra": "^10.1.0",
         "get-stdin": "^8.0.0",
         "globby": "^11.1.0",
         "got": "^11.8.6",
-        "graceful-fs": "^4.2.10",
+        "graceful-fs": "^4.2.11",
         "https-proxy-agent": "^5.0.1",
         "is-docker": "^2.2.1",
         "js-yaml": "^4.1.0",
-        "json-cycle": "^1.3.0",
+        "json-colorizer": "^2.2.2",
+        "json-cycle": "^1.5.0",
         "json-refs": "^3.0.15",
         "lodash": "^4.17.21",
         "memoizee": "^0.4.15",
         "micromatch": "^4.0.5",
-        "node-fetch": "^2.6.7",
+        "node-fetch": "^2.6.11",
         "npm-registry-utilities": "^1.0.0",
         "object-hash": "^3.0.0",
-        "open": "^8.4.0",
+        "open": "^8.4.2",
         "path2": "^0.1.0",
         "process-utils": "^4.0.0",
         "promise-queue": "^2.2.5",
         "require-from-string": "^2.0.2",
-        "semver": "^7.3.8",
+        "semver": "^7.5.3",
         "signal-exit": "^3.0.7",
+        "stream-buffers": "^3.0.2",
         "strip-ansi": "^6.0.1",
         "supports-color": "^8.1.1",
-        "tar": "^6.1.13",
+        "tar": "^6.1.15",
         "timers-ext": "^0.1.7",
         "type": "^2.7.2",
         "untildify": "^4.0.0",
         "uuid": "^9.0.0",
+        "ws": "^7.5.9",
         "yaml-ast-parser": "0.0.43"
       },
       "bin": {
@@ -10961,9 +11036,9 @@
       }
     },
     "node_modules/serverless/node_modules/node-fetch": {
-      "version": "2.6.7",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
-      "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
+      "version": "2.6.12",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.12.tgz",
+      "integrity": "sha512-C/fGU2E8ToujUivIO0H+tpQ6HWo4eEmchoPIoXtxCrVghxdKq+QOHqEZW7tuP3KlV3bC8FRMO5nMCC7Zm1VP6g==",
       "dev": true,
       "dependencies": {
         "whatwg-url": "^5.0.0"
@@ -10981,9 +11056,9 @@
       }
     },
     "node_modules/serverless/node_modules/semver": {
-      "version": "7.3.8",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
-      "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
+      "version": "7.5.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+      "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
       "dev": true,
       "dependencies": {
         "lru-cache": "^6.0.0"
@@ -11002,6 +11077,27 @@
       "dev": true,
       "bin": {
         "uuid": "dist/bin/uuid"
+      }
+    },
+    "node_modules/serverless/node_modules/ws": {
+      "version": "7.5.9",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.9.tgz",
+      "integrity": "sha512-F+P9Jil7UiSKSkppIiD94dN07AwvFixvLIj1Og1Rl9GGMuNipJnV9JzjD6XuqmAeiswGvUmNLjr5cFuXwNS77Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=8.3.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": "^5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
       }
     },
     "node_modules/serverless/node_modules/yallist": {
@@ -11059,9 +11155,9 @@
       "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ=="
     },
     "node_modules/simple-git": {
-      "version": "3.15.1",
-      "resolved": "https://registry.npmjs.org/simple-git/-/simple-git-3.15.1.tgz",
-      "integrity": "sha512-73MVa5984t/JP4JcQt0oZlKGr42ROYWC3BcUZfuHtT3IHKPspIvL0cZBnvPXF7LL3S/qVeVHVdYYmJ3LOTw4Rg==",
+      "version": "3.19.1",
+      "resolved": "https://registry.npmjs.org/simple-git/-/simple-git-3.19.1.tgz",
+      "integrity": "sha512-Ck+rcjVaE1HotraRAS8u/+xgTvToTuoMkT9/l9lvuP5jftwnYUp6DwuJzsKErHgfyRk8IB8pqGHWEbM3tLgV1w==",
       "dev": true,
       "dependencies": {
         "@kwsites/file-exists": "^1.1.1",
@@ -11396,6 +11492,15 @@
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
       "dev": true
     },
+    "node_modules/stream-buffers": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/stream-buffers/-/stream-buffers-3.0.2.tgz",
+      "integrity": "sha512-DQi1h8VEBA/lURbSwFtEHnSTb9s2/pwLEaFuNhXwy1Dx3Sa0lOuYT2yNUr4/j2fs8oCAMANtrZ5OrPZtyVs3MQ==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.10.0"
+      }
+    },
     "node_modules/stream-promise": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/stream-promise/-/stream-promise-3.2.0.tgz",
@@ -11684,14 +11789,14 @@
       }
     },
     "node_modules/tar": {
-      "version": "6.1.13",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-6.1.13.tgz",
-      "integrity": "sha512-jdIBIN6LTIe2jqzay/2vtYLlBHa3JF42ot3h1dW8Q0PaAG4v8rm0cvpVePtau5C6OKXGGcgO9q2AMNSWxiLqKw==",
+      "version": "6.1.15",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-6.1.15.tgz",
+      "integrity": "sha512-/zKt9UyngnxIT/EAGYuxaMYgOIJiP81ab9ZfkILq4oNLPFX50qyYmu7jRj9qeXoxmJHjGlbH0+cm2uy1WCs10A==",
       "dev": true,
       "dependencies": {
         "chownr": "^2.0.0",
         "fs-minipass": "^2.0.0",
-        "minipass": "^4.0.0",
+        "minipass": "^5.0.0",
         "minizlib": "^2.1.1",
         "mkdirp": "^1.0.3",
         "yallist": "^4.0.0"
@@ -12336,19 +12441,22 @@
       }
     },
     "node_modules/xml2js": {
-      "version": "0.4.19",
-      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.19.tgz",
-      "integrity": "sha512-esZnJZJOiJR9wWKMyuvSE1y6Dq5LCuJanqhxslH2bxM6duahNZ+HMpCLhBQGZkbX6xRf8x1Y2eJlgt2q3qo49Q==",
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.5.0.tgz",
+      "integrity": "sha512-drPFnkQJik/O+uPKpqSgr22mpuFHqKdbS835iAQrUC73L2F5WkboIRd63ai/2Yg6I1jzifPFKH2NTK+cfglkIA==",
       "dev": true,
       "dependencies": {
         "sax": ">=0.6.0",
-        "xmlbuilder": "~9.0.1"
+        "xmlbuilder": "~11.0.0"
+      },
+      "engines": {
+        "node": ">=4.0.0"
       }
     },
     "node_modules/xmlbuilder": {
-      "version": "9.0.7",
-      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-9.0.7.tgz",
-      "integrity": "sha512-7YXTQc3P2l9+0rjaUbLwMKRhtmwg1M1eDf6nag7urC7pIPYLD9W/jmzQ4ptRSUbodw5S0jfoGTflLemQibSpeQ==",
+      "version": "11.0.1",
+      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-11.0.1.tgz",
+      "integrity": "sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA==",
       "dev": true,
       "engines": {
         "node": ">=4.0"

--- a/package.json
+++ b/package.json
@@ -120,7 +120,7 @@
     "mocha": "^10.2.0",
     "nyc": "^15.1.0",
     "prettier": "^2.8.1",
-    "serverless": "^3.26.0",
+    "serverless": "^3.31.0",
     "standard-version": "^9.5.0"
   },
   "peerDependencies": {

--- a/src/config/supportedRuntimes.js
+++ b/src/config/supportedRuntimes.js
@@ -11,7 +11,7 @@
 export const supportedGo = new Set(['go1.x'])
 
 // JAVA
-export const supportedJava = new Set(['java8', 'java8.al2', 'java11'])
+export const supportedJava = new Set(['java8', 'java8.al2', 'java11', 'java17'])
 
 // NODE.JS
 export const supportedNodejs = new Set([

--- a/tests/runtimes/java/java/serverless.yml
+++ b/tests/runtimes/java/java/serverless.yml
@@ -12,7 +12,7 @@ provider:
   memorySize: 1024
   name: aws
   region: us-east-1
-  runtime: java8
+  runtime: java17
   stage: dev
   versionFunctions: false
 


### PR DESCRIPTION
Adds support for the recently released Java 17 runtime for AWS Lambda: https://aws.amazon.com/about-aws/whats-new/2023/04/aws-lambda-java-17/

Java 17 has been recognised in `serverless` since `3.31.0`: https://github.com/serverless/serverless/releases/tag/v3.31.0

Lambda runtimes: https://docs.aws.amazon.com/lambda/latest/dg/lambda-runtimes.html 
