### PR TITLE
Support Python 3.12

### DIFF
--- a/src/config/supportedRuntimes.js
+++ b/src/config/supportedRuntimes.js
@@ -30,6 +30,7 @@ export const supportedPython = new Set([
   "python3.9",
   "python3.10",
   "python3.11",
+  "python3.12",
 ])
 
 // RUBY


### PR DESCRIPTION
## Description

Add support for Python 3.12

## Motivation and Context

- Python 3.12 is supported since [14 DEC 2023](https://aws.amazon.com/blogs/compute/python-3-12-runtime-now-available-in-aws-lambda/)  by AWS 
- Python 3.12 is supported [soon](https://github.com/serverless/serverless/pull/12300#issuecomment-1948357990) (or yet :) )  by serverless

## How Has This Been Tested?

There is a warning, coming probably from serverless, but nevertheless I can work with Python 3.12 using this fork


```
❯ serverless offline
Running "serverless" from node_modules

Warning: Invalid configuration encountered
  at 'provider.runtime': must be equal to one of the allowed values [dotnet6, go1.x, java17, java11, java8, java8.al2, nodejs14.x, nodejs16.x, nodejs18.x, nodejs20.x, provided, provided.al2, provided.al2023, python3.7, python3.8, python3.9, python3.10, python3.11, ruby2.7, ruby3.2]

Learn more about configuration validation here: http://slss.io/configuration-validation

Starting Offline at stage dev (<some-aws-region>)

Offline [http for lambda] listening on http://localhost:3002
Function names exposed for local invocation by aws-sdk:
           * main: <some-function-name>

   ┌────────────────────────────────────────────────────────────────────────┐
   │                                                                        │
   │   POST | http://localhost:3000/                                        │
   │   POST | http://localhost:3000/2015-03-31/functions/main/invocations   │
   │                                                                        │
   └────────────────────────────────────────────────────────────────────────┘

Server ready: http://localhost:3000 🚀

```

## Screenshots (if appropriate):
