### PR TITLE
Add support for ruby 4.0

### DIFF
--- a/src/config/supportedRuntimes.js
+++ b/src/config/supportedRuntimes.js
@@ -25,6 +25,7 @@ export const supportedRuntimesArchitecture = {
   "ruby3.2": [ARM64, X86_64],
   "ruby3.3": [ARM64, X86_64],
   "ruby3.4": [ARM64, X86_64],
+  "ruby4.0": [ARM64, X86_64],
   java8: [X86_64],
   "java8.al2": [ARM64, X86_64],
   java11: [ARM64, X86_64],
@@ -74,6 +75,7 @@ export const supportedRuby = new Set([
   "ruby3.2",
   "ruby3.3",
   "ruby3.4",
+  "ruby4.0",
 ])
 
 export const supportedRuntimes = new Set([

--- a/tests/integration/docker/ruby/ruby4.0/dockerRuby4.0.test.js
+++ b/tests/integration/docker/ruby/ruby4.0/dockerRuby4.0.test.js
@@ -1,0 +1,39 @@
+import assert from "node:assert"
+import { env } from "node:process"
+import { join } from "desm"
+import { setup, teardown } from "../../../../_testHelpers/index.js"
+import { BASE_URL } from "../../../../config.js"
+
+describe("Ruby 4.0 with Docker tests", function desc() {
+  beforeEach(() =>
+    setup({
+      servicePath: join(import.meta.url),
+    }),
+  )
+
+  afterEach(() => teardown())
+
+  //
+  ;[
+    {
+      description: "should work with ruby4.0 in docker container",
+      expected: {
+        message: "Hello Ruby 4.0!",
+      },
+      path: "/dev/hello",
+    },
+  ].forEach(({ description, expected, path }) => {
+    it(description, async function it() {
+      // "Could not find 'Docker', skipping tests."
+      if (!env.DOCKER_DETECTED) {
+        this.skip()
+      }
+
+      const url = new URL(path, BASE_URL)
+      const response = await fetch(url)
+      const json = await response.json()
+
+      assert.equal(json.message, expected.message)
+    })
+  })
+})

--- a/tests/integration/docker/ruby/ruby4.0/handler.rb
+++ b/tests/integration/docker/ruby/ruby4.0/handler.rb
@@ -1,0 +1,12 @@
+
+require 'json'
+
+def hello(event:, context:)
+  {
+    body: JSON.generate({
+      message: 'Hello Ruby 4.0!',
+      version: RUBY_VERSION,
+    }),
+    statusCode: 200,
+  }
+end

--- a/tests/integration/docker/ruby/ruby4.0/serverless.yml
+++ b/tests/integration/docker/ruby/ruby4.0/serverless.yml
@@ -1,0 +1,30 @@
+service: docker-ruby-4-0-tests
+
+configValidationMode: error
+deprecationNotificationMode: error
+
+plugins:
+  - ../../../../../src/index.js
+
+provider:
+  architecture: x86_64
+  deploymentMethod: direct
+  memorySize: 1024
+  name: aws
+  region: us-east-1
+  runtime: ruby4.0
+  stage: dev
+  versionFunctions: false
+
+custom:
+  serverless-offline:
+    noTimeout: true
+    useDocker: true
+
+functions:
+  hello:
+    events:
+      - http:
+          method: get
+          path: hello
+    handler: handler.hello


### PR DESCRIPTION
## Description

Add support for ruby 4.0 runtime in `serverless-offline` for local Lambda development and testing. Both [AWS](https://aws.amazon.com/about-aws/whats-new/2026/04/aws-lambda-adds-ruby/) and [serverless framework](https://github.com/serverless/serverless/releases/tag/sf-core%404.38.0) now support ruby 4.0.  This PR follow the pattern for similar changes the previous PRs:
- https://github.com/dherault/serverless-offline/pull/1862
- https://github.com/dherault/serverless-offline/pull/1878

### Changes
- Add support for ruby 4.0

## Motivation

This resolves the following error when running Serverless Offline on Ruby 3.4.

> Warning: found unsupported runtime 'ruby4.0' for function 'xxx'

## Testing

- [CI passed](https://github.com/btalayeminaei/serverless-offline/actions/runs/27968139145) in my fork
* Local test

```
$ npx mocha --require ./tests/mochaHooks.cjs --grep "Ruby 4.0"


  Ruby 4.0 with Docker tests
    ✔ should work with ruby4.0 in docker container (15239ms)


  1 passing (22s)
```