### PR TITLE
fix: improve wildcard handling in authorizer policy resource parser

### DIFF
--- a/src/events/authMatchPolicyResource.js
+++ b/src/events/authMatchPolicyResource.js
@@ -1,7 +1,8 @@
 function parseResource(resource) {
-  const [, region, accountId, restApiId, path] = resource.match(
-    /arn:aws:execute-api:(.*?):(.*?):(.*?)\/(.*)/,
-  )
+  const [, region = "*", accountId = "*", restApiId = "*", path = "*"] =
+    resource.match(
+      /arn:aws:execute-api(?::([^:\s]+))(?::([^:\s]+))?(?::([^:\s\/]+))?(?:\/(.*))?/,
+    )
 
   return {
     accountId,

--- a/src/events/authMatchPolicyResource.js
+++ b/src/events/authMatchPolicyResource.js
@@ -27,10 +27,6 @@ export default function authMatchPolicyResource(policyResource, resource) {
     return true
   }
 
-  if (policyResource === "arn:aws:execute-api:*:*:*") {
-    return true
-  }
-
   if (policyResource.includes("*") || policyResource.includes("?")) {
     // Policy contains a wildcard resource
 

--- a/src/events/authMatchPolicyResource.js
+++ b/src/events/authMatchPolicyResource.js
@@ -1,7 +1,7 @@
 function parseResource(resource) {
   const [, region = "*", accountId = "*", restApiId = "*", path = "*"] =
     resource.match(
-      /arn:aws:execute-api(?::([^:\s]+))(?::([^:\s]+))?(?::([^:\s\/]+))?(?:\/(.*))?/,
+      /arn:aws:execute-api(?::([^:\s]+))(?::([^:\s]+))?(?::([^:\s/]+))?(?:\/(.*))?/,
     )
 
   return {

--- a/src/events/authMatchPolicyResource.js
+++ b/src/events/authMatchPolicyResource.js
@@ -1,7 +1,7 @@
 function parseResource(resource) {
   const [, region = "*", accountId = "*", restApiId = "*", path = "*"] =
     resource.match(
-      /arn:aws:execute-api(?::([^:\s]+))(?::([^:\s]+))?(?::([^:\s/]+))?(?:\/(.*))?/,
+      /arn:aws:execute-api:([^\s:]+)(?::([^\s:]+))?(?::([^\s/:]+))?(?:\/(.*))?/,
     )
 
   return {

--- a/tests/old-unit/authMatchPolicyResource.test.js
+++ b/tests/old-unit/authMatchPolicyResource.test.js
@@ -25,6 +25,62 @@ describe("authMatchPolicyResource", () => {
     })
   })
 
+  describe("when the resource ends with a wildcarded region segment", () => {
+    const wildcardResource = "arn:aws:execute-api:*"
+
+    it("matches anything", () => {
+      for (const resource of [
+        "arn:aws:execute-api:eu-west-1:random-account-id:random-api-id/development/GET/dinosaurs",
+        "arn:aws:execute-api:us-west-1:123456:random-api-id/development/GET/diinosaurs",
+        "arn:aws:execute-api:eu-west-2:123abc:random-api-id/development/PUT/dinosaurs",
+        "arn:aws:execute-api:eu-west-1:random-account-id:123abc/development/GET/dinosaurs:extinct",
+        "arn:aws:execute-api:ap-southeast-1:random-account-id:random-api-id/development/GET/diinosaurs",
+      ]) {
+        assert.strictEqual(
+          authMatchPolicyResource(wildcardResource, resource),
+          true,
+        )
+      }
+    })
+  })
+
+  describe("when the resource ends with a wildcarded account-id segment", () => {
+    const wildcardResource = "arn:aws:execute-api:eu-west-1:*"
+
+    describe("and the resource is in the same region", () => {
+      it("matches regardless of what comes afterwards", () => {
+        for (const resource of [
+          "arn:aws:execute-api:eu-west-1:random-account-id:random-api-id/development/GET/dinosaurs",
+          "arn:aws:execute-api:eu-west-1:123456:random-api-id/development/GET/diinosaurs",
+          "arn:aws:execute-api:eu-west-1:123abc:random-api-id/development/PUT/dinosaurs",
+          "arn:aws:execute-api:eu-west-1:random-account-id:123abc/development/GET/dinosaurs:extinct",
+        ]) {
+          assert.strictEqual(
+            authMatchPolicyResource(wildcardResource, resource),
+            true,
+          )
+        }
+      })
+    })
+
+    describe("and the resource is in a different region", () => {
+      it("does not match regardless of what comes afterwards", () => {
+        for (const resource of [
+          "arn:aws:execute-api:eu-west-2:random-account-id:random-api-id/development/GET/dinosaurs",
+          "arn:aws:execute-api:us-west-1:123456:random-api-id/development/GET/diinosaurs",
+          "arn:aws:execute-api:eu-west-2:123abc:random-api-id/development/PUT/dinosaurs",
+          "arn:aws:execute-api:eu-west-2:random-account-id:123abc/development/GET/dinosaurs:extinct",
+          "arn:aws:execute-api:ap-southeast-1:random-account-id:random-api-id/development/GET/diinosaurs",
+        ]) {
+          assert.strictEqual(
+            authMatchPolicyResource(wildcardResource, resource),
+            false,
+          )
+        }
+      })
+    })
+  })
+
   describe("when the resource has wildcards", () => {
     describe("and it matches", () => {
       const wildcardResource =

--- a/tests/old-unit/authMatchPolicyResource.test.js
+++ b/tests/old-unit/authMatchPolicyResource.test.js
@@ -25,6 +25,25 @@ describe("authMatchPolicyResource", () => {
     })
   })
 
+  describe("when the resource defines all segments with a wildcard", () => {
+    const wildcardResource = "arn:aws:execute-api:*:*:*"
+
+    it("matches anything", () => {
+      for (const resource of [
+        "arn:aws:execute-api:eu-west-1:random-account-id:random-api-id/development/GET/dinosaurs",
+        "arn:aws:execute-api:us-west-1:123456:random-api-id/development/GET/diinosaurs",
+        "arn:aws:execute-api:eu-west-2:123abc:random-api-id/development/PUT/dinosaurs",
+        "arn:aws:execute-api:eu-west-1:random-account-id:123abc/development/GET/dinosaurs:extinct",
+        "arn:aws:execute-api:ap-southeast-1:random-account-id:random-api-id/development/GET/diinosaurs",
+      ]) {
+        assert.strictEqual(
+          authMatchPolicyResource(wildcardResource, resource),
+          true,
+        )
+      }
+    })
+  })
+
   describe("when the resource ends with a wildcarded region segment", () => {
     const wildcardResource = "arn:aws:execute-api:*"
 


### PR DESCRIPTION
## Description

Improves the parsing logic of resource arns in authorizer policies so that it handles wildcards more correctly

## Motivation and Context

Currently `serverless-offline` will crash if you use a resource arn that ends with a wildcard'd segment even though that is allowed [per the docs](https://docs.aws.amazon.com/apigateway/latest/developerguide/api-gateway-control-access-using-iam-policies-to-invoke-api.html#api-gateway-calling-api-permissions):

> If you specify a wildcard (*), the Resource expression applies the wildcard to the rest of the expression.

and [here too](https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_elements_resource.html#reference_policies_elements_resource_wildcards):

> If the wildcard (*) is the last character of a resource ARN segment, it can expand to match beyond colon boundaries

Resolves #1794

## How Has This Been Tested?

I ran the test suite and tried it out locally.

## Screenshots (if appropriate):
