### PR TITLE
Fix: Restore missing import for Headers in invocationsRoute

### DIFF
--- a/src/lambda/routes/invocations/invocationsRoute.js
+++ b/src/lambda/routes/invocations/invocationsRoute.js
@@ -1,5 +1,6 @@
 import { Buffer } from 'node:buffer'
 import InvocationsController from './InvocationsController.js'
+import { Headers } from 'node-fetch'
 
 const { parse } = JSON
 


### PR DESCRIPTION
## Description

This pull request addresses an issue in the invocationsRoute module. The problem was identified as a missing import statement for the Headers class from 'node-fetch,' leading to a "ReferenceError: Headers is not defined" error, particularly evident during attempts to invoke AWS Lambda locally via: 

``const lambda = new AWS.Lambda({
  endpoint: 'http://localhost:3002'
});``

## Motivation and Context

The absence of the import for Headers resulted in a severe malfunction of the invocationsRoute module, impacting the proper parsing of headers during local AWS Lambda invocation. 

## How Has This Been Tested?

I tested these changes locally by reproducing the issue and ensuring that the error is resolved after adding the missing import. 
Tested on Node 18, serverless-offline 13.3.1.