### PR TITLE
fix: recreate worker thread after a timeout (#1896)

### DIFF
--- a/src/lambda/handler-runner/HandlerRunner.js
+++ b/src/lambda/handler-runner/HandlerRunner.js
@@ -98,9 +98,19 @@ export default class HandlerRunner {
   }
 
   // () => Promise<void>
-  cleanup() {
+  async cleanup() {
     // TODO console.log('handler runner cleanup')
-    return this.#runner.cleanup()
+    const runner = this.#runner
+
+    // drop the reference so the next run() lazily recreates a fresh runner.
+    // this is essential after a timeout: the worker thread is terminated by
+    // cleanup() but the (now dead) runner would otherwise be reused, wedging
+    // every subsequent invocation. see https://github.com/dherault/serverless-offline/issues/1896
+    this.#runner = null
+
+    if (runner != null) {
+      await runner.cleanup()
+    }
   }
 
   async run(event, context) {

--- a/tests/timeout/serverless.yml
+++ b/tests/timeout/serverless.yml
@@ -24,3 +24,10 @@ functions:
           path: timeout-handler
     handler: src/handler.timeoutHandler
     timeout: 1
+  conditionalTimeoutHandler:
+    events:
+      - http:
+          method: get
+          path: conditional-timeout-handler
+    handler: src/handler.conditionalTimeoutHandler
+    timeout: 1

--- a/tests/timeout/src/handler.js
+++ b/tests/timeout/src/handler.js
@@ -10,3 +10,20 @@ export async function timeoutHandler() {
     statusCode: 200,
   }
 }
+
+// sleeps past the timeout only when called with ?slow=true, so the same
+// function can be made to time out once and then succeed instantly.
+// the slow/fast decision comes from the request, not module state, so it
+// survives the worker thread being recreated after a timeout.
+export async function conditionalTimeoutHandler(event) {
+  if (event.queryStringParameters?.slow === "true") {
+    await new Promise((resolve) => {
+      setTimeout(resolve, 2000)
+    })
+  }
+
+  return {
+    body: stringify("foo"),
+    statusCode: 200,
+  }
+}

--- a/tests/timeout/timeout.test.js
+++ b/tests/timeout/timeout.test.js
@@ -28,4 +28,25 @@ describe("handler payload tests", function desc() {
       assert.equal(response.status, status)
     })
   })
+
+  // regression test for https://github.com/dherault/serverless-offline/issues/1896
+  it("recovers after a timeout: a later invocation succeeds", async () => {
+    const slowUrl = new URL(
+      "/dev/conditional-timeout-handler?slow=true",
+      BASE_URL,
+    )
+    const fastUrl = new URL(
+      "/dev/conditional-timeout-handler?slow=false",
+      BASE_URL,
+    )
+
+    // first invocation exceeds the timeout (the worker thread is terminated)
+    const slowResponse = await fetch(slowUrl)
+    assert.equal(slowResponse.status, 504)
+
+    // the next invocation must get a fresh worker and return immediately,
+    // instead of reusing the terminated one and hanging until it 504s too
+    const fastResponse = await fetch(fastUrl)
+    assert.equal(fastResponse.status, 200)
+  })
 })


### PR DESCRIPTION
Fixes #1896

## Problem

With the default worker-thread runner, a function that exceeds its timeout **once** is permanently wedged: every *subsequent* invocation returns 504 — even instant ones — until the process is restarted.

This is **not** the expected "handler ran past its timeout → 504" behaviour (#1714). The problem is the *next* invocation. On real Lambda the platform just uses a fresh execution environment; in serverless-offline the worker thread is terminated on timeout and **never recreated**, so all following requests hang for the full timeout and 504, forever.

## Root cause

On timeout, `LambdaFunction.runHandler()` calls `HandlerRunner.cleanup()`, which terminates the worker thread but leaves `#runner` pointing at the now-dead `WorkerThreadRunner`:

```js
cleanup() {
  return this.#runner.cleanup() // #runner still references the terminated runner
}
```

The `LambdaFunction` then returns to the pool as `IDLE`. With `reloadHandler` false (the default), `LambdaFunctionPool.get()` hands that same instance back on the next request, and `run()` reuses the dead runner (since `#runner` is non-null). The message is posted to a terminated worker that never replies, so `Promise.race` always resolves via the timeout → 504, indefinitely.

## Fix

`HandlerRunner.cleanup()` now drops its `#runner` reference before delegating, so the next `run()` lazily rebuilds a fresh runner via `#loadRunner()`. This restores real-Lambda-like behaviour (a fresh execution environment after a timeout). It's also now defensive against `#runner` being null.

## Testing

Added a regression test in `tests/timeout/`: a `conditionalTimeoutHandler` whose slow/fast decision comes from the request (`?slow=true|false`), not worker module state (which resets when the worker is recreated). The test times out once, then asserts a subsequent fast invocation returns **200** instead of hanging to another 504.

Verified locally against the real offline server:
- ✅ New test passes with the fix (second call returns 200 in ~1s).
- ✅ With the fix reverted, the new test **fails** (second call 504s) — confirming it's discriminating.
- ✅ Full `TEST=node` suite passes (299 passing); prettier + eslint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)