### PR TITLE
Add support for nodejs20.x runtime

### DIFF
--- a/src/config/supportedRuntimes.js
+++ b/src/config/supportedRuntimes.js
@@ -17,6 +17,7 @@ export const supportedNodejs = new Set([
   'nodejs14.x',
   'nodejs16.x',
   'nodejs18.x',
+  'nodejs20.x',
 ])
 
 // PROVIDED
@@ -50,5 +51,6 @@ export const unsupportedDockerRuntimes = new Set([
   'nodejs14.x',
   'nodejs16.x',
   'nodejs18.x',
+  'nodejs20.x',
   'python3.9',
 ])


### PR DESCRIPTION
## Description
Added Node 18 runtime.

Closes https://github.com/dherault/serverless-offline/issues/1742

## Motivation and Context

[AWS now supports Node 18.](https://docs.aws.amazon.com/lambda/latest/dg/lambda-nodejs.html)
https://aws.amazon.com/blogs/compute/node-js-20-x-runtime-now-available-in-aws-lambda/

related PR in serverless framework
https://github.com/serverless/serverless/pull/12251
