### PR TITLE
fix: return 500 Internal Server Error on python error

### DIFF
--- a/src/events/http/HttpServer.js
+++ b/src/events/http/HttpServer.js
@@ -660,9 +660,12 @@ export default class HttpServer {
 
         // Mocks Lambda errors
         result = {
-          errorMessage,
-          errorType: err.constructor.name,
-          stackTrace: this.#getArrayStackTrace(err.stack),
+          statusCode: errorStatusCode,
+          body: JSON.stringify({
+            message: errorMessage,
+            type: err.constructor.name,
+            stackTrace: this.#getArrayStackTrace(err.stack),
+          })
         }
 
         log.error(errorMessage)

--- a/src/events/http/HttpServer.js
+++ b/src/events/http/HttpServer.js
@@ -645,7 +645,7 @@ export default class HttpServer {
       /* RESPONSE SELECTION (among endpoint's possible responses) */
 
       // Failure handling
-      let errorStatusCode = "502"
+      let errorStatusCode = "500"
 
       if (err) {
         const errorMessage = (err.message || err).toString()
@@ -655,7 +655,7 @@ export default class HttpServer {
         if (found && found.length > 1) {
           ;[, errorStatusCode] = found
         } else {
-          errorStatusCode = "502"
+          errorStatusCode = "500"
         }
 
         // Mocks Lambda errors

--- a/src/events/http/HttpServer.js
+++ b/src/events/http/HttpServer.js
@@ -660,12 +660,12 @@ export default class HttpServer {
 
         // Mocks Lambda errors
         result = {
-          statusCode: errorStatusCode,
           body: JSON.stringify({
             message: errorMessage,
-            type: err.constructor.name,
             stackTrace: this.#getArrayStackTrace(err.stack),
+            type: err.constructor.name,
           }),
+          statusCode: errorStatusCode,
         }
 
         log.error(errorMessage)

--- a/src/events/http/HttpServer.js
+++ b/src/events/http/HttpServer.js
@@ -665,7 +665,7 @@ export default class HttpServer {
             message: errorMessage,
             type: err.constructor.name,
             stackTrace: this.#getArrayStackTrace(err.stack),
-          })
+          }),
         }
 
         log.error(errorMessage)

--- a/src/lambda/handler-runner/python-runner/PythonRunner.js
+++ b/src/lambda/handler-runner/python-runner/PythonRunner.js
@@ -106,7 +106,7 @@ export default class PythonRunner {
       const onErr = (data) => {
         log.notice(data.toString())
 
-        rej(new Error('Internal Server Error'))
+        rej(new Error("Internal Server Error"))
       }
 
       const onLine = (line) => {

--- a/src/lambda/handler-runner/python-runner/PythonRunner.js
+++ b/src/lambda/handler-runner/python-runner/PythonRunner.js
@@ -104,9 +104,9 @@ export default class PythonRunner {
       })
 
       const onErr = (data) => {
-        // TODO
-
         log.notice(data.toString())
+
+        rej(new Error('Internal Server Error'))
       }
 
       const onLine = (line) => {

--- a/tests/runtimes/python/python3/handler.py
+++ b/tests/runtimes/python/python3/handler.py
@@ -9,3 +9,6 @@ def hello(event, context):
         "body": json.dumps(body),
         "statusCode": 200,
     }
+
+def error(event, context):
+    raise Exception("This is an error")

--- a/tests/runtimes/python/python3/python3.test.js
+++ b/tests/runtimes/python/python3/python3.test.js
@@ -37,4 +37,13 @@ describe("Python 3 tests", function desc() {
       assert.deepEqual(json, expected)
     })
   })
+
+  it("should return a 500 on error", async () => {
+    const url = new URL("/dev/error", BASE_URL)
+    const response = await fetch(url)
+    const json = await response.json()
+
+    assert.equal(response.status, 500)
+    assert.equal(json.message, "Internal Server Error")
+  })
 })

--- a/tests/runtimes/python/python3/serverless.yml
+++ b/tests/runtimes/python/python3/serverless.yml
@@ -23,3 +23,9 @@ functions:
           method: get
           path: hello
     handler: handler.hello
+  error:
+    events:
+      - http:
+          method: get
+          path: error
+    handler: handler.error


### PR DESCRIPTION
## Description

Return a 500 Internal Server Error when the Python handler raises an error

## Motivation and Context

When (Python) code raises an error, AWS Lambda returns a 500 with a generic JSON response.
With this change the behaviour of Serverless Offline is more inline with AWS Lambda.

## How Has This Been Tested?

Added an automated test for Python.

## Screenshots (if appropriate):
