### PR TITLE
feat: Support CloudFormation Join & Sub function in environment variable

### DIFF
--- a/src/lambda/LambdaFunction.js
+++ b/src/lambda/LambdaFunction.js
@@ -7,6 +7,7 @@ import { setTimeout } from "node:timers/promises"
 import { emptyDir, ensureDir, remove } from "fs-extra"
 import jszip from "jszip"
 import { log } from "../utils/log.js"
+import renderIntrinsicFunction from "../utils/renderIntrinsicFunction.js"
 import HandlerRunner from "./handler-runner/index.js"
 import LambdaContext from "./LambdaContext.js"
 import {
@@ -114,8 +115,8 @@ export default class LambdaFunction {
             entries(process.env).filter(([key]) => key.startsWith("AWS_")),
           )),
       ...this.#getAwsEnvVars(),
-      ...provider.environment,
-      ...functionDefinition.environment,
+      ...renderIntrinsicFunction(provider.environment),
+      ...renderIntrinsicFunction(functionDefinition.environment),
       IS_OFFLINE: "true",
     }
 

--- a/src/utils/__tests__/renderIntrinsicFunction.test.js
+++ b/src/utils/__tests__/renderIntrinsicFunction.test.js
@@ -1,0 +1,80 @@
+import assert from "node:assert"
+import renderIntrinsicFunction from "../renderIntrinsicFunction.js"
+
+describe("renderIntrinsicFunction", () => {
+  it("should process Fn::Join correctly", () => {
+    const input = { "Fn::Join": [":", ["a", "b", "c"]] }
+    const result = renderIntrinsicFunction(input)
+    assert.strictEqual(result, "a:b:c")
+  })
+
+  it("should process !Join correctly", () => {
+    const input = { "!Join": [":", ["a", "b", "c"]] }
+    const result = renderIntrinsicFunction(input)
+    assert.strictEqual(result, "a:b:c")
+  })
+
+  it("should process Fn::Sub correctly", () => {
+    const input = {
+      "Fn::Sub": ["The name is ${name}", { name: "CloudFormation" }], // eslint-disable-line no-template-curly-in-string
+    }
+    const result = renderIntrinsicFunction(input)
+    assert.strictEqual(result, "The name is CloudFormation")
+  })
+
+  it("should process !Sub correctly", () => {
+    const input = { "!Sub": ["Hello ${name}", { name: "World" }] } // eslint-disable-line no-template-curly-in-string
+    const result = renderIntrinsicFunction(input)
+    assert.strictEqual(result, "Hello World")
+  })
+
+  it("should process nested Join correctly", () => {
+    const input = {
+      "Fn::Join": ["-", [{ "!Join": [":", ["a", "b", "c"]] }, "d"]],
+    }
+    const result = renderIntrinsicFunction(input)
+    assert.strictEqual(result, "a:b:c-d")
+  })
+
+  it("should process plain strings without modification", () => {
+    const input = "This is a plain string"
+    const result = renderIntrinsicFunction(input)
+    assert.strictEqual(result, "This is a plain string")
+  })
+
+  it("should process numbers without modification", () => {
+    const input = 42
+    const result = renderIntrinsicFunction(input)
+    assert.strictEqual(result, 42)
+  })
+
+  it("should process arrays without intrinsic functions", () => {
+    const input = ["a", "b", "c"]
+    const result = renderIntrinsicFunction(input)
+    assert.deepStrictEqual(result, ["a", "b", "c"])
+  })
+
+  it("should process nested intrinsic functions in arrays", () => {
+    const input = ["a", { "Fn::Join": [":", ["b", "c"]] }, "d"]
+    const result = renderIntrinsicFunction(input)
+    assert.deepStrictEqual(result, ["a", "b:c", "d"])
+  })
+
+  it("should throw an error for unsupported intrinsic functions", () => {
+    const input = { "Fn::UnsupportedFunction": "Value" }
+    const result = renderIntrinsicFunction(input)
+    assert.deepStrictEqual(result, { "Fn::UnsupportedFunction": "Value" })
+  })
+
+  it("should throw an error for unsupported shorthand intrinsic functions", () => {
+    const input = { "!UnsupportedFunction": "Value" }
+    const result = renderIntrinsicFunction(input)
+    assert.deepStrictEqual(result, { "!UnsupportedFunction": "Value" })
+  })
+
+  it("should process nested arrays with intrinsic functions", () => {
+    const input = ["a", ["b", { "!Join": [":", ["c", "d"]] }]]
+    const result = renderIntrinsicFunction(input)
+    assert.deepStrictEqual(result, ["a", ["b", "c:d"]])
+  })
+})

--- a/src/utils/renderIntrinsicFunction.js
+++ b/src/utils/renderIntrinsicFunction.js
@@ -1,0 +1,34 @@
+export default function renderIntrinsicFunction(input) {
+  if (input === null || input === undefined) {
+    return input
+  }
+
+  if (typeof input === "string") {
+    return input
+  }
+
+  if (Array.isArray(input)) {
+    return input.map(renderIntrinsicFunction)
+  }
+
+  if (typeof input === "object") {
+    const result = {}
+    for (const [key, value] of Object.entries(input)) {
+      if (key === "Fn::Join" || key === "!Join") {
+        const [delimiter, list] = value
+        return list.map(renderIntrinsicFunction).join(delimiter)
+      }
+      if (key === "Fn::Sub" || key === "!Sub") {
+        const [template, variables] = value
+        result[key] = template.replaceAll(/\${(.*?)}/g, (match, variable) => {
+          return variable in variables ? variables[variable] : match
+        })
+        return result[key]
+      }
+      result[key] = renderIntrinsicFunction(value)
+    }
+    return result
+  }
+
+  return input
+}


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->
- Support CloudFormation the following intrinsic functions in environment variable
  - `Fn::Join`
  - `!Join`
  - `Fn::Sub`
  - `!Sub`

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- Fix #1013
- Fix #1713

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

example yaml:
```yaml
service: aws-node-project
frameworkVersion: '3'

provider:
  name: aws
  runtime: nodejs18.x
  region: ap-northeast-1
  stage: dev
  environment:
      getKeyARN:
        Fn::Join:
          - ':'
          - - 'arn:aws:lambda'
            - ${self:provider.region}
            - Ref: 'AWS::AccountId'
            - 'function'
            - ${self:service}-${self:provider.stage}-getKey
      qa: 12345

functions:
  function1:
    handler: index.handler
    environment:
      getKeyARN:
        Fn::Join:
          - ':'
          - - 'arn:aws:lambda'
            - ${self:provider.region}
            - Ref: 'AWS::AccountId'
            - 'function'
            - ${self:service}-${self:provider.stage}-getKey
      qa: 12345

plugins:
  - serverless-offline
```
eample js:
```js
module.exports.handler = async (event) => {
  console.log("test")
  console.log(process.env)
  return {
    statusCode: 200,
    body: JSON.stringify(
      {
        message: 'Go Serverless v3.0! Your function executed successfully!',
        input: event,
      },
      null,
      2
    ),
  };
};
```
