### PR TITLE
feat: add --watch hot reload for Lambda handlers

### DIFF
--- a/README.md
+++ b/README.md
@@ -249,6 +249,12 @@ Default: ''
 
 Reloads handler with each request.
 
+#### watch
+
+Watch handler files for changes and hot-reload Lambda functions without restarting the server. Uses native `fs.watch` with debouncing. In-flight requests are not interrupted; only idle instances are flushed immediately.<br />
+Ignored when `--useInProcess` is enabled (module cache cannot be cleared in-process).<br />
+Default: false
+
 #### resourceRoutes
 
 Turns on loading of your HTTP proxy settings from serverless.yml.

--- a/src/config/commandOptions.js
+++ b/src/config/commandOptions.js
@@ -129,6 +129,11 @@ export default {
     type: "boolean",
     usage: "Run handlers in the same process as 'serverless-offline'.",
   },
+  watch: {
+    type: "boolean",
+    usage:
+      "Watch handler files for changes and hot-reload Lambda functions without restarting the server.",
+  },
   webSocketHardTimeout: {
     type: "string",
     usage:

--- a/src/config/defaultOptions.js
+++ b/src/config/defaultOptions.js
@@ -26,6 +26,7 @@ export default {
   terminateIdleLambdaTime: 60,
   useDocker: false,
   useInProcess: false,
+  watch: false,
   webSocketHardTimeout: 7200,
   webSocketIdleTimeout: 600,
   websocketPort: 3001,

--- a/src/lambda/FileWatcher.js
+++ b/src/lambda/FileWatcher.js
@@ -1,0 +1,118 @@
+import { watch } from "node:fs"
+import { log } from "../utils/log.js"
+
+const DEBOUNCE_MS = 300
+
+const IGNORE_PATTERNS = new Set([
+  "node_modules",
+  ".git",
+  ".serverless",
+  ".serverless-offline",
+  ".build",
+  ".esbuild",
+  ".webpack",
+])
+
+export default class FileWatcher {
+  #createWatcher = null
+
+  #debounceTimer = null
+
+  #debounceMs = null
+
+  #flushPromise = Promise.resolve()
+
+  #isStopping = false
+
+  #lambda = null
+
+  #servicePath = null
+
+  #watcher = null
+
+  constructor(servicePath, lambda, { createWatcher, debounceMs } = {}) {
+    this.#servicePath = servicePath
+    this.#lambda = lambda
+    this.#createWatcher = createWatcher ?? watch
+    this.#debounceMs = debounceMs ?? DEBOUNCE_MS
+  }
+
+  start() {
+    log.notice("Watching for file changes in service path...")
+    this.#isStopping = false
+
+    try {
+      this.#watcher = this.#createWatcher(
+        this.#servicePath,
+        { recursive: true },
+        this.#onChange.bind(this),
+      )
+
+      this.#watcher.on("error", (err) => {
+        log.warning(
+          `File watcher failed (${err.code ?? err.message}). --watch is no longer active. Restart the server to re-enable.`,
+        )
+        this.#stopWatcher()
+      })
+    } catch (err) {
+      log.warning(
+        `Unable to start file watcher: ${err.message}. --watch disabled.`,
+      )
+    }
+  }
+
+  async stop() {
+    this.#isStopping = true
+
+    clearTimeout(this.#debounceTimer)
+
+    // close first so no new change callbacks get queued while stopping
+    this.#stopWatcher()
+
+    // wait for any in-flight flush to finish
+    await this.#flushPromise
+  }
+
+  #onChange(eventType, filename) {
+    if (
+      this.#isStopping ||
+      this.#watcher == null ||
+      !filename ||
+      this.#shouldIgnore(filename)
+    ) {
+      return
+    }
+
+    clearTimeout(this.#debounceTimer)
+
+    this.#debounceTimer = setTimeout(() => {
+      if (this.#isStopping || this.#watcher == null) {
+        return
+      }
+
+      log.notice(
+        `File change detected: ${filename}. Reloading Lambda functions...`,
+      )
+
+      this.#flushPromise = this.#flushPromise.then(async () => {
+        try {
+          await this.#lambda.flushPool()
+        } catch (err) {
+          log.error(`Failed to reload Lambda functions: ${err.message}`)
+        }
+      })
+    }, this.#debounceMs)
+  }
+
+  #stopWatcher() {
+    if (this.#watcher) {
+      this.#watcher.close()
+      this.#watcher = null
+    }
+  }
+
+  #shouldIgnore(filename) {
+    const segments = filename.split(/[/\\]/)
+    return segments.some((segment) => IGNORE_PATTERNS.has(segment))
+  }
+}

--- a/src/lambda/FileWatcher.test.js
+++ b/src/lambda/FileWatcher.test.js
@@ -1,0 +1,154 @@
+import assert from "node:assert"
+import FileWatcher from "./FileWatcher.js"
+
+class FakeFsWatcher {
+  #callback = null
+
+  #events = new Map()
+
+  closed = false
+
+  options = null
+
+  servicePath = null
+
+  constructor(callback) {
+    this.#callback = callback
+  }
+
+  close() {
+    this.closed = true
+  }
+
+  emitChange(filename) {
+    this.#callback("change", filename)
+  }
+
+  on(event, callback) {
+    this.#events.set(event, callback)
+    return this
+  }
+
+  emitError(error) {
+    const callback = this.#events.get("error")
+
+    if (callback) {
+      callback(error)
+    }
+  }
+}
+
+function sleep(ms) {
+  return new Promise((resolve) => {
+    setTimeout(resolve, ms)
+  })
+}
+
+describe("FileWatcher", () => {
+  let fileWatcher
+  let fakeWatcher
+
+  afterEach(async () => {
+    if (fileWatcher) {
+      await fileWatcher.stop()
+      fileWatcher = null
+    }
+  })
+
+  function createWatcher(servicePath, options, callback) {
+    fakeWatcher = new FakeFsWatcher(callback)
+    fakeWatcher.servicePath = servicePath
+    fakeWatcher.options = options
+
+    return fakeWatcher
+  }
+
+  it("should flush lambda pool on file changes", async () => {
+    let flushCalls = 0
+    const lambda = {
+      async flushPool() {
+        flushCalls += 1
+      },
+    }
+
+    fileWatcher = new FileWatcher("/service", lambda, {
+      createWatcher,
+      debounceMs: 10,
+    })
+
+    fileWatcher.start()
+    fakeWatcher.emitChange("src/handler.js")
+    await sleep(40)
+
+    assert.strictEqual(flushCalls, 1)
+    assert.strictEqual(fakeWatcher.servicePath, "/service")
+    assert.deepStrictEqual(fakeWatcher.options, { recursive: true })
+  })
+
+  it("should ignore configured directories for both path separators", async () => {
+    let flushCalls = 0
+    const lambda = {
+      async flushPool() {
+        flushCalls += 1
+      },
+    }
+
+    fileWatcher = new FileWatcher("/service", lambda, {
+      createWatcher,
+      debounceMs: 10,
+    })
+
+    fileWatcher.start()
+    fakeWatcher.emitChange("node_modules/pkg/index.js")
+    fakeWatcher.emitChange(String.raw`node_modules\pkg\index.js`)
+    fakeWatcher.emitChange(".webpack/main.js")
+    await sleep(40)
+
+    assert.strictEqual(flushCalls, 0)
+  })
+
+  it("should not enqueue new flushes after stop begins", async () => {
+    let flushCalls = 0
+    let firstFlushStartedResolve = null
+    let releaseFirstFlush = null
+
+    const firstFlushStarted = new Promise((resolve) => {
+      firstFlushStartedResolve = resolve
+    })
+
+    const firstFlushDone = new Promise((resolve) => {
+      releaseFirstFlush = resolve
+    })
+
+    const lambda = {
+      async flushPool() {
+        flushCalls += 1
+
+        if (flushCalls === 1) {
+          firstFlushStartedResolve()
+          await firstFlushDone
+        }
+      },
+    }
+
+    fileWatcher = new FileWatcher("/service", lambda, {
+      createWatcher,
+      debounceMs: 10,
+    })
+
+    fileWatcher.start()
+    fakeWatcher.emitChange("src/one.js")
+    await firstFlushStarted
+
+    const stopPromise = fileWatcher.stop()
+    fakeWatcher.emitChange("src/two.js")
+    releaseFirstFlush()
+    await stopPromise
+    await sleep(40)
+
+    assert.strictEqual(flushCalls, 1)
+    assert.strictEqual(fakeWatcher.closed, true)
+
+    fileWatcher = null
+  })
+})

--- a/src/lambda/Lambda.js
+++ b/src/lambda/Lambda.js
@@ -62,6 +62,10 @@ export default class Lambda {
     return this.#httpServer.stop(timeout)
   }
 
+  flushPool() {
+    return this.#lambdaFunctionPool.flushPool()
+  }
+
   cleanup() {
     return this.#lambdaFunctionPool.cleanup()
   }

--- a/src/lambda/LambdaFunctionPool.test.js
+++ b/src/lambda/LambdaFunctionPool.test.js
@@ -1,0 +1,140 @@
+import assert from "node:assert"
+import LambdaFunctionPool from "./LambdaFunctionPool.js"
+
+function createFakeLambdaFunction(initialStatus = "IDLE") {
+  let currentStatus = initialStatus
+
+  return {
+    cleanedUp: false,
+
+    cleanup() {
+      this.cleanedUp = true
+      return Promise.resolve()
+    },
+
+    get idleTimeInMillis() {
+      return currentStatus === "IDLE" ? 999_999 : 0
+    },
+
+    setStatus(val) {
+      currentStatus = val
+    },
+
+    get status() {
+      return currentStatus
+    },
+  }
+}
+
+const BASE_OPTIONS = {
+  reloadHandler: false,
+  terminateIdleLambdaTime: 9999,
+}
+
+function sleep(ms) {
+  return new Promise((resolve) => {
+    setTimeout(resolve, ms)
+  })
+}
+
+describe("LambdaFunctionPool", () => {
+  let pool
+
+  afterEach(async () => {
+    if (pool) {
+      await pool.cleanup()
+    }
+  })
+
+  describe("flushPool", () => {
+    it("should return a new instance after flush", async () => {
+      const instances = []
+      const factory = () => {
+        const fn = createFakeLambdaFunction()
+        instances.push(fn)
+        return fn
+      }
+
+      pool = new LambdaFunctionPool(null, BASE_OPTIONS, {
+        createFunction: factory,
+      })
+      pool.start()
+
+      pool.get("myFunc", {})
+      assert.strictEqual(instances.length, 1)
+
+      await pool.flushPool()
+
+      pool.get("myFunc", {})
+      assert.strictEqual(instances.length, 2)
+      assert.notStrictEqual(instances[0], instances[1])
+    })
+
+    it("should cleanup IDLE instances immediately", async () => {
+      const idleFn = createFakeLambdaFunction("IDLE")
+
+      pool = new LambdaFunctionPool(null, BASE_OPTIONS, {
+        createFunction: () => idleFn,
+      })
+      pool.start()
+      pool.get("myFunc", {})
+
+      await pool.flushPool()
+
+      assert.strictEqual(idleFn.cleanedUp, true)
+    })
+
+    it("should not cleanup BUSY instances during flush", async () => {
+      const busyFn = createFakeLambdaFunction("BUSY")
+
+      pool = new LambdaFunctionPool(null, BASE_OPTIONS, {
+        createFunction: () => busyFn,
+      })
+      pool.start()
+      pool.get("myFunc", {})
+
+      await pool.flushPool()
+
+      assert.strictEqual(busyFn.cleanedUp, false)
+    })
+
+    it("should retire BUSY instances and cleanup on shutdown", async () => {
+      const busyFn = createFakeLambdaFunction("BUSY")
+
+      pool = new LambdaFunctionPool(null, BASE_OPTIONS, {
+        createFunction: () => busyFn,
+      })
+      pool.start()
+      pool.get("myFunc", {})
+
+      await pool.flushPool()
+      assert.strictEqual(busyFn.cleanedUp, false)
+
+      // full cleanup (shutdown) should drain retiring set
+      await pool.cleanup()
+      assert.strictEqual(busyFn.cleanedUp, true)
+
+      // prevent afterEach double-cleanup
+      pool = null
+    })
+
+    it("should cleanup retired instances shortly after they become IDLE", async () => {
+      const busyFn = createFakeLambdaFunction("BUSY")
+
+      pool = new LambdaFunctionPool(null, BASE_OPTIONS, {
+        createFunction: () => busyFn,
+        retireCheckIntervalMs: 10,
+      })
+      pool.start()
+      pool.get("myFunc", {})
+
+      await pool.flushPool()
+      assert.strictEqual(busyFn.cleanedUp, false)
+
+      busyFn.setStatus("IDLE")
+      await sleep(60)
+
+      assert.strictEqual(busyFn.cleanedUp, true)
+    })
+  })
+})


### PR DESCRIPTION
## Description

This PR adds opt-in hot watch support for Lambda handlers via a new `--watch` option.

### What changed
- Added `watch` CLI/config option (default: `false`)
  - `src/config/commandOptions.js`
  - `src/config/defaultOptions.js`
- Added `FileWatcher` implementation using native `fs.watch` with debouncing
  - `src/lambda/FileWatcher.js`
- Integrated watcher lifecycle into startup/shutdown
  - start watcher when `--watch` is enabled and Lambda is present
  - skip with warning when `--useInProcess` is enabled
  - stop watcher cleanly on shutdown
  - `src/ServerlessOffline.js`
- Added pool flush API and behavior to support hot reload without interrupting in-flight requests
  - `Lambda.flushPool()` passthrough
  - pool flushes `IDLE` instances immediately and retires `BUSY` instances for cleanup when they become idle
  - `src/lambda/Lambda.js`
  - `src/lambda/LambdaFunctionPool.js`
- Added unit tests for flush/retire behavior
  - `src/lambda/LambdaFunctionPool.test.js`
- Added README documentation for `watch`
  - `README.md`

## Motivation and Context

Today, code changes generally require restarting `serverless-offline` (or enabling per-request reload behavior). This PR improves local DX by allowing handler changes to be picked up automatically while the server keeps running.

Key goals:
- keep hot reload opt-in (`--watch`)
- avoid interrupting in-flight invocations
- keep existing non-watch behavior unchanged
- avoid watch mode for `--useInProcess` where module cache cannot be safely reset

## How Has This Been Tested?

Ran targeted lint and unit tests for all touched hot-watch code paths:

```bash
npx eslint src/ServerlessOffline.js src/lambda/FileWatcher.js src/lambda/FileWatcher.test.js src/lambda/LambdaFunctionPool.js src/lambda/LambdaFunctionPool.test.js
npx mocha --no-config src/lambda/FileWatcher.test.js src/lambda/LambdaFunctionPool.test.js
```
Results:
• ESLint: passed
• Mocha: 8 passing
Notes:
• Tests cover debounce-triggered flush, ignore patterns, watcher stop race behavior, and BUSY/IDLE retire cleanup semantics.