### PR TITLE
Add support ruby 3.3

### DIFF
--- a/src/config/supportedRuntimes.js
+++ b/src/config/supportedRuntimes.js
@@ -24,6 +24,7 @@ export const supportedRuntimesArchitecture = {
   "python3.12": [ARM64, X86_64],
   "ruby2.7": [ARM64, X86_64],
   "ruby3.2": [ARM64, X86_64],
+  "ruby3.3": [ARM64, X86_64],
   java8: [X86_64],
   "java8.al2": [ARM64, X86_64],
   java11: [ARM64, X86_64],
@@ -69,7 +70,7 @@ export const supportedPython = new Set([
 ])
 
 // RUBY
-export const supportedRuby = new Set(["ruby2.7", "ruby3.2"])
+export const supportedRuby = new Set(["ruby2.7", "ruby3.2", "ruby3.3"])
 
 export const supportedRuntimes = new Set([
   // ...supportedDotnetcore,

--- a/tests/integration/docker/ruby/ruby3.2/serverless.yml
+++ b/tests/integration/docker/ruby/ruby3.2/serverless.yml
@@ -1,4 +1,4 @@
-service: docker-ruby-3-2-tests
+service: docker-ruby-3-3-tests
 
 configValidationMode: error
 deprecationNotificationMode: error
@@ -12,7 +12,7 @@ provider:
   memorySize: 1024
   name: aws
   region: us-east-1
-  runtime: ruby3.2
+  runtime: ruby3.3
   stage: dev
   versionFunctions: false
 

--- a/tests/integration/docker/ruby/ruby3.3/dockerRuby3.3.test.js
+++ b/tests/integration/docker/ruby/ruby3.3/dockerRuby3.3.test.js
@@ -1,0 +1,39 @@
+import assert from "node:assert"
+import { env } from "node:process"
+import { join } from "desm"
+import { setup, teardown } from "../../../../_testHelpers/index.js"
+import { BASE_URL } from "../../../../config.js"
+
+describe("Ruby 3.3 with Docker tests", function desc() {
+  beforeEach(() =>
+    setup({
+      servicePath: join(import.meta.url),
+    }),
+  )
+
+  afterEach(() => teardown())
+
+  //
+  ;[
+    {
+      description: "should work with ruby3.3 in docker container",
+      expected: {
+        message: "Hello Ruby 3.3!",
+      },
+      path: "/dev/hello",
+    },
+  ].forEach(({ description, expected, path }) => {
+    it(description, async function it() {
+      // "Could not find 'Docker', skipping tests."
+      if (!env.DOCKER_DETECTED) {
+        this.skip()
+      }
+
+      const url = new URL(path, BASE_URL)
+      const response = await fetch(url)
+      const json = await response.json()
+
+      assert.equal(json.message, expected.message)
+    })
+  })
+})


### PR DESCRIPTION
## Description

Add support for Ruby 3.3 in serverless-offline.

## Motivation and Context

Currently, when running Serverless Framework with Ruby 3.3, `serverless-offline` fails with the following error:

```
Warning: Warning: found unsupported runtime 'ruby3.3' for function 'xxx'
× Unsupported runtime
```

Note that support for Ruby 3.3 in the Serverless Framework has been proposed but has not yet been merged. The corresponding PR is available here:
https://github.com/serverless/serverless/pull/12420

## How Has This Been Tested?

I have confirmed that an application using Ruby 3.3 runs successfully in Serverless Offline.

## Screenshots (if appropriate):
