### PR TITLE
docs: change to serverless-dynamodb

### DIFF
--- a/README.md
+++ b/README.md
@@ -835,7 +835,7 @@ For example:
 plugins:
   - serverless-middleware # modifies some of your handler based on configuration
   - serverless-webpack # package your javascript handlers using webpack
-  - serverless-dynamodb-local # adds a local dynamo db
+  - serverless-dynamodb # adds a local dynamo db
   - serverless-offline # runs last so your code has been pre-processed and dynamo is ready
 ```
 


### PR DESCRIPTION
## Description

This PR updates the DynamoDB component in our project, transitioning from `serverless-dynamodb-local` to `serverless-dynamodb`. The primary motivation for this change is the lack of maintenance and critical issues with `serverless-dynamodb-local`, which prevent the local installation of DynamoDB. A significant issue is the change in the URL from which DynamoDB is downloaded, a change not accommodated by `serverless-dynamodb-local`, rendering it unusable.

## Motivation and Context

`serverless-dynamodb` is a direct fork which is maintained and solves above problem.

## Changes

Modified the README file to reference serverless-dynamodb instead of serverless-dynamodb-local
