### PR TITLE
feat: support dev Okta JWT tokens

### DIFF
--- a/src/events/http/HttpServer.js
+++ b/src/events/http/HttpServer.js
@@ -459,7 +459,7 @@ export default class HttpServer {
       request.payload = request.payload && request.payload.toString(encoding)
       request.rawPayload = request.payload
 
-      // incomming request message
+      // incoming request message
       log.notice()
 
       log.notice()

--- a/src/events/http/createJWTAuthScheme.js
+++ b/src/events/http/createJWTAuthScheme.js
@@ -5,7 +5,7 @@ import { log } from "../../utils/log.js"
 const { isArray } = Array
 const { now } = Date
 
-export default function createAuthScheme(jwtOptions) {
+export default function createJWTAuthScheme(jwtOptions) {
   const authorizerName = jwtOptions.name
 
   const identitySourceMatch = /^\$request.header.((?:\w+-?)+\w+)$/.exec(
@@ -88,7 +88,7 @@ export default function createAuthScheme(jwtOptions) {
         return h.authenticated({
           credentials: {
             claims,
-            scopes,
+            // scopes, // this is being ignored by serverless-offline
           },
         })
       } catch (err) {

--- a/src/events/http/createJWTAuthScheme.js
+++ b/src/events/http/createJWTAuthScheme.js
@@ -88,7 +88,7 @@ export default function createJWTAuthScheme(jwtOptions) {
         return h.authenticated({
           credentials: {
             claims,
-            // scopes, // this is being ignored by serverless-offline
+            scopes,
           },
         })
       } catch (err) {

--- a/src/events/http/createJWTAuthScheme.js
+++ b/src/events/http/createJWTAuthScheme.js
@@ -43,7 +43,7 @@ export default function createAuthScheme(jwtOptions) {
           return Boom.unauthorized("JWT Token expired")
         }
 
-        const { aud, iss, scope, client_id: clientId } = claims
+        const { aud, iss, scope, scp, client_id: clientId } = claims
         if (iss !== jwtOptions.issuerUrl) {
           log.notice(`JWT Token not from correct issuer url`)
 
@@ -68,13 +68,13 @@ export default function createAuthScheme(jwtOptions) {
 
         let scopes = null
         if (jwtOptions.scopes && jwtOptions.scopes.length > 0) {
-          if (!scope) {
+          if (!scope && !scp) {
             log.notice(`JWT Token missing valid scope`)
 
             return Boom.forbidden("JWT Token missing valid scope")
           }
 
-          scopes = scope.split(" ")
+          scopes = scp || scope.split(" ")
           if (scopes.every((s) => !jwtOptions.scopes.includes(s))) {
             log.notice(`JWT Token missing valid scope`)
 
@@ -85,7 +85,6 @@ export default function createAuthScheme(jwtOptions) {
         log.notice(`JWT Token validated`)
 
         // Set the credentials for the rest of the pipeline
-        // return resolve(
         return h.authenticated({
           credentials: {
             claims,

--- a/src/events/http/lambda-events/LambdaProxyIntegrationEvent.js
+++ b/src/events/http/lambda-events/LambdaProxyIntegrationEvent.js
@@ -134,8 +134,8 @@ export default class LambdaProxyIntegrationEvent {
     if (token) {
       try {
         claims = decodeJwt(token)
-        if (claims.scope) {
-          scopes = claims.scope.split(" ")
+        if (claims.scp || claims.scope) {
+          scopes = claims.scp || claims.scope.split(" ")
           // In AWS HTTP Api the scope property is removed from the decoded JWT
           // I'm leaving this property because I'm not sure how all of the authorizers
           // for AWS REST Api handle JWT.

--- a/src/events/http/lambda-events/LambdaProxyIntegrationEventV2.js
+++ b/src/events/http/lambda-events/LambdaProxyIntegrationEventV2.js
@@ -120,8 +120,8 @@ export default class LambdaProxyIntegrationEventV2 {
     if (token) {
       try {
         claims = decodeJwt(token)
-        if (claims.scope) {
-          scopes = claims.scope.split(" ")
+        if (claims.scp || claims.scope) {
+          scopes = claims.scp || claims.scope.split(" ")
           // In AWS HTTP Api the scope property is removed from the decoded JWT
           // I'm leaving this property because I'm not sure how all of the authorizers
           // for AWS REST Api handle JWT.

--- a/tests/integration/jwt-authorizer/jwt-authorizer.test.js
+++ b/tests/integration/jwt-authorizer/jwt-authorizer.test.js
@@ -29,6 +29,20 @@ const baseJWT = {
   version: 2,
 }
 
+const oktaJWT = {
+  aud: "api://default",
+  auth_time: floor(now() / 1000),
+  cid: "ZjE4ZGVlYzUtMDU1Ni00",
+  eid: "5d6f052a03414da69c500",
+  exp: floor(now() / 1000) + 5000,
+  iat: floor(now() / 1000),
+  iss: "https://dev-00000000.okta.com/oauth2/default",
+  jti: "9a2f8ae5-9a8d-4d88-be36-bc0a1e042718",
+  scp: ["email", "profile", "openid"],
+  sub: "user@example.com",
+  ver: 1,
+}
+
 const expiredJWT = {
   ...baseJWT,
   exp: floor(now() / 1000) - 2000,
@@ -147,6 +161,19 @@ describe("jwt authorizer tests", function desc() {
       },
       jwt: baseJWT,
       path: "/user2",
+      status: 200,
+    },
+    {
+      description: "Valid Okta format JWT with scp for scopes",
+      expected: {
+        requestContext: {
+          claims: oktaJWT,
+          scopes: ["email", "profile", "openid"],
+        },
+        status: "authorized",
+      },
+      jwt: oktaJWT,
+      path: "/user3",
       status: 200,
     },
     {

--- a/tests/integration/jwt-authorizer/jwt-authorizer.test.js
+++ b/tests/integration/jwt-authorizer/jwt-authorizer.test.js
@@ -168,7 +168,6 @@ describe("jwt authorizer tests", function desc() {
       expected: {
         requestContext: {
           claims: oktaJWT,
-          scopes: ["email", "profile", "openid"],
         },
         status: "authorized",
       },

--- a/tests/integration/jwt-authorizer/jwt-authorizer.test.js
+++ b/tests/integration/jwt-authorizer/jwt-authorizer.test.js
@@ -168,6 +168,7 @@ describe("jwt authorizer tests", function desc() {
       expected: {
         requestContext: {
           claims: oktaJWT,
+          scopes: ["email", "profile", "openid"],
         },
         status: "authorized",
       },

--- a/tests/integration/jwt-authorizer/serverless.yml
+++ b/tests/integration/jwt-authorizer/serverless.yml
@@ -16,6 +16,11 @@ provider:
           - ZjE4ZGVlYzUtMDU1Ni00ZWM4LThkMDAtYTlkMmIzNWE4NTNj
         identitySource: $request.header.Authorization
         issuerUrl: https://cognito-idp.us-east-1.amazonaws.com/us-east-1_notreal
+      oktaJwtAuthorizer:
+        audience:
+          - "api://default"
+        identitySource: $request.header.Authorization
+        issuerUrl: https://dev-00000000.okta.com/oauth2/default
     payload: "1.0"
   memorySize: 1024
   name: aws
@@ -39,4 +44,13 @@ functions:
               - email
           method: get
           path: /user2
+      - httpApi:
+          authorizer:
+            name: oktaJwtAuthorizer
+            scopes:
+              - openid
+              - profile
+              - email
+          method: get
+          path: /user3
     handler: src/handler.user


### PR DESCRIPTION
## Description

Need to work locally with an Okta dev JWT instead of cognito. There was only one key difference that had to be implemented.

## Motivation and Context
Local httpApi JWT validation was written around Cognito but would not work with a dev JWT token from Okta. The only key difference is scopes provided as an scp array instead of a scopes text string, so the changes were just related to that. It will use the scp array if provided, but falls back to original behavior otherwise.

In unit tests, I did put in a new authorizer in the serverless.yml also reflecting the different audience and a JWT Okta example showing some other differences like cid vs client_id but the authorizer already handles those differences.

## How Has This Been Tested?

Tested with dev key on my own project using serverless-offline pointing to file:// per docs from my original project
Wrote a unit test with an Okta JWT token in the same format
Ran full existing test suites

## Screenshots (if appropriate):
