### PR TITLE
feat: add support for python 3.12 and 3.13 to v13

### DIFF
--- a/src/config/supportedRuntimes.js
+++ b/src/config/supportedRuntimes.js
@@ -21,6 +21,8 @@ export const supportedRuntimesArchitecture = {
   "python3.9": [ARM64, X86_64],
   "python3.10": [ARM64, X86_64],
   "python3.11": [ARM64, X86_64],
+  "python3.12": [ARM64, X86_64],
+  "python3.13": [ARM64, X86_64],
   "ruby2.7": [ARM64, X86_64],
   "ruby3.2": [ARM64, X86_64],
   java8: [X86_64],
@@ -64,6 +66,8 @@ export const supportedPython = new Set([
   "python3.9",
   "python3.10",
   "python3.11",
+  "python3.12",
+  "python3.13",
 ])
 
 // RUBY


### PR DESCRIPTION
## Description

Add support for Python 3.12 and 3.12 to v13 version

## Motivation and Context

Python 3.12 is supported by v14 but not by v13.

## How Has This Been Tested?

There is a warning, coming probably from serverless, but nevertheless I can work with Python 3.12 using this fork

```
❯ serverless offline
Running "serverless" from node_modules

Warning: Invalid configuration encountered
  at 'provider.runtime': must be equal to one of the allowed values [dotnet6, go1.x, java17, java11, java8, java8.al2, nodejs14.x, nodejs16.x, nodejs18.x, nodejs20.x, provided, provided.al2, provided.al2023, python3.7, python3.8, python3.9, python3.10, python3.11, ruby2.7, ruby3.2]

Learn more about configuration validation here: http://slss.io/configuration-validation

Starting Offline at stage dev (<some-aws-region>)

Offline [http for lambda] listening on http://localhost:3002
Function names exposed for local invocation by aws-sdk:
           * main: <some-function-name>

   ┌────────────────────────────────────────────────────────────────────────┐
   │                                                                        │
   │   POST | http://localhost:3000/                                        │
   │   POST | http://localhost:3000/2015-03-31/functions/main/invocations   │
   │                                                                        │
   └────────────────────────────────────────────────────────────────────────┘

Server ready: http://localhost:3000 🚀
```
## Screenshots (if appropriate):
