### PR TITLE
Code review fixes: env leak, worker-thread, WS cleanup, HTTP/ALB handlers

### DIFF
--- a/.github/workflows/lint_and_test.yml
+++ b/.github/workflows/lint_and_test.yml
@@ -13,7 +13,7 @@ env:
 
 jobs:
   build:
-    name: "node.js v${{ matrix.node-version }}"
+    name: "Node.js v${{ matrix.node-version }}"
     runs-on: ubuntu-latest
     timeout-minutes: 40
     environment: ${{ github.event_name == 'pull_request_target' && 'fork-pr-tests' || '' }}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -39,6 +39,7 @@ npx mocha --require ./tests/mochaHooks.cjs --grep "partial test name"
 ### Plugin lifecycle and event dispatch
 
 [src/ServerlessOffline.js](src/ServerlessOffline.js) is the orchestrator. On `start()` it:
+
 1. `#mergeOptions()` — merges options with precedence **CLI options > `custom.serverless-offline` in serverless.yml > [defaultOptions](src/config/defaultOptions.js)**, then derives CORS config.
 2. `#getEvents()` — walks every function in the Serverless service and buckets its events into `lambdas`, `httpEvents`, `httpApiEvents`, `albEvents`, `scheduleEvents`, `webSocketEvents`. Note `httpApi` events are normalized here into a `routeKey` form and tagged `isHttpApi`, with payload version (`1.0`/`2.0`) resolved.
 3. Lazily `import()`s and instantiates only the event modules that have events. **All event modules and runtime runners are dynamically imported** so an unused subsystem (e.g. Docker, Python) is never loaded.
@@ -59,6 +60,7 @@ This is the core. The chain is:
 ### Run modes (per [src/lambda/handler-runner/](src/lambda/handler-runner/))
 
 Node.js runtimes:
+
 - **worker-thread-runner** (default) — handler runs in an isolated Worker thread; no shared `process.env`/global state; supports reload.
 - **in-process-runner** — handler runs in the same process as serverless-offline (shared env/globals, no reload). Selected with `--useInProcess`.
 
@@ -84,4 +86,4 @@ HTTP authorizers live in [src/events/http/](src/events/http/): `createAuthScheme
 - `src/**/__tests__/*.test.js` — unit tests colocated with source.
 - [tests/integration/](tests/integration/) — per-feature service fixtures (authorizers, cors, websocket, alb, docker, lambda-invoke, etc.); each spins up an actual offline server.
 - [tests/end-to-end/](tests/end-to-end/), [tests/runtimes/](tests/runtimes/) (go/python/java), [tests/handler-module-formats/](tests/handler-module-formats/), [tests/lambda-run-mode/](tests/lambda-run-mode/) (in-process vs worker-threads), [tests/timeout/](tests/timeout/).
-- [tests/_testHelpers/](tests/_testHelpers/) — `setup`/`teardown` that launch the real serverless binary against a fixture, plus artifact-compression and docker-image helpers.
+- [tests/\_testHelpers/](tests/_testHelpers/) — `setup`/`teardown` that launch the real serverless binary against a fixture, plus artifact-compression and docker-image helpers.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,87 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## What this is
+
+`serverless-offline` is a plugin for the [Serverless Framework](https://github.com/serverless/serverless) (peer dependency `serverless@^4`). It emulates AWS Lambda + API Gateway (plus ALB, WebSocket, and scheduled events) locally by starting HTTP servers that replicate the AWS request lifecycle and invoke your handlers. It is **pure ESM** (`"type": "module"`) and requires Node `>=20`.
+
+The package is consumed as a Serverless plugin, not run directly. The Serverless Framework loads the class exported from [src/index.js](src/index.js) and drives it through plugin hooks (`offline:start:init` → `start()`, `offline:start:ready`, `offline:start:end` → `end()`).
+
+## Commands
+
+```bash
+npm run lint              # eslint .
+npm run lint:fix          # eslint . --fix
+npm run prettier          # prettier --check .
+npm run prettier:fix      # prettier --write .
+npm run code-quality      # prettier check + lint (run before committing)
+
+npm test                  # all tests (mocha)
+npm run test:unit         # unit tests only (src/**/*.test.js + tests/old-unit)
+npm run test:e2e          # end-to-end tests (tests/end-to-end)
+npm run test:node         # node-runtime-focused suite
+npm run test:docker       # docker integration tests
+npm run test:cov          # coverage via nyc
+```
+
+Run a single test file or filter:
+
+```bash
+npx mocha --require ./tests/mochaHooks.cjs path/to/file.test.js
+npx mocha --require ./tests/mochaHooks.cjs --grep "partial test name"
+```
+
+**Tests require `SERVERLESS_ACCESS_KEY` to be set** — [tests/mochaHooks.cjs](tests/mochaHooks.cjs) hard-exits otherwise (get one via `npx serverless login`). The hook also auto-detects `java`, `python3`, `ruby`, `docker`, and `go` on the machine and sets `*_DETECTED` env vars; runtime-specific tests skip themselves when their toolchain is absent. The `TEST` env var selects which spec globs mocha runs — see [.mocharc.cjs](.mocharc.cjs). Test timeout is 300s.
+
+## Architecture
+
+### Plugin lifecycle and event dispatch
+
+[src/ServerlessOffline.js](src/ServerlessOffline.js) is the orchestrator. On `start()` it:
+1. `#mergeOptions()` — merges options with precedence **CLI options > `custom.serverless-offline` in serverless.yml > [defaultOptions](src/config/defaultOptions.js)**, then derives CORS config.
+2. `#getEvents()` — walks every function in the Serverless service and buckets its events into `lambdas`, `httpEvents`, `httpApiEvents`, `albEvents`, `scheduleEvents`, `webSocketEvents`. Note `httpApi` events are normalized here into a `routeKey` form and tagged `isHttpApi`, with payload version (`1.0`/`2.0`) resolved.
+3. Lazily `import()`s and instantiates only the event modules that have events. **All event modules and runtime runners are dynamically imported** so an unused subsystem (e.g. Docker, Python) is never loaded.
+
+Each event subsystem lives under [src/events/](src/events/) and follows the same shape: an `index.js` re-exporting a class, an `*EventDefinition.js` that parses the serverless.yml event config, an `HttpServer.js` (Hapi server), and a top-level class (`Http`, `Alb`, `Schedule`, `WebSocket`) with `createServer()` / `create(events)` / `start()` / `stop()`. The HTTP/ALB/WebSocket servers are all [Hapi](https://hapi.dev) servers.
+
+### Lambda invocation pipeline
+
+This is the core. The chain is:
+
+`Lambda` → `LambdaFunctionPool` → `LambdaFunction` → `HandlerRunner` → a concrete runner.
+
+- [src/lambda/Lambda.js](src/lambda/Lambda.js) — registry of functions by key and by AWS function name; also owns the local **Lambda invoke HTTP server (default port 3002)** that emulates the AWS SDK `Invoke` / `InvokeAsync` APIs (see [src/lambda/routes/](src/lambda/routes/)). This is what lets one local lambda call another via the AWS SDK pointed at `http://localhost:3002`.
+- [src/lambda/LambdaFunctionPool.js](src/lambda/LambdaFunctionPool.js) — pools `LambdaFunction` instances per function key. Reuses any `IDLE` instance unless `reloadHandler` is set (which forces a fresh instance each call). A background timer reaps instances idle longer than `terminateIdleLambdaTime` seconds.
+- [src/lambda/LambdaFunction.js](src/lambda/LambdaFunction.js) — one invocation context: builds the env vars (always copies `AWS_*` from the host; copies all of `process.env` only when `localEnvironment` is set; applies `provider.environment` + function `environment` through `renderIntrinsicFunction`), extracts the deployment artifact zip if `package.artifact` is set, enforces the timeout via `Promise.race` against a `LambdaTimeoutError`, and tracks BUSY/IDLE status + billed duration.
+- [src/lambda/handler-runner/HandlerRunner.js](src/lambda/handler-runner/HandlerRunner.js) — picks the concrete runner from the runtime string and options. This is the **run-mode decision point**.
+
+### Run modes (per [src/lambda/handler-runner/](src/lambda/handler-runner/))
+
+Node.js runtimes:
+- **worker-thread-runner** (default) — handler runs in an isolated Worker thread; no shared `process.env`/global state; supports reload.
+- **in-process-runner** — handler runs in the same process as serverless-offline (shared env/globals, no reload). Selected with `--useInProcess`.
+
+Other runtimes run in a child process: **python-runner**, **ruby-runner**, **go-runner**, **java-runner** (uses `java-invoke-local`). **docker-runner** runs any supported runtime in a container, selected with `--useDocker`.
+
+Supported runtimes and their architectures are declared in [src/config/supportedRuntimes.js](src/config/supportedRuntimes.js). An unsupported runtime warns but does not abort.
+
+### Authorizers
+
+HTTP authorizers live in [src/events/http/](src/events/http/): `createAuthScheme.js` (custom/token/request authorizers, registered as Hapi auth schemes), `createJWTAuthScheme.js` + `authJWTSettingsExtractor.js` (JWT for httpApi), and policy evaluation in [src/events/](src/events/) (`authCanExecuteResource.js`, `authMatchPolicyResource.js`, `authValidateContext.js`). WebSocket authorizers are under [src/events/websocket/lambda-events/](src/events/websocket/lambda-events/).
+
+## Conventions
+
+- **Pure ESM, file extensions required in imports** (`./foo.js`, enforced by the `import/extensions` ESLint rule). Dynamic `import()` is used deliberately for lazy-loading subsystems — keep it that way.
+- **No bare `Buffer` / `process` globals** — import them from `node:buffer` / `node:process` (enforced by `no-restricted-globals`).
+- ESLint extends Airbnb base + `unicorn` + Prettier; `sort-keys` is **on** (object keys must be alphabetical). Config files use the `.cjs` extension. See [.eslintrc.cjs](.eslintrc.cjs).
+- Classes use native `#private` fields heavily (see `LambdaFunction`, `ServerlessOffline`).
+- Logging goes through [src/utils/log.js](src/utils/log.js) (`log.notice` / `log.debug` / `log.warning` / `log.error`), not `console`.
+- `ServerlessOffline.internals()` exists only to expose private methods to the test suite — note the `TODO FIXME` markers; don't rely on it in production code.
+
+## Tests layout
+
+- `src/**/__tests__/*.test.js` — unit tests colocated with source.
+- [tests/integration/](tests/integration/) — per-feature service fixtures (authorizers, cors, websocket, alb, docker, lambda-invoke, etc.); each spins up an actual offline server.
+- [tests/end-to-end/](tests/end-to-end/), [tests/runtimes/](tests/runtimes/) (go/python/java), [tests/handler-module-formats/](tests/handler-module-formats/), [tests/lambda-run-mode/](tests/lambda-run-mode/) (in-process vs worker-threads), [tests/timeout/](tests/timeout/).
+- [tests/_testHelpers/](tests/_testHelpers/) — `setup`/`teardown` that launch the real serverless binary against a fixture, plus artifact-compression and docker-image helpers.

--- a/README.md
+++ b/README.md
@@ -155,7 +155,7 @@ Default: localhost
 
 #### dockerHostServicePath
 
-Defines service path which is used by SLS running inside Docker container.
+Defines the service path used by SLS running inside a Docker container.
 
 #### dockerNetwork
 
@@ -284,14 +284,14 @@ By default you can send your requests to `http://localhost:3000/`. Please note t
 
 - You'll need to restart the plugin if you modify your `serverless.yml` or any of the default velocity template files.
 - When no Content-Type header is set on a request, API Gateway defaults to `application/json`, and so does the plugin.
-  But if you send an `application/x-www-form-urlencoded` or a `multipart/form-data` body with an `application/json` (or no) Content-Type, API Gateway won't parse your data (you'll get the ugly raw as input), whereas the plugin will answer 400 (malformed JSON).
+  But if you send an `application/x-www-form-urlencoded` or a `multipart/form-data` body with an `application/json` (or no) Content-Type, API Gateway won't parse your data (you'll get the ugly raw data as input), whereas the plugin will answer 400 (malformed JSON).
   Please consider explicitly setting your requests' Content-Type and using separate templates.
 
 ## Run modes
 
 ### node.js
 
-Lambda handlers with `serverless-offline` for the `node.js` runtime can run in different execution modes and have some differences with a variety of pros and cons. They are currently mutually exclusive and it's not possible to use a combination, e.g. use `in-process` for one Lambda, and `worker-threads` for another. It is planned to combine the flags into one single flag in the future and also add support for combining run modes.
+Lambda handlers with `serverless-offline` for the `node.js` runtime can run in different execution modes, each with its own pros and cons. They are currently mutually exclusive and it's not possible to use a combination, e.g. use `in-process` for one Lambda, and `worker-threads` for another. It is planned to combine the flags into one single flag in the future and also add support for combining run modes.
 
 #### worker-threads (default)
 
@@ -466,7 +466,7 @@ If you're using least-privilege principals for your AWS roles, this policy shoul
 }
 ```
 
-Once you run a function that boots up the Docker container, it'll look through the layers for that function, download them in order to your layers folder, and save a hash of your layers so it can be re-used in the future. You'll only need to re-download your layers if they change in the future. If you want your layers to re-download, simply remove your layers folder.
+Once you run a function that boots up the Docker container, it'll look through the layers for that function, download them to your layers folder, and save a hash of your layers so it can be re-used in the future. You'll only need to re-download your layers if they change in the future. If you want your layers to re-download, simply remove your layers folder.
 
 You should then be able to invoke functions as normal, and they're executed against the layers in your docker container.
 
@@ -490,11 +490,11 @@ When running Docker Lambda inside another Docker container, you may need to over
 
 #### dockerNetwork
 
-When running Docker Lambda inside another Docker container, you may need to override network that Docker Lambda connects to in order to communicate with other containers.
+When running Docker Lambda inside another Docker container, you may need to override the network that Docker Lambda connects to in order to communicate with other containers.
 
 #### dockerReadOnly
 
-For certain programming languages and frameworks, it's desirable to be able to write to the filesystem for things like testing with local SQLite databases, or other testing-only modifications. For this, you can set `dockerReadOnly: false`, and this will allow local filesystem modifications. This does not strictly mimic AWS Lambda, as Lambda has a Read-Only filesystem, so this should be used as a last resort.
+For certain programming languages and frameworks, it's desirable to be able to write to the filesystem for things like testing with local SQLite databases, or other testing-only modifications. For this, you can set `dockerReadOnly: false`, and this will allow local filesystem modifications. This does not strictly mimic AWS Lambda, as Lambda has a read-only filesystem, so this should be used as a last resort.
 
 #### layersDir
 
@@ -506,7 +506,7 @@ By default layers are downloaded on a per-project basis, however, if you want to
 
 As defined in the [Serverless Documentation](https://serverless.com/framework/docs/providers/aws/events/apigateway/#setting-api-keys-for-your-rest-api) you can use API Keys as a simple authentication method.
 
-Serverless-offline will emulate the behaviour of APIG and create a random token that's printed on the screen. With this token you can access your private methods adding `x-api-key: generatedToken` to your request header. All api keys will share the same token.
+Serverless-offline will emulate the behaviour of APIG and create a random token that's printed on the screen. With this token you can access your private methods by adding `x-api-key: generatedToken` to your request header. All API keys will share the same token.
 
 ### Custom authorizers
 
@@ -524,7 +524,7 @@ The Custom authorizer is passed an `event` object as below:
 
 The `methodArn` does not include the Account id or API id.
 
-The plugin only supports retrieving Tokens from headers. You can configure the header as below:
+The plugin only supports retrieving tokens from headers. You can configure the header as below:
 
 ```js
 "authorizer": {
@@ -775,7 +775,7 @@ There's support for [websocketsApiRouteSelectionExpression](https://docs.aws.ama
 
 ## Debug process
 
-The Serverless offline plugin will respond to the overall framework settings and output additional information to the console in debug mode. In order to do this you will have to set the `SLS_DEBUG` environmental variable. You can run the following in the command line to switch to debug mode execution.
+The Serverless offline plugin will respond to the overall framework settings and output additional information to the console in debug mode. In order to do this you will have to set the `SLS_DEBUG` environment variable. You can run the following in the command line to switch to debug mode execution.
 
 > Unix: `export SLS_DEBUG=*`
 
@@ -789,9 +789,9 @@ Initial installation:
 For each debug run:
 `node-debug sls offline`
 
-The system will start in wait status. This will also automatically start the chrome browser and wait for you to set breakpoints for inspection. Set the breakpoints as needed and, then, click the play button for the debugging to continue.
+The system will start in wait status. This will also automatically start the Chrome browser and wait for you to set breakpoints for inspection. Set the breakpoints as needed and, then, click the play button for the debugging to continue.
 
-Depending on the breakpoint, you may need to call the URL path for your function in separate browser window for your serverless function to be run and made available for debugging.
+Depending on the breakpoint, you may need to call the URL path for your function in a separate browser window for your serverless function to be run and made available for debugging.
 
 ### Interactive Debugging with Visual Studio Code (VSC)
 
@@ -832,7 +832,7 @@ Example:
 }
 ```
 
-In VSC, you can, then, add breakpoints to your code. To start a debug session you can either start your script in `package.json` by clicking the hovering debug intellisense icon or by going to your debug pane and selecting the Debug Serverless Offline configuration.
+In VSC, you can then add breakpoints to your code. To start a debug session you can either start your script in `package.json` by clicking the hovering debug IntelliSense icon or by going to your debug pane and selecting the Debug Serverless Offline configuration.
 
 ## Resource permissions and AWS profile
 

--- a/src/events/alb/HttpServer.js
+++ b/src/events/alb/HttpServer.js
@@ -168,7 +168,7 @@ export default class HttpServer {
     return async (request, h) => {
       const requestPath = this.#options.noPrependStageInUrl
         ? request.path
-        : request.path.substr(`/${stage}`.length)
+        : request.path.slice(`/${stage}`.length)
 
       // Payload processing
       const encoding = detectEncoding(request)

--- a/src/events/http/HttpServer.js
+++ b/src/events/http/HttpServer.js
@@ -451,7 +451,7 @@ export default class HttpServer {
       const requestPath =
         endpoint.isHttpApi || this.#options.noPrependStageInUrl
           ? request.path
-          : request.path.substr(`/${stage}`.length)
+          : request.path.slice(`/${stage}`.length)
 
       // payload processing
       const encoding = detectEncoding(request)
@@ -537,14 +537,9 @@ export default class HttpServer {
 
       if (
         contentTypesThatRequirePayloadParsing.includes(contentType) &&
-        request.payload &&
-        request.payload.length > 1
+        request.payload
       ) {
         try {
-          if (!request.payload || request.payload.length === 0) {
-            request.payload = "{}"
-          }
-
           request.payload = parse(request.payload)
         } catch (err) {
           log.debug("error in converting request.payload to JSON:", err)

--- a/src/events/websocket/WebSocketClients.js
+++ b/src/events/websocket/WebSocketClients.js
@@ -273,17 +273,8 @@ export default class WebSocketClients {
       log.debug(`Error in route handler '${route.functionKey}'`, err)
     }
 
-    const authorizerData = this.#webSocketAuthorizersCache.get(connectionId)
-    let authorizedEvent
-
-    if (authorizerData) {
-      authorizedEvent = event
-      authorizedEvent.requestContext.identity = authorizerData.identity
-      authorizedEvent.requestContext.authorizer = authorizerData.authorizer
-    }
-
     const lambdaFunction = this.#lambda.get(route.functionKey)
-    lambdaFunction.setEvent(authorizedEvent || event)
+    lambdaFunction.setEvent(event)
 
     try {
       const { body } = await lambdaFunction.runHandler()

--- a/src/lambda/handler-runner/python-runner/PythonRunner.js
+++ b/src/lambda/handler-runner/python-runner/PythonRunner.js
@@ -8,7 +8,7 @@ import { log } from "../../../utils/log.js"
 import { splitHandlerPathAndName } from "../../../utils/index.js"
 
 const { parse, stringify } = JSON
-const { assign, hasOwn } = Object
+const { hasOwn } = Object
 
 export default class PythonRunner {
   static #payloadIdentifier = "__offline_payload__"
@@ -47,7 +47,7 @@ export default class PythonRunner {
         handlerName,
       ],
       {
-        env: assign(process.env, this.#env),
+        env: { ...process.env, ...this.#env },
         shell: true,
       },
     )

--- a/src/lambda/handler-runner/worker-thread-runner/workerThreadHelper.js
+++ b/src/lambda/handler-runner/worker-thread-runner/workerThreadHelper.js
@@ -24,6 +24,7 @@ parentPort.on("message", async (messageData) => {
     result = await inProcessRunner.run(event, context)
   } catch (err) {
     port.postMessage(err)
+    return
   }
 
   // TODO check serializeability (contains function, symbol etc)


### PR DESCRIPTION
Fixes from a full codebase review, each as its own commit.

## Changes

- **Fix PythonRunner mutating the global `process.env`** — `assign(process.env, this.#env)` used `process.env` as the `Object.assign` target, mutating serverless-offline's own environment and leaking each function's env vars into the parent process and across invocations. Now uses a non-mutating copy `{ ...process.env, ...this.#env }`, matching `RubyRunner`.
- **Return after posting error in the worker-thread helper** — on a handler error the `catch` posted the error then fell through and posted a second, `undefined` result message. Added a `return` so exactly one message is sent per invocation.
- **Remove redundant authorizer-context block in `WebSocketClients`** — `#processEvent` re-applied `requestContext.identity`/`authorizer` that both callers (the message and disconnect handlers) already set on the event before passing it in.
- **Clean up HTTP/ALB request handlers** — simplified JSON payload parsing (dropped the unreachable empty-payload branch and the `length > 1` guard that skipped valid single-char JSON bodies; now parses any non-empty payload) and replaced the deprecated `String.prototype.substr` with `slice` in both the HTTP and ALB stage-prefix stripping.

## Notes

- `npm run lint` passes clean.
- Deliberately out of scope: dev-dependency audit vulnerabilities (all in the test toolchain — nyc/mocha/eslint transitives, none shipped, no clean fix), PythonRunner's `shell: true`, and the JWT/`--noAuth`/`--ignoreJWTSignature` behavior (intentional dev-emulator design).
- The full `npm test` suite was not run locally — it requires a `SERVERLESS_ACCESS_KEY` and Go/Java/Python/Ruby runtimes; CI (Node 20/22/24) will exercise these changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)