### PR TITLE
fix: ensure resource policy matches the whole arn

### DIFF
--- a/src/events/authMatchPolicyResource.js
+++ b/src/events/authMatchPolicyResource.js
@@ -61,7 +61,7 @@ export default function authMatchPolicyResource(policyResource, resource) {
     // for the requested resource and the resource defined in the policy
     // Need to create a regex replacing ? with one character and * with any number of characters
     const regExp = new RegExp(
-      parsedPolicyResource.path.replaceAll("*", ".*").replaceAll("?", "."),
+      `${parsedPolicyResource.path.replaceAll("*", ".*").replaceAll("?", ".")}$`,
     )
 
     return regExp.test(parsedResource.path)

--- a/tests/old-unit/authMatchPolicyResource.test.js
+++ b/tests/old-unit/authMatchPolicyResource.test.js
@@ -155,6 +155,38 @@ describe("authMatchPolicyResource", () => {
         })
       })
     })
+
+    describe("when the resource has segment wildcards", () => {
+      const wildcardResource =
+        "arn:aws:execute-api:*:*:random-api-id/local/GET/organizations"
+
+      describe("and it matches", () => {
+        it("returns true", () => {
+          const resource =
+            "arn:aws:execute-api:eu-west-1:random-account-id:random-api-id/local/GET/organizations"
+
+          assert.strictEqual(
+            authMatchPolicyResource(wildcardResource, resource),
+            true,
+          )
+        })
+      })
+
+      describe("and it does not match", () => {
+        it("returns false", () => {
+          for (const resource of [
+            "arn:aws:execute-api:eu-west-1:random-account-id:random-api-id/local/GET/me",
+            "arn:aws:execute-api:eu-west-1:random-account-id:random-api-id/local/GET/organisations",
+            "arn:aws:execute-api:eu-west-1:random-account-id:random-api-id/local/GET/organizations/1",
+          ]) {
+            assert.strictEqual(
+              authMatchPolicyResource(wildcardResource, resource),
+              false,
+            )
+          }
+        })
+      })
+    })
   })
 
   describe("when the resource has single character wildcards", () => {


### PR DESCRIPTION
## Description

This changes the regexp used to test resource arns with wildcards so that they don't have an implicit wildcard at the end

## Motivation and Context

Resolves #1191

## How Has This Been Tested?

I have run the tests and used this locally

## Screenshots (if appropriate):
