### PR TITLE
feat: add support for provided.al2023

### DIFF
--- a/src/config/supportedRuntimes.js
+++ b/src/config/supportedRuntimes.js
@@ -31,6 +31,7 @@ export const supportedRuntimesArchitecture = {
   provided: [X86_64],
   dotnet6: [ARM64, X86_64],
   "provided.al2": [ARM64, X86_64],
+  "provided.al2023": [ARM64, X86_64],
 }
 
 // GO
@@ -48,7 +49,11 @@ export const supportedNodejs = new Set([
 ])
 
 // PROVIDED
-export const supportedProvided = new Set(["provided", "provided.al2"])
+export const supportedProvided = new Set([
+  "provided",
+  "provided.al2",
+  "provided.al2023",
+])
 
 // PYTHON
 export const supportedPython = new Set([

--- a/tests/integration/docker/provided-al2023/bootstrap
+++ b/tests/integration/docker/provided-al2023/bootstrap
@@ -1,0 +1,21 @@
+#!/bin/sh
+
+set -euo pipefail
+
+# Initialization - load function handler
+source $LAMBDA_TASK_ROOT/"$(echo $_HANDLER | cut -d. -f1).sh"
+
+# Processing
+while true
+do
+  HEADERS="$(mktemp)"
+  # Get an event
+  EVENT_DATA=$(curl -sS -LD "$HEADERS" -X GET "http://${AWS_LAMBDA_RUNTIME_API}/2018-06-01/runtime/invocation/next")
+  REQUEST_ID=$(grep -Fi Lambda-Runtime-Aws-Request-Id "$HEADERS" | tr -d '[:space:]' | cut -d: -f2)
+
+  # Execute the handler function from the script
+  RESPONSE=$($(echo "$_HANDLER" | cut -d. -f2) "$EVENT_DATA")
+
+  # Send the response
+  curl -s -X POST "http://${AWS_LAMBDA_RUNTIME_API}/2018-06-01/runtime/invocation/$REQUEST_ID/response"  -d "$RESPONSE" -o /dev/null
+done

--- a/tests/integration/docker/provided-al2023/dockerProvided.test.js
+++ b/tests/integration/docker/provided-al2023/dockerProvided.test.js
@@ -1,0 +1,39 @@
+import assert from "node:assert"
+import { env } from "node:process"
+import { join } from "desm"
+import { setup, teardown } from "../../../_testHelpers/index.js"
+import { BASE_URL } from "../../../config.js"
+
+describe("Provided.al2023 with Docker tests", function desc() {
+  beforeEach(() =>
+    setup({
+      servicePath: join(import.meta.url),
+    }),
+  )
+
+  afterEach(() => teardown())
+
+  //
+  ;[
+    {
+      description: "should work with provided.al2023 in docker container",
+      expected: {
+        message: "Hello Provided.al2023!",
+      },
+      path: "/dev/hello",
+    },
+  ].forEach(({ description, expected, path }) => {
+    it(description, async function it() {
+      // "Could not find 'Docker', skipping tests."
+      if (!env.DOCKER_DETECTED) {
+        this.skip()
+      }
+
+      const url = new URL(path, BASE_URL)
+      const response = await fetch(url)
+      const json = await response.json()
+
+      assert.deepEqual(json, expected)
+    })
+  })
+})

--- a/tests/integration/docker/provided-al2023/handler.sh
+++ b/tests/integration/docker/provided-al2023/handler.sh
@@ -1,0 +1,5 @@
+function hello () {
+  RESPONSE="{\"body\": \"{\\\"message\\\": \\\"Hello Provided.al2023!\\\"}\", \"statusCode\": 200}"
+
+  echo $RESPONSE
+}

--- a/tests/integration/docker/provided-al2023/serverless.yml
+++ b/tests/integration/docker/provided-al2023/serverless.yml
@@ -1,0 +1,30 @@
+service: docker-provided-tests
+
+configValidationMode: error
+deprecationNotificationMode: error
+
+plugins:
+  - ../../../../src/index.js
+
+provider:
+  architecture: x86_64
+  deploymentMethod: direct
+  memorySize: 1024
+  name: aws
+  region: us-east-1
+  runtime: provided.al2023
+  stage: dev
+  versionFunctions: false
+
+custom:
+  serverless-offline:
+    noTimeout: true
+    useDocker: true
+
+functions:
+  hello:
+    events:
+      - http:
+          method: get
+          path: hello
+    handler: handler.hello


### PR DESCRIPTION
## Description

This PR adds support for provided.al2023 (https://docs.aws.amazon.com/linux/al2023/ug/lambda.html)

## Motivation and Context

AL2023 image is available for some time ans should be added. `provided.al2023` runtime is based on the AL2023 minimal container image, it is substantially smaller at less than 40 MB than the `provided.al2` runtime at around 109 MB

## How Has This Been Tested?

New tests has been added for provided.al2023
