### PR TITLE
feat: add support for nodejs24.x runtime to v13.  Closes #1879

### DIFF
--- a/src/config/supportedRuntimes.js
+++ b/src/config/supportedRuntimes.js
@@ -16,6 +16,7 @@ export const supportedRuntimesArchitecture = {
   "nodejs18.x": [ARM64, X86_64],
   "nodejs20.x": [ARM64, X86_64],
   "nodejs22.x": [ARM64, X86_64],
+  "nodejs24.x": [ARM64, X86_64],
   "python3.7": [X86_64],
   "python3.8": [ARM64, X86_64],
   "python3.9": [ARM64, X86_64],
@@ -50,6 +51,7 @@ export const supportedNodejs = new Set([
   "nodejs18.x",
   "nodejs20.x",
   "nodejs22.x",
+  "nodejs24.x",
 ])
 
 // PROVIDED

--- a/tests/integration/docker/nodejs/nodejs24.x/dockerNodejs24.x.test.js
+++ b/tests/integration/docker/nodejs/nodejs24.x/dockerNodejs24.x.test.js
@@ -1,0 +1,37 @@
+import assert from "node:assert"
+import { env } from "node:process"
+import { join } from "desm"
+import { setup, teardown } from "../../../../_testHelpers/index.js"
+import { BASE_URL } from "../../../../config.js"
+
+describe("Node.js 24.x with Docker tests", function desc() {
+  beforeEach(() =>
+    setup({
+      servicePath: join(import.meta.url),
+    }),
+  )
+
+  afterEach(() => teardown())
+  ;[
+    {
+      description: "should work with nodejs24.x in docker container",
+      expected: {
+        message: "Hello Node.js 24.x!",
+      },
+      path: "/dev/hello",
+    },
+  ].forEach(({ description, expected, path }) => {
+    it(description, async function it() {
+      // "Could not find 'Docker', skipping tests."
+      if (!env.DOCKER_DETECTED) {
+        this.skip()
+      }
+
+      const url = new URL(path, BASE_URL)
+      const response = await fetch(url)
+      const json = await response.json()
+
+      assert.equal(json.message, expected.message)
+    })
+  })
+})

--- a/tests/integration/docker/nodejs/nodejs24.x/handler.js
+++ b/tests/integration/docker/nodejs/nodejs24.x/handler.js
@@ -1,0 +1,16 @@
+"use strict"
+
+// eslint-disable-next-line unicorn/prefer-node-protocol
+const { versions } = require("process")
+
+const { stringify } = JSON
+
+module.exports.hello = async () => {
+  return {
+    body: stringify({
+      message: "Hello Node.js 24.x!",
+      version: versions.node,
+    }),
+    statusCode: 200,
+  }
+}

--- a/tests/integration/docker/nodejs/nodejs24.x/serverless.yml
+++ b/tests/integration/docker/nodejs/nodejs24.x/serverless.yml
@@ -1,0 +1,30 @@
+service: docker-nodejs24-x-test
+
+configValidationMode: warn
+deprecationNotificationMode: error
+
+plugins:
+  - ../../../../../src/index.js
+
+provider:
+  architecture: x86_64
+  deploymentMethod: direct
+  memorySize: 1024
+  name: aws
+  region: us-east-1
+  runtime: nodejs24.x
+  stage: dev
+  versionFunctions: false
+
+custom:
+  serverless-offline:
+    noTimeout: true
+    useDocker: true
+
+functions:
+  hello:
+    events:
+      - http:
+          method: get
+          path: hello
+    handler: handler.hello


### PR DESCRIPTION
## Description

Adds nodejs24.x to the supported runtimes in the v13 branch. This includes adding the runtime to both supportedRuntimesArchitecture (ARM64 + x86_64) and the supportedNodejs set, along with Docker integration tests following the existing pattern.

## Motivation and Context

nodejs24.x is available on AWS Lambda but is not recognized by serverless-offline v13, causing functions to fail with Unsupported runtime at invocation. v14 already has this support but requires Serverless v4. This follows the same approach used in [#1838 ](https://github.com/dherault/serverless-offline/issues/1838)(nodejs22.x) and [#1840](https://github.com/dherault/serverless-offline/issues/1840).

## How Has This Been Tested?
  - The new nodejs24.x Docker integration test was picked up by mocha and passed successfully (~11s).