### PR TITLE
fix: Support ALB Event response headers

### DIFF
--- a/examples/events/alb/serverless.yml
+++ b/examples/events/alb/serverless.yml
@@ -35,4 +35,3 @@ functions:
           listenerArn: arn:aws:elasticloadbalancing:us-east-1:12345:listener/app/my-load-balancer/50dc6c495c0c9188/50dc6c495c0c9188
           priority: 2
     handler: src/handler-response-header.responseHeader
-

--- a/examples/events/alb/src/handler-response-header.js
+++ b/examples/events/alb/src/handler-response-header.js
@@ -1,0 +1,19 @@
+const { stringify } = JSON
+
+export async function responseHeader(event, context) {
+  return {
+    body: stringify(
+      {
+        context,
+        event,
+      },
+      null,
+      2,
+    ),
+    headers: {
+      "Content-Type": "text/plain",
+      "Set-Cookie": "alb-cookie=works",
+    },
+    statusCode: 200,
+  }
+}

--- a/src/events/alb/HttpServer.js
+++ b/src/events/alb/HttpServer.js
@@ -267,6 +267,8 @@ export default class HttpServer {
         override: false,
       })
 
+      response.headers = headers
+
       if (typeof result === "string") {
         response.source = stringify(result)
       } else if (result && result.body !== undefined) {

--- a/tests/integration/alb-headers/alb-headers.test.js
+++ b/tests/integration/alb-headers/alb-headers.test.js
@@ -1,0 +1,36 @@
+import assert from "node:assert"
+import { join } from "desm"
+import { setup, teardown } from "../../_testHelpers/index.js"
+import { BASE_URL } from "../../config.js"
+
+describe("ALB Headers Tests", function desc() {
+  beforeEach(() =>
+    setup({
+      noPrependStageInUrl: false,
+      servicePath: join(import.meta.url),
+    }),
+  )
+
+  afterEach(() => teardown())
+
+  //
+  ;["GET", "POST"].forEach((method) => {
+    it(`${method} response headers`, async () => {
+      const url = new URL("/dev/response-headers", BASE_URL)
+      url.port = url.port ? "3003" : url.port
+      const options = {
+        method,
+      }
+
+      const response = await fetch(url, options)
+
+      assert.equal(response.status, 200)
+
+      const body = await response.text()
+
+      assert.equal(body, "Plain text")
+      assert.equal(response.headers.get("Content-Type"), "text/plain")
+      assert.equal(response.headers.get("Set-Cookie"), "alb-cookie=works")
+    })
+  })
+})

--- a/tests/integration/alb-headers/serverless.yml
+++ b/tests/integration/alb-headers/serverless.yml
@@ -1,10 +1,10 @@
-service: alb
+service: alb-headers
 
 configValidationMode: error
 deprecationNotificationMode: error
 
 plugins:
-  - serverless-offline
+  - ../../../src/index.js
 
 provider:
   architecture: arm64
@@ -17,22 +17,11 @@ provider:
   versionFunctions: false
 
 functions:
-  hello:
+  response-headers:
     events:
       - alb:
           conditions:
-            method: GET
-            path: hello
+            path: response-headers
           listenerArn: arn:aws:elasticloadbalancing:us-east-1:12345:listener/app/my-load-balancer/50dc6c495c0c9188/50dc6c495c0c9188
           priority: 1
-    handler: src/handler.hello
-  hello-headers:
-    events:
-      - alb:
-          conditions:
-            method: GET
-            path: hello-headers
-          listenerArn: arn:aws:elasticloadbalancing:us-east-1:12345:listener/app/my-load-balancer/50dc6c495c0c9188/50dc6c495c0c9188
-          priority: 2
-    handler: src/handler-response-header.responseHeader
-
+    handler: src/handler.responseHeader

--- a/tests/integration/alb-headers/src/handler.js
+++ b/tests/integration/alb-headers/src/handler.js
@@ -1,0 +1,10 @@
+export async function responseHeader() {
+  return {
+    body: "Plain text",
+    headers: {
+      "Content-Type": "text/plain",
+      "Set-Cookie": "alb-cookie=works",
+    },
+    statusCode: 200,
+  }
+}

--- a/tests/integration/alb-headers/src/package.json
+++ b/tests/integration/alb-headers/src/package.json
@@ -1,0 +1,3 @@
+{
+  "type": "module"
+}


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This PR adds support for ALB Event handlers to return headers.
This enables different "Content-Type" or "Set-Cookie" headers.

Fixes #1728 

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Examples were added to manually test as well as integration tests added.

## Screenshots (if appropriate):
