### PR TITLE
fix: skip adding authorizer to event if no authorizer is configured

### DIFF
--- a/src/events/http/HttpServer.js
+++ b/src/events/http/HttpServer.js
@@ -592,6 +592,11 @@ export default class HttpServer {
               )
 
         event = lambdaProxyIntegrationEvent.create()
+
+        if (!endpoint.authorizer) {
+          log.debug("no authorizer configured, deleting authorizer payload")
+          delete event.requestContext.authorizer
+        }
       }
 
       log.debug("event:", event)

--- a/src/events/http/HttpServer.js
+++ b/src/events/http/HttpServer.js
@@ -593,7 +593,11 @@ export default class HttpServer {
 
         event = lambdaProxyIntegrationEvent.create()
 
-        if (!endpoint.authorizer) {
+        const customizations = this.#serverless.service.custom
+        const hasCustomAuthProvider =
+          customizations?.offline?.customAuthenticationProvider
+
+        if (!endpoint.authorizer && !hasCustomAuthProvider) {
           log.debug("no authorizer configured, deleting authorizer payload")
           delete event.requestContext.authorizer
         }

--- a/tests/integration/request-authorizer/request-authorizer.test.js
+++ b/tests/integration/request-authorizer/request-authorizer.test.js
@@ -382,7 +382,7 @@ describe("request authorizer tests", () => {
     ].forEach(doTest)
   })
 
-  describe("authorizer explicitly disabled", () => {
+  describe("no authorizer configured", () => {
     ;[
       {
         description:

--- a/tests/integration/request-authorizer/request-authorizer.test.js
+++ b/tests/integration/request-authorizer/request-authorizer.test.js
@@ -33,6 +33,7 @@ describe("request authorizer tests", () => {
       {
         description: "should respond with Allow policy",
         expected: {
+          hasAuthorizer: true,
           status: "Authorized",
         },
         options: {
@@ -97,6 +98,7 @@ describe("request authorizer tests", () => {
       {
         description: "should respond with Allow policy",
         expected: {
+          hasAuthorizer: true,
           status: "Authorized",
         },
         options: {},
@@ -149,6 +151,7 @@ describe("request authorizer tests", () => {
       {
         description: "should respond with Allow policy",
         expected: {
+          hasAuthorizer: true,
           status: "Authorized",
         },
         options: {
@@ -213,6 +216,7 @@ describe("request authorizer tests", () => {
       {
         description: "should respond with Allow policy",
         expected: {
+          hasAuthorizer: true,
           status: "Authorized",
         },
         options: {},
@@ -265,6 +269,7 @@ describe("request authorizer tests", () => {
       {
         description: "should respond with isAuthorized true",
         expected: {
+          hasAuthorizer: true,
           status: "Authorized",
         },
         options: {
@@ -329,6 +334,7 @@ describe("request authorizer tests", () => {
       {
         description: "should respond with Allow policy",
         expected: {
+          hasAuthorizer: true,
           status: "Authorized",
         },
         options: {},
@@ -372,6 +378,41 @@ describe("request authorizer tests", () => {
         options: {},
         path: "/user2simple-querystring",
         status: 401,
+      },
+    ].forEach(doTest)
+  })
+
+  describe("authorizer explicitly disabled", () => {
+    ;[
+      {
+        description:
+          "should respond authorized with no authorizer with payload 1.0",
+        expected: {
+          hasAuthorizer: false,
+          status: "Authorized",
+        },
+        options: {
+          headers: {
+            Authorization: "Bearer fc3e55ea-e6ec-4bf2-94d2-06ae6efe6e5a",
+          },
+        },
+        path: "/user1-no-authorizer",
+        status: 200,
+      },
+      {
+        description:
+          "should respond authorized with no authorizer with payload 2.0",
+        expected: {
+          hasAuthorizer: false,
+          status: "Authorized",
+        },
+        options: {
+          headers: {
+            Authorization: "Bearer fc3e55ea-e6ec-4bf2-94d2-06ae6efe6e5a",
+          },
+        },
+        path: "/user2-no-authorizer",
+        status: 200,
       },
     ].forEach(doTest)
   })

--- a/tests/integration/request-authorizer/serverless.yml
+++ b/tests/integration/request-authorizer/serverless.yml
@@ -65,6 +65,16 @@ functions:
           path: /user1-header
     handler: src/handler.user
 
+  user1NoAuthorizer:
+    httpApi:
+      payload: "1.0"
+    events:
+      - httpApi:
+          authorizer: null
+          method: get
+          path: /user1-no-authorizer
+    handler: src/handler.user
+
   user2:
     events:
       - httpApi:
@@ -108,6 +118,16 @@ functions:
             name: requestAuthorizer2FormatSimpleQueryString
           method: get
           path: /user2simple-querystring
+    handler: src/handler.user
+
+  user2NoAuthorizer:
+    httpApi:
+      payload: "2.0"
+    events:
+      - httpApi:
+          authorizer: null
+          method: get
+          path: /user2-no-authorizer
     handler: src/handler.user
 
   requestAuthorizer1FormatHeader:

--- a/tests/integration/request-authorizer/serverless.yml
+++ b/tests/integration/request-authorizer/serverless.yml
@@ -70,7 +70,6 @@ functions:
       payload: "1.0"
     events:
       - httpApi:
-          authorizer: null
           method: get
           path: /user1-no-authorizer
     handler: src/handler.user
@@ -125,7 +124,6 @@ functions:
       payload: "2.0"
     events:
       - httpApi:
-          authorizer: null
           method: get
           path: /user2-no-authorizer
     handler: src/handler.user

--- a/tests/integration/request-authorizer/src/handler.js
+++ b/tests/integration/request-authorizer/src/handler.js
@@ -1,8 +1,12 @@
 const { stringify } = JSON
 
-export async function user() {
+export async function user(event) {
+  const { authorizer } = event.requestContext
   return {
-    body: stringify({ status: "Authorized" }),
+    body: stringify({
+      hasAuthorizer: !!authorizer,
+      status: "Authorized",
+    }),
     statusCode: 200,
   }
 }


### PR DESCRIPTION
## Description

AWS API Gateway does not include the `event.requestContext.authorizer` field if there is no `authorizer` configured for the function.

This PR deletes the `event.requestContext.authorizer` field if the function does not have an authorizer.

## Motivation and Context

- I'm doing serialization of API Gateway in Golang
  - It was failing because the `authorizer` payload didn't match what it expected
- Upon further investigation, I found that `serverless-offline` was _always_ setting `event.requestContext.authorizer` if a `Bearer` token comes through in the HTTP Authorization headers.
- My solution is to simply remove `event.requestContext.authorizer` if the lambda function does not have an `authorizer` set.

## How Has This Been Tested?

I've written tests and included them in this PR. Please let me know if you want me to kick the tires in any other ways!
