### PR TITLE
Update package.json to fix node v22.12 error on serverless

### DIFF
--- a/package.json
+++ b/package.json
@@ -112,9 +112,9 @@
     "mocha": "^10.7.3",
     "nyc": "^17.0.0",
     "prettier": "^3.3.3",
-    "serverless": "^3.2.0"
+    "serverless": "^3.40.0"
   },
   "peerDependencies": {
-    "serverless": "^3.2.0"
+    "serverless": "^3.40.0"
   }
 }


### PR DESCRIPTION
## Description

The error is the same as stated here serverless/serverless#12936 as the version target as dependency for the serverless-offline v13 is serverless ^3.2 the fixing update is not enforced.

Being nodejs22.x a supported runtime I think the version should be changed to fix this here also.

## Motivation and Context

Fix #1844

## How Has This Been Tested?

Adding the following line on devDependecies and running npm install does so the problem does not occur anymore and serverless offline can be started.

```
"devDependencies": {
  ...
  "serverless": "^3.40.0"
}
```


