### PR TITLE
Add python 3.13 support

### DIFF
--- a/src/config/supportedRuntimes.js
+++ b/src/config/supportedRuntimes.js
@@ -22,6 +22,7 @@ export const supportedRuntimesArchitecture = {
   "python3.10": [ARM64, X86_64],
   "python3.11": [ARM64, X86_64],
   "python3.12": [ARM64, X86_64],
+  "python3.13": [ARM64, X86_64],
   "ruby2.7": [ARM64, X86_64],
   "ruby3.2": [ARM64, X86_64],
   "ruby3.3": [ARM64, X86_64],
@@ -67,6 +68,7 @@ export const supportedPython = new Set([
   "python3.10",
   "python3.11",
   "python3.12",
+  "python3.13",
 ])
 
 // RUBY

--- a/tests/integration/docker/python/python3.13/dockerPython3.13.test.js
+++ b/tests/integration/docker/python/python3.13/dockerPython3.13.test.js
@@ -1,0 +1,39 @@
+import assert from "node:assert"
+import { env } from "node:process"
+import { join } from "desm"
+import { setup, teardown } from "../../../../_testHelpers/index.js"
+import { BASE_URL } from "../../../../config.js"
+
+describe("Python 3.13 with Docker tests", function desc() {
+  beforeEach(() =>
+    setup({
+      servicePath: join(import.meta.url),
+    }),
+  )
+
+  afterEach(() => teardown())
+
+  //
+  ;[
+    {
+      description: "should work with python3.13 in docker container",
+      expected: {
+        message: "Hello Python 3.13!",
+      },
+      path: "/dev/hello",
+    },
+  ].forEach(({ description, expected, path }) => {
+    it(description, async function it() {
+      // "Could not find 'Docker', skipping tests."
+      if (!env.DOCKER_DETECTED) {
+        this.skip()
+      }
+
+      const url = new URL(path, BASE_URL)
+      const response = await fetch(url)
+      const json = await response.json()
+
+      assert.deepEqual(json, expected)
+    })
+  })
+})

--- a/tests/integration/docker/python/python3.13/handler.py
+++ b/tests/integration/docker/python/python3.13/handler.py
@@ -1,0 +1,11 @@
+import json
+
+def hello(event, context):
+    body = {
+        "message": "Hello Python 3.13!"
+    }
+
+    return {
+        "body": json.dumps(body),
+        "statusCode": 200,
+    }

--- a/tests/integration/docker/python/python3.13/serverless.yml
+++ b/tests/integration/docker/python/python3.13/serverless.yml
@@ -1,0 +1,30 @@
+service: docker-python-3-13-tests
+
+configValidationMode: error
+deprecationNotificationMode: error
+
+plugins:
+  - ../../../../../src/index.js
+
+provider:
+  architecture: x86_64
+  deploymentMethod: direct
+  memorySize: 1024
+  name: aws
+  region: us-east-1
+  runtime: python3.13
+  stage: dev
+  versionFunctions: false
+
+custom:
+  serverless-offline:
+    noTimeout: true
+    useDocker: true
+
+functions:
+  hello:
+    events:
+      - http:
+          method: get
+          path: hello
+    handler: handler.hello


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->
Add support for Python 3.13 runtime in serverless-offline for local Lambda development and testing.

## Changes

Added python3.13 to supportedRuntimesArchitecture (ARM64, x86_64)

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This resolves the following issue https://github.com/dherault/serverless-offline/issues/1861

> Warning: found unsupported runtime 'python3.13' for function 'xxx'

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- Local test
``` 
npm run test -- --grep "Python"

> serverless-offline@14.4.0 test
> mocha --require ./tests/mochaHooks.cjs --grep Python

  Python 3.10 with Docker tests
    ✔ should work with python3.10 in docker container (2734ms)

  Python 3.11 with Docker tests
    ✔ should work with python3.11 in docker container (2566ms)

  Python 3.13 with Docker tests
    ✔ should work with python3.13 in docker container (2661ms)

  Python 3.7 with Docker tests
    ✔ should work with python3.7 in docker container (2586ms)

  Python 3.8 with Docker tests
    ✔ should work with python3.8 in docker container (2554ms)

  Python 3 tests
    ✔ should work with python returning a big JSON structure (118ms)

  Python 3 tests
    ✔ should work with python in a module (65ms)

  Python 3 tests
    ✔ should work with python 3 (78ms)


  8 passing (53s)
```

<!--- ## Screenshots (if appropriate): -->
