### PR TITLE
handle result structure without body

### DIFF
--- a/src/lambda/handler-runner/python-runner/invoke.py
+++ b/src/lambda/handler-runner/python-runner/invoke.py
@@ -104,9 +104,12 @@ if __name__ == '__main__':
             '__offline_payload__': result
         }
 
-        if isinstance(result['body'], bytes):
-            data['__offline_payload__']['body'] = base64.b64encode(result['body']).decode('utf-8')
-            data['isBase64Encoded'] = True
+        try:
+            if isinstance(result['body'], bytes):
+                data['__offline_payload__']['body'] = base64.b64encode(result['body']).decode('utf-8')
+                data['isBase64Encoded'] = True
+        except (TypeError, KeyError):
+            pass
 
         sys.stdout.write(json.dumps(data))
         sys.stdout.write('\n')

--- a/src/lambda/handler-runner/python-runner/invoke.py
+++ b/src/lambda/handler-runner/python-runner/invoke.py
@@ -104,12 +104,9 @@ if __name__ == '__main__':
             '__offline_payload__': result
         }
 
-        try:
-            if isinstance(result['body'], bytes):
-                data['__offline_payload__']['body'] = base64.b64encode(result['body']).decode('utf-8')
-                data['isBase64Encoded'] = True
-        except (TypeError, KeyError):
-            pass
+        if hasattr(result, 'body') and isinstance(result['body'], bytes):
+            data['__offline_payload__']['body'] = base64.b64encode(result['body']).decode('utf-8')
+            data['isBase64Encoded'] = True
 
         sys.stdout.write(json.dumps(data))
         sys.stdout.write('\n')


### PR DESCRIPTION
## Description

In this scenario, we are expecting a body key in the result object, but what if the result doesn't have a body key or if the result is a simple boolean? I actually, encountered a situation where a Lambda function was returning a bool, which caused the Lambda function to crash, leading to timeouts.

To address this, I added exception handling. If the result object contains a body key, it will function as expected. However, if the body key is absent, the Lambda function won't crash, preventing timeouts.

## Motivation and Context

This will resolve the issue where, if the result object doesn't have a body key, or if the result is a string or boolean, it won't crash. The exception will be handled smoothly.

## How Has This Been Tested?
I have added this change to the invoke.py and then ran the same lambda function, which resolved the issue and I was able to run the lambda functions.

## Screenshots (if appropriate):

<img width="454" alt="Screenshot 2024-08-27 at 1 50 44 AM" src="https://github.com/user-attachments/assets/b0aa2c39-16b2-47a3-90e4-02f91d7714a7">



