### PR TITLE
fix(InvocationsController): typo in error message

### DIFF
--- a/src/lambda/routes/invocations/InvocationsController.js
+++ b/src/lambda/routes/invocations/InvocationsController.js
@@ -12,7 +12,7 @@ export default class InvocationsController {
     const functionNames = this.#lambda.listFunctionNames()
     if (functionNames.length === 0 || !functionNames.includes(functionName)) {
       log.error(
-        `Attempt to invoke function '${functionName}' failed. Function does not exists.`,
+        `Attempt to invoke function '${functionName}' failed. Function does not exist.`,
       )
       // Conforms to the actual response from AWS Lambda when invoking a non-existent
       // function. Details on the error are provided in the Payload.Message key


### PR DESCRIPTION
## Description

There is a tiny typo in one of the `InvocationsController` error messages (an `s` at the end of the word `exist`)

## Motivation and Context

Quality of the plugin.

## How Has This Been Tested?

## Screenshots (if appropriate):
![image](https://github.com/dherault/serverless-offline/assets/37962844/c43911d6-af23-447a-be1f-93b9facddcd2)