### PR TITLE
Add support for mTLS

### DIFF
--- a/src/events/http/HttpServer.js
+++ b/src/events/http/HttpServer.js
@@ -56,16 +56,23 @@ export default class HttpServer {
   }
 
   async #loadCerts(httpsProtocol) {
-    const [cert, key, ca] = await Promise.all([
+    const [cert, key] = await Promise.all([
       readFile(resolve(httpsProtocol, 'cert.pem'), 'utf8'),
       readFile(resolve(httpsProtocol, 'key.pem'), 'utf8'),
-      readFile(resolve(httpsProtocol, 'ca.pem'), 'utf8'),
     ])
 
+    let ca
+    try {
+      ca = await readFile(resolve(httpsProtocol, 'ca.pem'), 'utf8')
+    } catch {
+      // If there's no ca.pem file, it's fine, we just won't use it.
+    }
+
     return {
+      ca,
       cert,
       key,
-      ca,
+
       // If a certificate authority is configured, it means we're doing mTLS and need to request a client cert.
       requestCert: !!ca,
     }

--- a/src/events/http/HttpServer.js
+++ b/src/events/http/HttpServer.js
@@ -56,14 +56,18 @@ export default class HttpServer {
   }
 
   async #loadCerts(httpsProtocol) {
-    const [cert, key] = await Promise.all([
+    const [cert, key, ca] = await Promise.all([
       readFile(resolve(httpsProtocol, 'cert.pem'), 'utf8'),
       readFile(resolve(httpsProtocol, 'key.pem'), 'utf8'),
+      readFile(resolve(httpsProtocol, 'ca.pem'), 'utf8'),
     ])
 
     return {
       cert,
       key,
+      ca,
+      // If a certificate authority is configured, it means we're doing mTLS and need to request a client cert.
+      requestCert: !!ca,
     }
   }
 

--- a/src/events/http/lambda-events/LambdaProxyIntegrationEvent.js
+++ b/src/events/http/lambda-events/LambdaProxyIntegrationEvent.js
@@ -193,24 +193,25 @@ export default class LambdaProxyIntegrationEvent {
           apiKey: env.SLS_API_KEY || 'offlineContext_apiKey',
           apiKeyId: env.SLS_API_KEY_ID || 'offlineContext_apiKeyId',
           caller: env.SLS_CALLER || 'offlineContext_caller',
-          clientCert: clientCertificate
-            ? {
-                clientCertPem: `-----BEGIN CERTIFICATE-----\n${clientCertificate.raw.toString(
-                  'base64',
-                )}\n-----END CERTIFICATE-----`,
-                issuerDN: Object.entries(clientCertificate.issuer)
-                  .map((entry) => `${entry[0]}=${entry[1]}`)
-                  .join(','),
-                serialNumber: clientCertificate.serialNumber,
-                subjectDN: Object.entries(clientCertificate.subject)
-                  .map((entry) => `${entry[0]}=${entry[1]}`)
-                  .join(','),
-                validity: {
-                  notAfter: clientCertificate.valid_to,
-                  notBefore: clientCertificate.valid_from,
-                },
-              }
-            : undefined,
+          clientCert:
+            clientCertificate && clientCertificate.raw
+              ? {
+                  clientCertPem: `-----BEGIN CERTIFICATE-----\n${clientCertificate.raw.toString(
+                    'base64',
+                  )}\n-----END CERTIFICATE-----`,
+                  issuerDN: Object.entries(clientCertificate.issuer)
+                    .map((entry) => `${entry[0]}=${entry[1]}`)
+                    .join(','),
+                  serialNumber: clientCertificate.serialNumber,
+                  subjectDN: Object.entries(clientCertificate.subject)
+                    .map((entry) => `${entry[0]}=${entry[1]}`)
+                    .join(','),
+                  validity: {
+                    notAfter: clientCertificate.valid_to,
+                    notBefore: clientCertificate.valid_from,
+                  },
+                }
+              : undefined,
           cognitoAuthenticationProvider:
             _headers['cognito-authentication-provider'] ||
             env.SLS_COGNITO_AUTHENTICATION_PROVIDER ||


### PR DESCRIPTION
## Description

This PR adds support for mTLS by changing two things:

1. Supplying the `ca` and `requestCert: true` parameters for the server when in use.
2. Populating the `event.identity.clientCert` object when new requests come in.

Both of these behaviours only activate if you have a `httpsProtocol` directory configured in the serverless offline config, and have put a `ca.pem` file in it alongside the `key.pem` and `cert.pem` files.

## Motivation and Context

We use mTLS in our environment with API Gateway and want a way to test this locally. Serverless Offline doesn't currently support mTLS (#1730), so we figured it'd be nice to  add support for it so we can use Serverless Offline to more fully emulate our AWS setup.

## How Has This Been Tested?

You'll need to create some files to test this

### Creating a Certificate Authority (CA)

1. Create a private key for the Certificate Authority (`ca.key`):

```console
$ openssl genrsa -out ca.key 4096
```

2. Self sign it and generate the certificate to identify the certificate authority to clients (`ca.pem`):

```console
$ openssl req -x509 -new -nodes \
  -key ca.key \
  -sha256 \
  -days 365 \
  -subj "/C=AU/ST=Tasmania/L=Hobart/O=Some Company/OU=Certificate Services" \
  -out ca.pem
```

### Creating a Certificate for the Server

3. Generate the private key for the server (`key.pem`):

```console
$ openssl genrsa -out key.pem 4096
```

4. Generate a certificate signing request (CSR) using this key (`server.csr`):

```console
$ openssl req -new -sha256 \
  -key key.pem \
  -subj "/C=AU/ST=Tasmania/L=Hobart/O=Some Company/OU=Certificate Services" \
  -out server.csr
```

5. Sign it as the CA and create the certificate (`cert.pem`):

```console
$ openssl x509 -req \
  -in server.csr \
  -days 365 -sha256 \
  -CA ca.crt \
  -CAkey ca.key \
  -CAserial ca.srl \
  -CAcreateserial \
  -out cert.pem
```

### Creating a Certificate for the Client

3. Generate the private key for the client (`client.key`):

```console
$ openssl genrsa -out client.key 4096
```

4. Generate a certificate signing request (CSR) using this key (`client.csr`):

```console
$ openssl req -new -sha256 \
  -key client.key \
  -subj "/C=AU/ST=New South Wales/L=Barangaroo/O=Exogee/OU=Data Collection Services/CN=exogee.com" \
  -out client.csr
```

5. Sign it as the CA and create the certificate (`client.pem`):

```console
$ openssl x509 -req \
  -in client.csr \
  -days 365 -sha256 \
  -CA ca.crt \
  -CAkey ca.key \
  -CAserial ca.srl \
  -CAcreateserial \
  -out client.crt
```

Now you should have the following files:

* ca.key
* ca.pem
* ca.srl
* cert.pem
* client.key
* client.pem
* key.pem

Create a Node JS client passing the `ca.pem`, `client.key` and `client.pem` parameters as follows:

```typescript
import { Client } from 'undici';

const ca = await fsPromises.readFile('ca.pem');
const cert = await fsPromises.readFile('client.pem');
const key = await fsPromises.readFile('client.key');

const apiClient = new Client('https://localhost:3000', {
	connect: { ca, cert, key },
});

const apiResponse = await apiClient.request({
	path: '/',
	method: 'POST',
	body: JSON.stringify({ test: true }),
});
```

## Screenshots (if appropriate):
This results in the following event being sent to the handler:

```json
{
  "body": "{\"test\":true}",
  // ...
  "requestContext": {
    //...
    "identity": {
      // ...
      "clientCert": {
        "clientCertPem": "-----BEGIN CERTIFICATE-----\n[certificate contents in base64]\n-----END CERTIFICATE-----",
        "issuerDN": "C=AU,ST=Tasmania,L=Hobart,O=Some Company,OU=Certificate Services",
        "serialNumber": "032AA3D423A340C86DA38CE2EEF2114090EFC291",
        "subjectDN": "C=AU,ST=Tasmania,L=Hobart,O=Exogee,OU=Data Collection Services,CN=exogee.com",
        "validity": {
          "notAfter": "Sep  7 04:18:08 2024 GMT",
          "notBefore": "Sep  8 04:18:08 2023 GMT"
        }
      }
    }
  },
}
```

I've also tested without the `ca.pem` file in the directory to make sure nothing breaks / changes, and it worked fine for me.