### PR TITLE
feat: add support for nodejs22.x runtime to v13

### DIFF
--- a/src/config/supportedRuntimes.js
+++ b/src/config/supportedRuntimes.js
@@ -15,6 +15,7 @@ export const supportedRuntimesArchitecture = {
   "nodejs16.x": [ARM64, X86_64],
   "nodejs18.x": [ARM64, X86_64],
   "nodejs20.x": [ARM64, X86_64],
+  "nodejs22.x": [ARM64, X86_64],
   "python3.7": [X86_64],
   "python3.8": [ARM64, X86_64],
   "python3.9": [ARM64, X86_64],
@@ -46,6 +47,7 @@ export const supportedNodejs = new Set([
   "nodejs16.x",
   "nodejs18.x",
   "nodejs20.x",
+  "nodejs22.x",
 ])
 
 // PROVIDED

--- a/tests/integration/docker/multiple/serverless.yml
+++ b/tests/integration/docker/multiple/serverless.yml
@@ -44,11 +44,3 @@ functions:
           path: hello3
     handler: handler.hello
     runtime: python3.8
-
-  hello4:
-    events:
-      - http:
-          method: get
-          path: hello4
-    handler: handler.hello
-    runtime: nodejs20.x

--- a/tests/integration/docker/multiple/serverless.yml
+++ b/tests/integration/docker/multiple/serverless.yml
@@ -44,3 +44,11 @@ functions:
           path: hello3
     handler: handler.hello
     runtime: python3.8
+
+  hello4:
+    events:
+      - http:
+          method: get
+          path: hello4
+    handler: handler.hello
+    runtime: nodejs20.x

--- a/tests/integration/docker/nodejs/nodejs22.x/dockerNodejs22.x.test.js
+++ b/tests/integration/docker/nodejs/nodejs22.x/dockerNodejs22.x.test.js
@@ -1,0 +1,37 @@
+import assert from "node:assert"
+import { env } from "node:process"
+import { join } from "desm"
+import { setup, teardown } from "../../../../_testHelpers/index.js"
+import { BASE_URL } from "../../../../config.js"
+
+describe("Node.js 22.x with Docker tests", function desc() {
+  beforeEach(() =>
+    setup({
+      servicePath: join(import.meta.url),
+    }),
+  )
+
+  afterEach(() => teardown())
+  ;[
+    {
+      description: "should work with nodejs22.x in docker container",
+      expected: {
+        message: "Hello Node.js 22.x!",
+      },
+      path: "/dev/hello",
+    },
+  ].forEach(({ description, expected, path }) => {
+    it(description, async function it() {
+      // "Could not find 'Docker', skipping tests."
+      if (!env.DOCKER_DETECTED) {
+        this.skip()
+      }
+
+      const url = new URL(path, BASE_URL)
+      const response = await fetch(url)
+      const json = await response.json()
+
+      assert.equal(json.message, expected.message)
+    })
+  })
+})

--- a/tests/integration/docker/nodejs/nodejs22.x/handler.js
+++ b/tests/integration/docker/nodejs/nodejs22.x/handler.js
@@ -1,0 +1,16 @@
+"use strict"
+
+// eslint-disable-next-line unicorn/prefer-node-protocol
+const { versions } = require("process")
+
+const { stringify } = JSON
+
+module.exports.hello = async () => {
+  return {
+    body: stringify({
+      message: "Hello Node.js 22.x!",
+      version: versions.node,
+    }),
+    statusCode: 200,
+  }
+}

--- a/tests/integration/docker/nodejs/nodejs22.x/serverless.yml
+++ b/tests/integration/docker/nodejs/nodejs22.x/serverless.yml
@@ -1,6 +1,6 @@
 service: docker-nodejs22-x-test
 
-configValidationMode: error
+configValidationMode: warn
 deprecationNotificationMode: error
 
 plugins:

--- a/tests/integration/docker/nodejs/nodejs22.x/serverless.yml
+++ b/tests/integration/docker/nodejs/nodejs22.x/serverless.yml
@@ -1,0 +1,30 @@
+service: docker-nodejs22-x-test
+
+configValidationMode: error
+deprecationNotificationMode: error
+
+plugins:
+  - ../../../../../src/index.js
+
+provider:
+  architecture: x86_64
+  deploymentMethod: direct
+  memorySize: 1024
+  name: aws
+  region: us-east-1
+  runtime: nodejs22.x
+  stage: dev
+  versionFunctions: false
+
+custom:
+  serverless-offline:
+    noTimeout: true
+    useDocker: true
+
+functions:
+  hello:
+    events:
+      - http:
+          method: get
+          path: hello
+    handler: handler.hello


### PR DESCRIPTION
## Description
Add support for Node.js 22 runtime to v13 branch
<!--- Describe your changes in detail -->

## Motivation and Context
Same changes as https://github.com/dherault/serverless-offline/pull/1837 but for v13
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
