### PR TITLE
fix: keep authorizer override when noAuth is true (v13)

### DIFF
--- a/src/events/http/HttpServer.js
+++ b/src/events/http/HttpServer.js
@@ -2,7 +2,7 @@ import { Buffer } from "node:buffer"
 import { readFile } from "node:fs/promises"
 import { createRequire } from "node:module"
 import { join, resolve } from "node:path"
-import { exit } from "node:process"
+import { exit, env } from "node:process"
 import h2o2 from "@hapi/h2o2"
 import { Server } from "@hapi/hapi"
 import { log } from "../../utils/log.js"
@@ -613,7 +613,27 @@ export default class HttpServer {
         const hasCustomAuthProvider =
           customizations?.offline?.customAuthenticationProvider
 
-        if (!endpoint.authorizer && !hasCustomAuthProvider) {
+        const authorizerOverrideHeader =
+          request.headers["sls-offline-authorizer-override"]
+        const authorizerOverrideEnv = env.AUTHORIZER
+        const hasAuthorizerOverride = [
+          authorizerOverrideHeader,
+          authorizerOverrideEnv,
+        ].some((value) => {
+          if (!value) return false
+          try {
+            parse(value)
+            return true
+          } catch {
+            return false
+          }
+        })
+
+        if (
+          !endpoint.authorizer &&
+          !hasCustomAuthProvider &&
+          !hasAuthorizerOverride
+        ) {
           log.debug("no authorizer configured, deleting authorizer payload")
           delete event.requestContext.authorizer
         }

--- a/tests/integration/override-authorizer/override-authorizer.test.js
+++ b/tests/integration/override-authorizer/override-authorizer.test.js
@@ -34,7 +34,7 @@ describe("override authorizer tests", function desc() {
   })
 
   afterEach(async () => {
-    env.AUTHORIZER = undefined
+    delete env.AUTHORIZER
     await teardown()
   })
 


### PR DESCRIPTION
## Summary

- When `noAuth: true` is set in options, authorizer overrides configured via `--authorizer` flag were being silently ignored
- Fix preserves authorizer overrides even when `noAuth` is enabled, so custom authorizers still run

## Context

This is a re-submission targeting `v13`. The previous PR #1883 was closed because it was submitted from a `master`-based branch targeting `master`.

Closes / re-opens: https://github.com/dherault/serverless-offline/pull/1883

## Test plan

- [x] Run serverless-offline with `noAuth: true` and a custom `--authorizer` — authorizer should still be invoked
- [x] Run serverless-offline with `noAuth: true` and no authorizer override — behavior unchanged (no auth)