### PR TITLE
fix: update dependency to close vulnerability

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
         "java-invoke-local": "0.0.6",
         "jose": "^5.7.0",
         "js-string-escape": "^1.0.1",
-        "jsonpath-plus": "^10.0.0",
+        "jsonpath-plus": "^10.1.0",
         "jsonschema": "^1.4.1",
         "jszip": "^3.10.1",
         "luxon": "^3.5.0",
@@ -7490,9 +7490,10 @@
       ]
     },
     "node_modules/jsonpath-plus": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/jsonpath-plus/-/jsonpath-plus-10.0.0.tgz",
-      "integrity": "sha512-v7j76HGp/ibKlXYeZ7UrfCLSNDaBWuJMA0GaMjA4sZJtCtY89qgPyToDDcl2zdeHh4B5q/B3g2pQdW76fOg/dA==",
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/jsonpath-plus/-/jsonpath-plus-10.1.0.tgz",
+      "integrity": "sha512-gHfV1IYqH8uJHYVTs8BJX1XKy2/rR93+f8QQi0xhx95aCiXn1ettYAd5T+7FU6wfqyDoX/wy0pm/fL3jOKJ9Lg==",
+      "license": "MIT",
       "dependencies": {
         "@jsep-plugin/assignment": "^1.2.1",
         "@jsep-plugin/regex": "^1.0.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
         "java-invoke-local": "0.0.6",
         "jose": "^5.7.0",
         "js-string-escape": "^1.0.1",
-        "jsonpath-plus": "^10.1.0",
+        "jsonpath-plus": "^10.2.0",
         "jsonschema": "^1.4.1",
         "jszip": "^3.10.1",
         "luxon": "^3.5.0",
@@ -2021,9 +2021,10 @@
       }
     },
     "node_modules/@jsep-plugin/assignment": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@jsep-plugin/assignment/-/assignment-1.2.1.tgz",
-      "integrity": "sha512-gaHqbubTi29aZpVbBlECRpmdia+L5/lh2BwtIJTmtxdbecEyyX/ejAOg7eQDGNvGOUmPY7Z2Yxdy9ioyH/VJeA==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@jsep-plugin/assignment/-/assignment-1.3.0.tgz",
+      "integrity": "sha512-VVgV+CXrhbMI3aSusQyclHkenWSAm95WaiKrMxRFam3JSUiIaQjoMIw2sEs/OX4XifnqeQUN4DYbJjlA8EfktQ==",
+      "license": "MIT",
       "engines": {
         "node": ">= 10.16.0"
       },
@@ -2032,9 +2033,10 @@
       }
     },
     "node_modules/@jsep-plugin/regex": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@jsep-plugin/regex/-/regex-1.0.3.tgz",
-      "integrity": "sha512-XfZgry4DwEZvSFtS/6Y+R48D7qJYJK6R9/yJFyUFHCIUMEEHuJ4X95TDgJp5QkmzfLYvapMPzskV5HpIDrREug==",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@jsep-plugin/regex/-/regex-1.0.4.tgz",
+      "integrity": "sha512-q7qL4Mgjs1vByCaTnDFcBnV9HS7GVPJX5vyVoCgZHNSC9rjwIlmbXG5sUuorR5ndfHAIlJ8pVStxvjXHbNvtUg==",
+      "license": "MIT",
       "engines": {
         "node": ">= 10.16.0"
       },
@@ -7402,9 +7404,10 @@
       }
     },
     "node_modules/jsep": {
-      "version": "1.3.9",
-      "resolved": "https://registry.npmjs.org/jsep/-/jsep-1.3.9.tgz",
-      "integrity": "sha512-i1rBX5N7VPl0eYb6+mHNp52sEuaS2Wi8CDYx1X5sn9naevL78+265XJqy1qENEk7mRKwS06NHpUqiBwR7qeodw==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/jsep/-/jsep-1.4.0.tgz",
+      "integrity": "sha512-B7qPcEVE3NVkmSJbaYxvv4cHkVW7DQsZz13pUMrfS8z8Q/BuShN+gcTXrUlPiGqM2/t/EEaI030bpxMqY8gMlw==",
+      "license": "MIT",
       "engines": {
         "node": ">= 10.16.0"
       }
@@ -7490,14 +7493,14 @@
       ]
     },
     "node_modules/jsonpath-plus": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/jsonpath-plus/-/jsonpath-plus-10.1.0.tgz",
-      "integrity": "sha512-gHfV1IYqH8uJHYVTs8BJX1XKy2/rR93+f8QQi0xhx95aCiXn1ettYAd5T+7FU6wfqyDoX/wy0pm/fL3jOKJ9Lg==",
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/jsonpath-plus/-/jsonpath-plus-10.2.0.tgz",
+      "integrity": "sha512-T9V+8iNYKFL2n2rF+w02LBOT2JjDnTjioaNFrxRy0Bv1y/hNsqR/EBK7Ojy2ythRHwmz2cRIls+9JitQGZC/sw==",
       "license": "MIT",
       "dependencies": {
-        "@jsep-plugin/assignment": "^1.2.1",
-        "@jsep-plugin/regex": "^1.0.3",
-        "jsep": "^1.3.9"
+        "@jsep-plugin/assignment": "^1.3.0",
+        "@jsep-plugin/regex": "^1.0.4",
+        "jsep": "^1.4.0"
       },
       "bin": {
         "jsonpath": "bin/jsonpath-cli.js",

--- a/package.json
+++ b/package.json
@@ -90,7 +90,7 @@
     "java-invoke-local": "0.0.6",
     "jose": "^5.7.0",
     "js-string-escape": "^1.0.1",
-    "jsonpath-plus": "^10.1.0",
+    "jsonpath-plus": "^10.2.0",
     "jsonschema": "^1.4.1",
     "jszip": "^3.10.1",
     "luxon": "^3.5.0",

--- a/package.json
+++ b/package.json
@@ -90,7 +90,7 @@
     "java-invoke-local": "0.0.6",
     "jose": "^5.7.0",
     "js-string-escape": "^1.0.1",
-    "jsonpath-plus": "^10.0.0",
+    "jsonpath-plus": "^10.1.0",
     "jsonschema": "^1.4.1",
     "jszip": "^3.10.1",
     "luxon": "^3.5.0",


### PR DESCRIPTION
## Description

First of all thx for all the great work. Like many others we use `serverless-offline` at work. Today we got a dependabot alert for `serverless-offline` because it's dependency package `jsonpath-plus` is subject to a security vulnerability. [A recent bump](https://github.com/dherault/serverless-offline/issues/1825) to Version 10.0.0 only temporarily helped as it was soon found out to still be vulnerable to RCE. 

**Bumped `jsonpath-plus` dependency from 10.0.0 to 10.1.0 to get on top of a security vulnerability with the possibility of remote code execution.** 

## Motivation and Context
For reference you can check out the snyk report via NVD [here](https://nvd.nist.gov/vuln/detail/cve-2024-21534) or see the issue from `jsonpath-plus` [here](https://github.com/JSONPath-Plus/JSONPath/issues/226).

## Screenshots (if appropriate):
![image](https://github.com/user-attachments/assets/19ce9961-89b0-40dc-9acf-cab8d09f1669)
