### PR TITLE
fix: Support httpApi authorizer with different config and function names

### DIFF
--- a/src/events/http/HttpServer.js
+++ b/src/events/http/HttpServer.js
@@ -295,7 +295,7 @@ export default class HttpServer {
       return null
     }
 
-    const authFunctionName = this.#extractAuthFunctionName(endpoint)
+    let authFunctionName = this.#extractAuthFunctionName(endpoint)
 
     if (!authFunctionName) {
       return null
@@ -303,16 +303,31 @@ export default class HttpServer {
 
     log.notice(`Configuring Authorization: ${path} ${authFunctionName}`)
 
+    const standardFunctionExists =
+      this.#serverless.service.functions &&
+      this.#serverless.service.functions[authFunctionName]
+    const serverlessAuthorizerOptions =
+      this.#serverless.service.provider.httpApi &&
+      this.#serverless.service.provider.httpApi.authorizers &&
+      this.#serverless.service.provider.httpApi.authorizers[authFunctionName]
+
+    if (
+      !standardFunctionExists &&
+      serverlessAuthorizerOptions &&
+      serverlessAuthorizerOptions.functionName
+    ) {
+      log.notice(
+        `Redirecting authorizer function: ${authFunctionName} to ${serverlessAuthorizerOptions.functionName}`,
+      )
+      authFunctionName = serverlessAuthorizerOptions.functionName
+    }
+
     const authFunction = this.#serverless.service.getFunction(authFunctionName)
 
     if (!authFunction) {
       log.error(`Authorization function ${authFunctionName} does not exist`)
       return null
     }
-    const serverlessAuthorizerOptions =
-      this.#serverless.service.provider.httpApi &&
-      this.#serverless.service.provider.httpApi.authorizers &&
-      this.#serverless.service.provider.httpApi.authorizers[authFunctionName]
 
     const authorizerOptions = {
       enableSimpleResponses:
@@ -339,7 +354,14 @@ export default class HttpServer {
       return null
     }
 
-    if (typeof endpoint.authorizer === "string") {
+    if (serverlessAuthorizerOptions) {
+      assign(
+        authorizerOptions,
+        serverlessAuthorizerOptions,
+        endpoint.authorizer,
+      )
+      authorizerOptions.name = authFunctionName
+    } else if (typeof endpoint.authorizer === "string") {
       authorizerOptions.name = authFunctionName
     } else {
       assign(authorizerOptions, endpoint.authorizer)

--- a/src/events/http/HttpServer.js
+++ b/src/events/http/HttpServer.js
@@ -343,6 +343,7 @@ export default class HttpServer {
         : "1.0",
       resultTtlInSeconds:
         serverlessAuthorizerOptions?.resultTtlInSeconds ?? "300",
+      type: endpoint.isHttpApi ? serverlessAuthorizerOptions?.type : undefined,
     }
 
     if (

--- a/src/events/http/HttpServer.js
+++ b/src/events/http/HttpServer.js
@@ -313,6 +313,7 @@ export default class HttpServer {
 
     if (
       !standardFunctionExists &&
+      endpoint.isHttpApi &&
       serverlessAuthorizerOptions &&
       serverlessAuthorizerOptions.functionName
     ) {
@@ -354,18 +355,10 @@ export default class HttpServer {
       return null
     }
 
-    if (serverlessAuthorizerOptions) {
-      assign(
-        authorizerOptions,
-        serverlessAuthorizerOptions,
-        endpoint.authorizer,
-      )
-      authorizerOptions.name = authFunctionName
-    } else if (typeof endpoint.authorizer === "string") {
-      authorizerOptions.name = authFunctionName
-    } else {
+    if (typeof endpoint.authorizer !== "string") {
       assign(authorizerOptions, endpoint.authorizer)
     }
+    authorizerOptions.name = authFunctionName
 
     if (
       !authorizerOptions.identitySource &&

--- a/src/events/http/HttpServer.js
+++ b/src/events/http/HttpServer.js
@@ -342,7 +342,7 @@ export default class HttpServer {
         ? serverlessAuthorizerOptions?.payloadVersion || "2.0"
         : "1.0",
       resultTtlInSeconds:
-        serverlessAuthorizerOptions?.resultTtlInSeconds || "300",
+        serverlessAuthorizerOptions?.resultTtlInSeconds ?? "300",
     }
 
     if (

--- a/tests/integration/request-authorizer/request-authorizer.test.js
+++ b/tests/integration/request-authorizer/request-authorizer.test.js
@@ -329,6 +329,24 @@ describe("request authorizer tests", () => {
     ].forEach(doTest)
   })
 
+  describe("authorizer with alternative mismatched authorizer name", () => {
+    ;[
+      {
+        description: "should respond with isAuthorized true",
+        expected: {
+          status: "Authorized",
+        },
+        options: {
+          headers: {
+            AuthorizationSimple: "Bearer fc3e55ea-e6ec-4bf2-94d2-06ae6efe6e5a",
+          },
+        },
+        path: "/user2simple-header-alternative",
+        status: 200,
+      },
+    ].forEach(doTest)
+  })
+
   describe("authorizer with payload format 2.0 with simple responses enabled and querystring identity source", () => {
     ;[
       {

--- a/tests/integration/request-authorizer/request-authorizer.test.js
+++ b/tests/integration/request-authorizer/request-authorizer.test.js
@@ -334,6 +334,7 @@ describe("request authorizer tests", () => {
       {
         description: "should respond with isAuthorized true",
         expected: {
+          hasAuthorizer: true,
           status: "Authorized",
         },
         options: {

--- a/tests/integration/request-authorizer/serverless.yml
+++ b/tests/integration/request-authorizer/serverless.yml
@@ -12,20 +12,27 @@ provider:
   httpApi:
     authorizers:
       requestAuthorizer1FormatHeader:
-        functionName: requestAuthorizer1Format
+        functionName: requestAuthorizer1FormatHeader
         identitySource: $request.header.Authorization
         payloadVersion: "1.0"
         type: request
 
       requestAuthorizer2FormatHeader:
-        functionName: requestAuthorizer2Format
+        functionName: requestAuthorizer2FormatHeader
         identitySource: $request.header.Authorization
         payloadVersion: "2.0"
         type: request
 
       requestAuthorizer2FormatSimpleHeader:
         enableSimpleResponses: true
-        functionName: requestAuthorizer2FormatSimple
+        functionName: requestAuthorizer2FormatSimpleHeader
+        identitySource: $request.header.AuthorizationSimple
+        payloadVersion: "2.0"
+        type: request
+
+      requestAuthorizer2FormatSimpleHeaderAlternative:
+        enableSimpleResponses: true
+        functionName: requestAuthorizer2FormatSimpleHeader
         identitySource: $request.header.AuthorizationSimple
         payloadVersion: "2.0"
         type: request
@@ -90,6 +97,15 @@ functions:
             name: requestAuthorizer2FormatSimpleHeader
           method: get
           path: /user2simple-header
+    handler: src/handler.user
+
+  user2simpleAlternative:
+    events:
+      - httpApi:
+          authorizer:
+            name: requestAuthorizer2FormatSimpleHeaderAlternative
+          method: get
+          path: /user2simple-header-alternative
     handler: src/handler.user
 
   user1WithQueryString:


### PR DESCRIPTION
## Description

httpApi authorizer's have their config in the provider section with a name that can be used by httpApi events to attach that authorizer.  The authorizer's underlying function is separately defined and is allowed to have a different name than the authorizer config in the provider section.  The current implementation by serverless-offline requires that both of those names are the same.  This PR fixes this issue by embedding all of the provider config and setting the function name to the one defined in the config.

## Motivation and Context

Fixes #1624 

## How Has This Been Tested?

Manually tested with a small sample app that reproduced the initial issue.  Updated existing integration tests that weren't actually using the correct authorizer names (they were using the function names).  Added new integration test to reference an authorizer based on config name and have it point to a function name with a different name.

## Screenshots (if appropriate):

N/A