### PR TITLE
hot reload

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
+# Ryze0323 Fork Version
+
+In the case of version 12.0.4, a speed issue occurred because all packages had to be read and processed each time when developing in a node environment. All folders except the node_modules folder have been changed to reflect user changes.
 # Serverless Offline
 
 <p>

--- a/README.md
+++ b/README.md
@@ -1,6 +1,3 @@
-# Ryze0323 Fork Version
-
-In the case of version 12.0.4, a speed issue occurred because all packages had to be read and processed each time when developing in a node environment. All folders except the node_modules folder have been changed to reflect user changes.
 # Serverless Offline
 
 <p>

--- a/src/lambda/handler-runner/in-process-runner/aws-lambda-ric/UserFunction.js
+++ b/src/lambda/handler-runner/in-process-runner/aws-lambda-ric/UserFunction.js
@@ -334,6 +334,11 @@ const { pathToFileURL } = require('node:url')
     throw new MalformedStreamingHandler('Only response streaming is supported.')
   }
   module.exports.load = async function (appRoot, fullHandlerString) {
+    Object.keys(require.cache)
+      .filter((cache) => !cache.includes('node_modules'))
+      .forEach((item) => {
+        delete require.cache[item]
+      })
     _throwIfInvalidHandler(fullHandlerString)
     const [moduleRoot, moduleAndHandler] =
       _moduleRootAndHandler(fullHandlerString)


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Added a hot reload function that retrieves the latest source code except for node_modules in the require cache when loading.


## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
In case of serverless offline, it is necessary for fast development

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
We confirmed quick reflection by actually connecting offline and modifying the source.

## Screenshots (if appropriate):
